### PR TITLE
Separating out vars and tidy up comments

### DIFF
--- a/Examples/KerrBH/SimulationParameters.hpp
+++ b/Examples/KerrBH/SimulationParameters.hpp
@@ -3,8 +3,6 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-// Last edited K Clough 16.10.16
-
 #ifndef SIMULATIONPARAMETERS_HPP_
 #define SIMULATIONPARAMETERS_HPP_
 

--- a/Examples/ScalarField/ScalarFieldLevel.hpp
+++ b/Examples/ScalarField/ScalarFieldLevel.hpp
@@ -3,8 +3,6 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-// Last edited K Clough 16.10.16
-
 #ifndef SCALARFIELDLEVEL_HPP_
 #define SCALARFIELDLEVEL_HPP_
 

--- a/Examples/ScalarField/UserVariables.hpp
+++ b/Examples/ScalarField/UserVariables.hpp
@@ -3,8 +3,6 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-// Last edited K Clough 16.10.16
-
 #ifndef USERVARIABLES_HPP
 #define USERVARIABLES_HPP
 

--- a/Source/CCZ4/ADMConformalVars.hpp
+++ b/Source/CCZ4/ADMConformalVars.hpp
@@ -1,0 +1,105 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef ADMCONFORMALVARS_HPP_
+#define ADMCONFORMALVARS_HPP_
+
+#include "Tensor.hpp"
+#include "UserVariables.hpp"
+#include "VarsTools.hpp"
+
+/// Namespace for ADM vars in conformally decomposed form
+/** The structs in this namespace collect all the ADM variables. It's main use
+ *is to make a local, nicely laid-out, copy of the ADM variables for the
+ *current grid cell (Otherwise, this data would only exist on the grid in the
+ *huge, flattened Chombo array). \sa {CCZ4Vars, BSSNVars}
+ **/
+namespace ADMConformalVars
+{
+/// Vars object for ADM vars, including gauge vars
+template <class data_t> struct VarsNoGauge
+{
+    data_t chi;          //!< Conformal factor
+    Tensor<2, data_t> h; //!< Conformal metric
+    data_t K;            //!< Trace of the extrinsic curvature
+    Tensor<2, data_t> A; //!< trace-free part of the rescale extrinsic
+                         //! curvature, i.e. \f$\chi
+                         //!(K_{ij})^{\mathrm{TF}}\f$
+
+    /// Defines the mapping between members of Vars and Chombo grid
+    /// variables (enum in User_Variables)
+    template <typename mapping_function_t>
+    void enum_mapping(mapping_function_t mapping_function)
+    {
+        using namespace VarsTools; // define_enum_mapping is part of VarsTools
+        // Scalars
+        define_enum_mapping(mapping_function, c_chi, chi);
+        define_enum_mapping(mapping_function, c_K, K);
+
+        // Symmetric 2-tensors
+        define_symmetric_enum_mapping(mapping_function,
+                                      GRInterval<c_h11, c_h33>(), h);
+        define_symmetric_enum_mapping(mapping_function,
+                                      GRInterval<c_A11, c_A33>(), A);
+    }
+};
+
+/// Vars object for ADM vars, including gauge vars
+template <class data_t> struct VarsWithGauge : public VarsNoGauge<data_t>
+{
+    data_t lapse;
+    Tensor<1, data_t> shift;
+
+    /// Defines the mapping between members of Vars and Chombo grid
+    /// variables (enum in User_Variables)
+    template <typename mapping_function_t>
+    void enum_mapping(mapping_function_t mapping_function)
+    {
+        using namespace VarsTools; // define_enum_mapping is part of VarsTools
+        VarsNoGauge<data_t>::enum_mapping(mapping_function);
+        define_enum_mapping(mapping_function, c_lapse, lapse);
+        define_enum_mapping(mapping_function, GRInterval<c_shift1, c_shift3>(),
+                            shift);
+    }
+};
+
+/// Vars object for ADM vars requiring second derivs, excluding gauge vars
+template <class data_t> struct Diff2VarsNoGauge
+{
+    data_t chi;          //!< Conformal factor
+    Tensor<2, data_t> h; //!< Conformal metric
+
+    template <typename mapping_function_t>
+    void enum_mapping(mapping_function_t mapping_function)
+    {
+        using namespace VarsTools; // define_enum_mapping is part of VarsTools
+        define_enum_mapping(mapping_function, c_chi, chi);
+        define_symmetric_enum_mapping(mapping_function,
+                                      GRInterval<c_h11, c_h33>(), h);
+    }
+};
+
+/// Vars object for ADM vars requiring second derivs, with gauge vars
+template <class data_t>
+struct Diff2VarsWithGauge : public Diff2VarsNoGauge<data_t>
+{
+    data_t lapse;
+    Tensor<1, data_t> shift;
+
+    /// Defines the mapping between members of Vars and Chombo grid
+    /// variables (enum in User_Variables)
+    template <typename mapping_function_t>
+    void enum_mapping(mapping_function_t mapping_function)
+    {
+        using namespace VarsTools; // define_enum_mapping is part of VarsTools
+        Diff2VarsNoGauge<data_t>::enum_mapping(mapping_function);
+        define_enum_mapping(mapping_function, c_lapse, lapse);
+        define_enum_mapping(mapping_function, GRInterval<c_shift1, c_shift3>(),
+                            shift);
+    }
+};
+}
+
+#endif /* ADMCONFORMALVARS_HPP_ */

--- a/Source/CCZ4/BSSNVars.hpp
+++ b/Source/CCZ4/BSSNVars.hpp
@@ -1,0 +1,74 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef BSSNVARS_HPP_
+#define BSSNVARS_HPP_
+
+#include "ADMConformalVars.hpp"
+#include "Tensor.hpp"
+#include "VarsTools.hpp"
+
+/// Namespace for BSSN vars
+/** The structs in this namespace collect all the BSSN variables. It's main use
+ *  is to make a local, nicely laid-out, copy of the BSSN variables for the
+ *  current grid cell (Otherwise, this data would only exist on the grid in
+ *  the huge, flattened Chombo array). \sa {CCZ4Vars, ADMConformalVars}
+ **/
+namespace BSSNVars
+{
+/// Vars object for BSSN vars excluding gauge vars
+template <class data_t>
+struct VarsNoGauge : public ADMConformalVars::VarsNoGauge<data_t>
+{
+    Tensor<1, data_t> Gamma; //!< Conformal connection functions
+
+    /// Defines the mapping between members of Vars and Chombo grid
+    /// variables (enum in User_Variables)
+    template <typename mapping_function_t>
+    void enum_mapping(mapping_function_t mapping_function)
+    {
+        using namespace VarsTools; // define_enum_mapping is part of VarsTools
+        ADMConformalVars::VarsNoGauge<data_t>::enum_mapping(mapping_function);
+        define_enum_mapping(mapping_function, GRInterval<c_Gamma1, c_Gamma3>(),
+                            Gamma); //!< The auxilliary variable Gamma^i
+    }
+};
+
+/// Vars object for BSSN vars, including gauge vars
+template <class data_t> struct VarsWithGauge : public VarsNoGauge<data_t>
+{
+    data_t lapse;
+    Tensor<1, data_t> shift;
+    Tensor<1, data_t> B; //!< \f$B^i = \partial_t \beta^i\f$, this is used
+                         //! for second order shift conditions
+
+    /// Defines the mapping between members of Vars and Chombo grid
+    /// variables (enum in User_Variables)
+    template <typename mapping_function_t>
+    void enum_mapping(mapping_function_t mapping_function)
+    {
+        using namespace VarsTools; // define_enum_mapping is part of VarsTools
+        VarsNoGauge<data_t>::enum_mapping(mapping_function);
+        define_enum_mapping(mapping_function, c_lapse, lapse);
+        define_enum_mapping(mapping_function, GRInterval<c_shift1, c_shift3>(),
+                            shift);
+        define_enum_mapping(mapping_function, GRInterval<c_B1, c_B3>(), B);
+    }
+};
+
+/// Vars object for BSSN vars needing second derivs, excluding gauge vars
+template <class data_t>
+struct Diff2VarsNoGauge : public ADMConformalVars::Diff2VarsNoGauge<data_t>
+{
+};
+
+/// Vars object for BSSN vars needing second derivs, including gauge vars
+template <class data_t>
+struct Diff2VarsWithGauge : public ADMConformalVars::Diff2VarsWithGauge<data_t>
+{
+};
+}
+
+#endif /* BSSNVARS_HPP_ */

--- a/Source/CCZ4/CCZ4.hpp
+++ b/Source/CCZ4/CCZ4.hpp
@@ -7,6 +7,7 @@
 #define CCZ4_HPP_
 
 #include "CCZ4Geometry.hpp"
+#include "CCZ4Vars.hpp"
 #include "Cell.hpp"
 #include "FourthOrderDerivatives.hpp"
 #include "Tensor.hpp"
@@ -35,47 +36,11 @@ class CCZ4
     };
 
     /// CCZ4 variables
-    /** This struct collects all the CCZ4 variables. It's main use is to make a
-     *local, nicely laid-out, copy of the CCZ4 variables for the current grid
-     *cell (Otherwise, this data would only exist on the grid in the huge,
-     *flattened Chombo array). To this end, CCZ4::Vars inherits from VarsBase
-     *which contains functionality to connect the local copy of the variables
-     *with values in the Chombo grid.
-     **/
-    template <class data_t> struct Vars
-    {
-        data_t chi;              //!< Conformal factor
-        Tensor<2, data_t> h;     //!< Conformal metric
-        data_t K;                //!< Trace of the extrinsic curvature
-        Tensor<2, data_t> A;     //!< trace-free part of the rescale extrinsic
-                                 //! curvature, i.e. \f$\chi
-                                 //!(K_{ij})^{\mathrm{TF}}\f$
-        Tensor<1, data_t> Gamma; //!< Conformal connection functions
-        data_t Theta; //!< CCZ4 quantity associated to hamiltonian constraint
-        data_t lapse;
-        Tensor<1, data_t> shift;
-        Tensor<1, data_t> B; //!< \f$B^i = \partial_t \beta^i\f$, this is used
-                             //! for second order shift conditions
+    template <class data_t> using Vars = CCZ4Vars::VarsWithGauge<data_t>;
 
-        /// Defines the mapping between members of Vars and Chombo grid
-        /// variables (enum in User_Variables)
-        template <typename mapping_function_t>
-        void enum_mapping(mapping_function_t mapping_function);
-    };
-
-    /// 2nd derivatives are only calculated for a small subset defined by
-    /// Deriv2Vars
-    /** Making this split speeds up the code significantly */
-    template <class data_t> struct Diff2Vars
-    {
-        data_t chi; //!< Conformal factor
-        data_t lapse;
-        Tensor<2, data_t> h; //!< Conformal metric
-        Tensor<1, data_t> shift;
-
-        template <typename mapping_function_t>
-        void enum_mapping(mapping_function_t mapping_function);
-    };
+    /// CCZ4 variables
+    template <class data_t>
+    using Diff2Vars = CCZ4Vars::Diff2VarsWithGauge<data_t>;
 
     /// Parameters for CCZ4
     /** This struct collects all parameters that are necessary for CCZ4 such as
@@ -113,7 +78,7 @@ class CCZ4
          double sigma,               //!< Kreiss-Oliger dissipation coefficient
          int formulation = USE_CCZ4, //!< Switches between CCZ4, BSSN,...
          double cosmological_constant = 0 //!< Value of the cosmological const.
-         );
+    );
 
     /// Compute function
     /** This function orchestrates the calculation of the rhs for one specific

--- a/Source/CCZ4/CCZ4.impl.hpp
+++ b/Source/CCZ4/CCZ4.impl.hpp
@@ -231,46 +231,4 @@ void CCZ4::rhs_equation(vars_t<data_t> &rhs, const vars_t<data_t> &vars,
     }
 }
 
-template <class data_t>
-template <typename mapping_function_t>
-void CCZ4::Vars<data_t>::enum_mapping(mapping_function_t mapping_function)
-{
-    // Define the mapping from components of chombo grid to elements in Vars.
-    // This allows to read/write data from the chombo grid into local
-    // variables in Vars (which only exist for the current cell).
-
-    using namespace VarsTools; // define_enum_mapping is part of VarsTools
-    // Scalars
-    define_enum_mapping(mapping_function, c_chi, chi);
-    define_enum_mapping(mapping_function, c_K, K);
-    define_enum_mapping(mapping_function, c_Theta, Theta);
-    define_enum_mapping(mapping_function, c_lapse, lapse);
-
-    // Vectors
-    define_enum_mapping(mapping_function, GRInterval<c_Gamma1, c_Gamma3>(),
-                        Gamma);
-    define_enum_mapping(mapping_function, GRInterval<c_shift1, c_shift3>(),
-                        shift);
-    define_enum_mapping(mapping_function, GRInterval<c_B1, c_B3>(), B);
-
-    // Symmetric 2-tensors
-    define_symmetric_enum_mapping(mapping_function, GRInterval<c_h11, c_h33>(),
-                                  h);
-    define_symmetric_enum_mapping(mapping_function, GRInterval<c_A11, c_A33>(),
-                                  A);
-}
-
-template <class data_t>
-template <typename mapping_function_t>
-void CCZ4::Diff2Vars<data_t>::enum_mapping(mapping_function_t mapping_function)
-{
-    using namespace VarsTools; // define_enum_mapping is part of VarsTools
-    define_enum_mapping(mapping_function, c_chi, chi);
-    define_enum_mapping(mapping_function, c_lapse, lapse);
-    define_enum_mapping(mapping_function, GRInterval<c_shift1, c_shift3>(),
-                        shift);
-    define_symmetric_enum_mapping(mapping_function, GRInterval<c_h11, c_h33>(),
-                                  h);
-}
-
 #endif /* CCZ4_IMPL_HPP_ */

--- a/Source/CCZ4/CCZ4Vars.hpp
+++ b/Source/CCZ4/CCZ4Vars.hpp
@@ -1,0 +1,69 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef CCZ4VARS_HPP_
+#define CCZ4VARS_HPP_
+
+#include "ADMConformalVars.hpp"
+#include "BSSNVars.hpp"
+#include "Tensor.hpp"
+#include "VarsTools.hpp"
+
+/// Namespace for CCZ4 vars
+/** The structs in this namespace collect all the CCZ4 variables. It's main use
+ *  is to make a local, nicely laid-out, copy of the CCZ4 variables for the
+ *  current grid cell (Otherwise, this data would only exist on the grid in
+ *  the huge, flattened Chombo array). \sa {CCZ4Vars, ADMConformalVars}
+ **/
+namespace CCZ4Vars
+{
+/// Vars object for CCZ4 vars, including gauge vars
+template <class data_t>
+struct VarsNoGauge : public BSSNVars::VarsNoGauge<data_t>
+{
+    data_t Theta; //!< CCZ4 quantity associated to Hamiltonian constraint
+
+    /// Defines the mapping between members of Vars and Chombo grid
+    /// variables (enum in User_Variables)
+    template <typename mapping_function_t>
+    void enum_mapping(mapping_function_t mapping_function)
+    {
+        using namespace VarsTools; // define_enum_mapping is part of VarsTools
+        BSSNVars::VarsNoGauge<data_t>::enum_mapping(mapping_function);
+        define_enum_mapping(mapping_function, c_Theta, Theta);
+    }
+};
+
+/// Vars object for CCZ4 vars, including gauge vars
+template <class data_t>
+struct VarsWithGauge : public BSSNVars::VarsWithGauge<data_t>
+{
+    data_t Theta; //!< CCZ4 quantity associated to hamiltonian constraint
+
+    /// Defines the mapping between members of Vars and Chombo grid
+    /// variables (enum in User_Variables)
+    template <typename mapping_function_t>
+    void enum_mapping(mapping_function_t mapping_function)
+    {
+        using namespace VarsTools; // define_enum_mapping is part of VarsTools
+        BSSNVars::VarsWithGauge<data_t>::enum_mapping(mapping_function);
+        define_enum_mapping(mapping_function, c_Theta, Theta);
+    }
+};
+
+/// Vars object for CCZ4 vars needing second derivs, excluding gauge vars
+template <class data_t>
+struct Diff2VarsNoGauge : public ADMConformalVars::Diff2VarsNoGauge<data_t>
+{
+};
+
+/// Vars object for CCZ4 vars needing second derivs, including gauge vars
+template <class data_t>
+struct Diff2VarsWithGauge : public ADMConformalVars::Diff2VarsWithGauge<data_t>
+{
+};
+}
+
+#endif /* CCZ4VARS_HPP_ */

--- a/Source/CCZ4/Constraints.hpp
+++ b/Source/CCZ4/Constraints.hpp
@@ -8,6 +8,7 @@
 #ifndef CONSTRAINTS_HPP_
 #define CONSTRAINTS_HPP_
 
+#include "BSSNVars.hpp"
 #include "Cell.hpp"
 #include "FArrayBox.H"
 #include "FourthOrderDerivatives.hpp"
@@ -21,19 +22,12 @@
 class Constraints
 {
   public:
-    template <class data_t> struct Vars
-    {
-        data_t chi;
-        Tensor<2, data_t> h;
-        data_t K;
-        Tensor<2, data_t> A;
-        Tensor<1, data_t> Gamma;
+    /// CCZ4 variables
+    template <class data_t> using Vars = BSSNVars::VarsNoGauge<data_t>;
 
-        /// Defines the mapping between members of Vars and Chombo grid
-        /// variables (enum in User_Variables)
-        template <typename mapping_function_t>
-        void enum_mapping(mapping_function_t mapping_function);
-    };
+    /// CCZ4 variables
+    template <class data_t>
+    using Diff2Vars = BSSNVars::Diff2VarsNoGauge<data_t>;
 
     template <class data_t> struct constraints_t
     {

--- a/Source/CCZ4/Constraints.impl.hpp
+++ b/Source/CCZ4/Constraints.impl.hpp
@@ -25,7 +25,7 @@ void Constraints::compute(Cell<data_t> current_cell) const
 {
     const auto vars = current_cell.template load_vars<Vars>();
     const auto d1 = m_deriv.template diff1<Vars>(current_cell);
-    const auto d2 = m_deriv.template diff2<Vars>(current_cell);
+    const auto d2 = m_deriv.template diff2<Diff2Vars>(current_cell);
 
     constraints_t<data_t> out = constraint_equations(vars, d1, d2);
 
@@ -76,22 +76,6 @@ Constraints::constraints_t<data_t> Constraints::constraint_equations(
     }
 
     return out;
-}
-
-template <class data_t>
-template <typename mapping_function_t>
-void Constraints::Vars<data_t>::enum_mapping(
-    mapping_function_t mapping_function)
-{
-    using namespace VarsTools; // define_enum_mapping is part of VarsTools
-    define_enum_mapping(mapping_function, c_chi, chi);
-    define_enum_mapping(mapping_function, c_K, K);
-    define_enum_mapping(mapping_function, GRInterval<c_Gamma1, c_Gamma3>(),
-                        Gamma);
-    define_symmetric_enum_mapping(mapping_function, GRInterval<c_h11, c_h33>(),
-                                  h);
-    define_symmetric_enum_mapping(mapping_function, GRInterval<c_A11, c_A33>(),
-                                  A);
 }
 
 #endif /* CONSTRAINTS_IMPL_HPP_ */

--- a/Source/CCZ4/GammaCalculator.hpp
+++ b/Source/CCZ4/GammaCalculator.hpp
@@ -3,12 +3,9 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-// Last update K Clough 23.02.2017
-
 #ifndef GAMMACALCULATOR_HPP_
 #define GAMMACALCULATOR_HPP_
 
-#include "CCZ4.hpp"
 #include "Cell.hpp"
 #include "Coordinates.hpp"
 #include "GRInterval.hpp"
@@ -19,8 +16,18 @@
 
 class GammaCalculator
 {
-    // Use the variable definition in CCZ4
-    template <class data_t> using Vars = CCZ4::Vars<data_t>;
+    // Only variables needed are metric
+    template <class data_t> struct Vars
+    {
+        Tensor<2, data_t> h;
+
+        template <typename mapping_function_t>
+        void enum_mapping(mapping_function_t mapping_function)
+        {
+            VarsTools::define_symmetric_enum_mapping(
+                mapping_function, GRInterval<c_h11, c_h33>(), h);
+        }
+    };
 
   protected:
     const FourthOrderDerivatives

--- a/Source/GRChomboCore/GRAMRLevel.hpp
+++ b/Source/GRChomboCore/GRAMRLevel.hpp
@@ -99,7 +99,7 @@ class GRAMRLevel : public AMRLevel, public InterpSource
                  Real newCrseTime,               //!< new crse time
                  Real time,      //!< current time centering of soln
                  Real fluxWeight //!< weight to apply to fluxRegister updates
-                 );
+    );
 
     /// implements soln += dt*rhs
     void updateODE(GRLevelData &soln, const GRLevelData &rhs, Real dt);

--- a/Source/GRChomboCore/SetupFunctions.hpp
+++ b/Source/GRChomboCore/SetupFunctions.hpp
@@ -10,8 +10,8 @@
 
 #include "parstream.H" //Gives us pout()
 #include <iostream>
-using std::endl;
 using std::cerr;
+using std::endl;
 #include "AMRLevelFactory.H"
 #include "GRAMR.hpp"
 #include "ParmParse.H"

--- a/Source/InitialConditions/BlackHoles/BinaryBH.impl.hpp
+++ b/Source/InitialConditions/BlackHoles/BinaryBH.impl.hpp
@@ -10,14 +10,14 @@
 #ifndef BINARYBH_IMPL_HPP_
 #define BINARYBH_IMPL_HPP_
 
+#include "BSSNVars.hpp"
 #include "BinaryBH.hpp"
-#include "CCZ4.hpp"
 #include "VarsTools.hpp"
 #include "simd.hpp"
 
 template <class data_t> void BinaryBH::compute(Cell<data_t> current_cell) const
 {
-    CCZ4::Vars<data_t> vars;
+    BSSNVars::VarsWithGauge<data_t> vars;
     VarsTools::assign(vars,
                       0.); // Set only the non-zero components explicitly below
     Coordinates<data_t> coords(current_cell, m_dx);

--- a/Source/InitialConditions/BlackHoles/KerrBH.hpp
+++ b/Source/InitialConditions/BlackHoles/KerrBH.hpp
@@ -3,12 +3,10 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-// Last update K Clough 21.05.2017
-
 #ifndef KERRBH_HPP_
 #define KERRBH_HPP_
 
-#include "CCZ4.hpp"
+#include "ADMConformalVars.hpp"
 #include "Cell.hpp"
 #include "Coordinates.hpp"
 #include "InitialDataTools.hpp"
@@ -22,7 +20,8 @@
 class KerrBH
 {
     // Use the variable definition in CCZ4
-    template <class data_t> using Vars = CCZ4::Vars<data_t>;
+    template <class data_t>
+    using Vars = ADMConformalVars::VarsWithGauge<data_t>;
 
   public:
     //! Stuct for the params of the Kerr BH

--- a/Source/InitialConditions/BlackHoles/KerrBH.impl.hpp
+++ b/Source/InitialConditions/BlackHoles/KerrBH.impl.hpp
@@ -3,8 +3,6 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-// Last update K Clough 23.04.2017
-
 #if !defined(KERRBH_HPP_)
 #error "This file should only be included through KerrBH.hpp"
 #endif

--- a/Source/Matter/ChiRelaxation.hpp
+++ b/Source/Matter/ChiRelaxation.hpp
@@ -67,7 +67,7 @@ template <class matter_t> class ChiRelaxation
     //! \sa compute()
     template <class data_t>
     void rhs_equation(
-        Vars<data_t> &rhs, //!<the RHS data for each variable at that point.
+        Vars<data_t> &rhs, //!< the RHS data for each variable at that point.
         const Vars<data_t> &vars, //!< the value of the variables at the point.
         const Vars<Tensor<1, data_t>>
             &d1, //!< the value of the first derivatives of the variables.

--- a/Source/Matter/DefaultPotential.hpp
+++ b/Source/Matter/DefaultPotential.hpp
@@ -3,8 +3,6 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-// Last edited K Clough 13.05.17
-
 #ifndef DEFAULTPOTENTIAL_HPP_
 #define DEFAULTPOTENTIAL_HPP_
 

--- a/Source/Matter/MatterCCZ4.hpp
+++ b/Source/Matter/MatterCCZ4.hpp
@@ -86,15 +86,15 @@ template <class matter_t> class MatterCCZ4 : public CCZ4
     template <class data_t>
     void add_emtensor_rhs(
         Vars<data_t>
-            &matter_rhs, //!<the RHS data for each variable at that point.
-        const Vars<data_t> &vars, //!<the value of the variables at the point.
+            &matter_rhs, //!< the RHS data for each variable at that point.
+        const Vars<data_t> &vars, //!< the value of the variables at the point.
         const Vars<Tensor<1, data_t>>
-            &d1 //!<the value of the first derivatives of the variables.
+            &d1 //!< the value of the first derivatives of the variables.
         ) const;
 
     // Class members
     matter_t my_matter;      //!< The matter object, e.g. a scalar field.
-    const double m_G_Newton; //!<Newton's constant, set to one by default.
+    const double m_G_Newton; //!< Newton's constant, set to one by default.
 };
 
 #include "MatterCCZ4.impl.hpp"

--- a/Source/Matter/ScalarField.hpp
+++ b/Source/Matter/ScalarField.hpp
@@ -3,8 +3,6 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-// Developed by K Clough 2017
-
 #ifndef SCALARFIELD_HPP_
 #define SCALARFIELD_HPP_
 

--- a/Source/utils/TensorAlgebra.hpp
+++ b/Source/utils/TensorAlgebra.hpp
@@ -12,9 +12,9 @@
 
 template <class data_t> struct chris_t
 {
-    Tensor<3, data_t> ULL;        //!<standard christoffel symbols
-    Tensor<3, data_t> LLL;        //!<3 lower indices
-    Tensor<1, data_t> contracted; //!<contracted christoffel
+    Tensor<3, data_t> ULL;        //!< standard christoffel symbols
+    Tensor<3, data_t> LLL;        //!< 3 lower indices
+    Tensor<1, data_t> contracted; //!< contracted christoffel
 };
 
 namespace TensorAlgebra


### PR DESCRIPTION
Make new separate namespaces for Vars structs, separated into:

- ADMConformalVars (h_ij, chi, lapse, shift, K, \tilde A_ij)
- BSSNVars (ADM plus Gamma^i and B^i)
- CCZ4Vars (BSSN plus Theta)

Also removed a few old "updated by" comments.