### PR TITLE
Removed outdated comment about the tagging criterion.

### DIFF
--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -203,7 +203,6 @@ void GRAMRLevel::tagCells(IntVectSet &a_tags)
                 for (int ix = xmin; ix <= xmax; ++ix)
                 {
                     IntVect iv(ix, iy, iz);
-                    // At the moment only base on gradient chi/chi^2
                     if (tagging_criterion(iv, 0) >= m_p.regrid_threshold)
                     {
 // local_tags |= is not thread safe.


### PR DESCRIPTION
Spoke to Markus and he claimed this was an outdated comment when the only tagging criterion that was implemented was for chi.