### PR TITLE
Added unit tests for the fourth order derivatives.

### DIFF
--- a/Tests/DerivativeUnitTests/DerivativeTestsCompute.hpp
+++ b/Tests/DerivativeUnitTests/DerivativeTestsCompute.hpp
@@ -1,0 +1,69 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef DERIVATIVETESTSCOMPUTE_HPP_
+#define DERIVATIVETESTSCOMPUTE_HPP_
+
+#include "FourthOrderDerivatives.hpp"
+#include "VarsTools.hpp"
+
+class DerivativeTestsCompute
+{
+  protected:
+    const FourthOrderDerivatives m_deriv;
+
+  public:
+    DerivativeTestsCompute(double dx) : m_deriv(dx) {}
+
+    template <class data_t> struct Vars
+    {
+        data_t d1;
+        data_t d2;
+        data_t d2_mixed;
+        data_t diss;
+        data_t advec_up;
+        data_t advec_down;
+
+        template <typename mapping_function_t>
+        void enum_mapping(mapping_function_t mapping_function)
+        {
+            using namespace VarsTools; // define_enum_mapping is part of
+                                       // VarsTools
+            define_enum_mapping(mapping_function, c_d1, d1);
+            define_enum_mapping(mapping_function, c_d2, d2);
+            define_enum_mapping(mapping_function, c_d2_mixed, d2_mixed);
+            define_enum_mapping(mapping_function, c_diss, diss);
+            define_enum_mapping(mapping_function, c_advec_up, advec_up);
+            define_enum_mapping(mapping_function, c_advec_down, advec_down);
+        }
+    };
+
+    template <class data_t> void compute(Cell<data_t> current_cell) const
+    {
+        const auto out_d1 = m_deriv.template diff1<Vars>(current_cell);
+        const auto out_d2 = m_deriv.template diff2<Vars>(current_cell);
+
+        Vars<data_t> out_diss;
+        VarsTools::assign(out_diss, 0.);
+        m_deriv.add_dissipation(out_diss, current_cell, 1.0);
+
+        Tensor<1, data_t> shift_down = {-2., 0., -3.};
+        const auto out_advec_down =
+            m_deriv.template advection<Vars>(current_cell, shift_down);
+
+        Tensor<1, data_t> shift_up = {2., 0., 3.};
+        const auto out_advec_up =
+            m_deriv.template advection<Vars>(current_cell, shift_up);
+
+        current_cell.store_vars(out_d1.d1[2], c_d1);
+        current_cell.store_vars(out_d2.d2[2][2], c_d2);
+        current_cell.store_vars(out_d2.d2[0][2], c_d2_mixed);
+        current_cell.store_vars(out_diss.diss, c_diss);
+        current_cell.store_vars(out_advec_down.advec_down, c_advec_down);
+        current_cell.store_vars(out_advec_up.advec_up, c_advec_up);
+    }
+};
+
+#endif /* DERIVATIVETESTSCOMPUTE_HPP_ */

--- a/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
+++ b/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
@@ -1,0 +1,94 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#include "FArrayBox.H"
+#include <iostream>
+
+#include "BoxIterator.H"
+#include "BoxLoops.hpp"
+#include "DerivativeTestsCompute.hpp"
+#include "UserVariables.hpp"
+
+bool is_wrong(double value, double correct_value, std::string deriv_type)
+{
+    if (abs(value - correct_value) > 1e-10)
+    {
+        std::cout.precision(17);
+        std::cout << "Test of " << deriv_type << " failed "
+                  << " with value " << value << " instad of " << correct_value
+                  << ".\n";
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+int main()
+{
+    const int num_cells = 512;
+    // box is flat in y direction to make test cheaper
+    IntVect domain_hi_vect(num_cells - 1, 0, num_cells - 1);
+    Box box(IntVect(0, 0, 0), domain_hi_vect);
+    Box ghosted_box(IntVect(-3, -3, -3),
+                    IntVect(num_cells + 2, 3, num_cells + 2));
+
+    FArrayBox in_fab(ghosted_box, NUM_VARS);
+    FArrayBox out_fab(box, NUM_VARS);
+
+    const double dx = 1.0 / num_cells;
+
+    BoxIterator bit_ghost(ghosted_box);
+    for (bit_ghost.begin(); bit_ghost.ok(); ++bit_ghost)
+    {
+        const double x = (0.5 + bit_ghost()[0]) * dx;
+        const double z = (0.5 + bit_ghost()[2]) * dx;
+        for (int i = 0; i < NUM_VARS; ++i)
+        {
+            in_fab(bit_ghost(), i) = x * z * (z - 1);
+        }
+        // The dissipation component is special:
+        in_fab(bit_ghost(), c_diss) = (pow(z - 0.5, 6) - 0.015625) / 720. +
+                                      (z - 1) * z * pow(x, 6) / 720.;
+    }
+
+    // Compute the derivatives for the timing comparison
+    BoxLoops::loop(DerivativeTestsCompute(dx), in_fab, out_fab);
+
+    BoxIterator bit(box);
+    for (bit.begin(); bit.ok(); ++bit)
+    {
+        const double x = (0.5 + bit()[0]) * dx;
+        const double z = (0.5 + bit()[2]) * dx;
+
+        bool error = false;
+        error |= is_wrong(out_fab(bit(), c_d1), 2 * x * (z - 0.5), "diff1");
+        error |= is_wrong(out_fab(bit(), c_d2), 2 * x, "diff2");
+        error |=
+            is_wrong(out_fab(bit(), c_d2_mixed), 2 * (z - 0.5), "mixed diff2");
+
+        double correct_dissipation = (1. + z * (z - 1)) * pow(dx, 5) / 64;
+        error |= is_wrong(out_fab(bit(), c_diss), correct_dissipation,
+                          "dissipation");
+
+        double correct_advec_down = -2 * z * (z - 1) - 3 * x * (2 * z - 1);
+        error |= is_wrong(out_fab(bit(), c_advec_down), correct_advec_down,
+                          "advection down");
+
+        double correct_advec_up = 2 * z * (z - 1) + 3 * x * (2 * z - 1);
+        error |= is_wrong(out_fab(bit(), c_advec_up), correct_advec_up,
+                          "advection up");
+
+        if (error)
+        {
+            std::cout << "Derivative unit tests NOT passed.\n";
+            return error;
+        }
+    }
+
+    std::cout << "Derivative unit tests passed.\n";
+    return 0;
+}

--- a/Tests/DerivativeUnitTests/GNUmakefile
+++ b/Tests/DerivativeUnitTests/GNUmakefile
@@ -1,0 +1,17 @@
+# -*- Mode: Makefile -*-
+
+### This makefile produces an executable for each name in the `ebase'
+###  variable using the libraries named in the `LibNames' variable.
+
+# Included makefiles need an absolute path to the Chombo installation
+# CHOMBO_HOME := Please set the CHOMBO_HOME locally(e.g. export CHOMBO_HOME=... in bash)
+
+ebase := DerivativeUnitTests
+
+LibNames := BoxTools
+
+src_dirs := $(GRCHOMBO_SOURCE)/utils \
+            $(GRCHOMBO_SOURCE)/simd \
+		   	$(GRCHOMBO_SOURCE)/BoxUtils
+
+include $(CHOMBO_HOME)/mk/Make.test

--- a/Tests/DerivativeUnitTests/UserVariables.hpp
+++ b/Tests/DerivativeUnitTests/UserVariables.hpp
@@ -1,0 +1,26 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef USERVARIABLES_HPP_
+#define USERVARIABLES_HPP_
+
+enum
+{
+    c_d1,
+    c_d2,
+    c_d2_mixed,
+    c_diss,
+    c_advec_up,
+    c_advec_down,
+    NUM_VARS
+};
+
+namespace UserVariables
+{
+static constexpr char const *variable_names[NUM_VARS] = {
+    "d1", "d2", "d2_mixed", "diss", "advec_up", "advec_down"};
+}
+
+#endif /* USERVARIABLES_HPP_ */


### PR DESCRIPTION
While the fourth order derivatives are also tested indirectly by the cpp ChF comparison I thought it would be good to push these unit tests too because:
- they are very helpful when writing new derivatives code (e.g. different order or boundary derivatives for boundary conditions)
- if there should ever be an error in the derivatives it will be easier to catch it directly with this unit test.