### PR TITLE
Fixed verbosity=1 setting and added timing info

### DIFF
--- a/Examples/BinaryBH/params.txt
+++ b/Examples/BinaryBH/params.txt
@@ -1,4 +1,4 @@
-verbosity = 1
+verbosity = 0
 chk_prefix = BinaryBH_
 #restart_file = BinaryBH_000360.3d.hdf5
 

--- a/Source/GRChomboCore/GRAMR.hpp
+++ b/Source/GRChomboCore/GRAMR.hpp
@@ -7,6 +7,8 @@
 #define GRAMR_HPP_
 
 #include "AMR.H"
+#include <chrono>
+#include <ratio>
 
 /// A child of Chombo's AMR class to interface with tools which require
 /// access to the whole AMR hierarchy (such as the AMRInterpolator)
@@ -16,6 +18,19 @@
  */
 class GRAMR : public AMR
 {
+    using Clock = std::chrono::steady_clock;
+    using Hours = std::chrono::duration<double, std::ratio<3600, 1>>;
+
+    std::chrono::time_point<Clock> start_time = Clock::now();
+
+  public:
+    auto get_walltime()
+    {
+        auto now = Clock::now();
+        auto duration = std::chrono::duration_cast<Hours>(now - start_time);
+
+        return duration.count();
+    }
 };
 
 #endif /* GRAMR_HPP_ */

--- a/Source/GRChomboCore/GRAMRLevel.hpp
+++ b/Source/GRChomboCore/GRAMRLevel.hpp
@@ -16,6 +16,7 @@
 #include "LevelRK4.H"
 #include "SimulationParameters.hpp"
 #include "UserVariables.hpp" // need NUM_VARS
+#include <sys/time.h>
 
 class GRAMRLevel : public AMRLevel, public InterpSource
 {
@@ -162,6 +163,7 @@ class GRAMRLevel : public AMRLevel, public InterpSource
     GRLevelData m_state_old; //!< the solution at the old time
     GRLevelData m_state_new; //!< the solution at the new time
     Real m_dx;               //!< grid spacing
+    double m_restart_time;
 
     GRAMR &m_gr_amr; //!< The GRAMR object containing this GRAMRLevel
 

--- a/Source/utils/GRParmParse.hpp
+++ b/Source/utils/GRParmParse.hpp
@@ -88,7 +88,7 @@ class GRParmParse : public ParmParse
         else
         {
             parameter = default_value;
-            pout() << "Parameter: " << name << "not found in parameter file. "
+            pout() << "Parameter: " << name << " not found in parameter file. "
                    << "It has been set to its default value." << std::endl;
         }
     }


### PR DESCRIPTION
These changes reduce unnecessary output when verbose=1 (in particular the BoxLayout is no longer printed) and add timing information to the verbose=0 output.