### PR TITLE
Added output of simd width at beginning.

### DIFF
--- a/Source/GRChomboCore/SetupFunctions.hpp
+++ b/Source/GRChomboCore/SetupFunctions.hpp
@@ -16,6 +16,8 @@ using std::endl;
 #include "GRAMR.hpp"
 #include "ParmParse.H"
 
+#include "simd.hpp"
+
 #ifdef EQUATION_DEBUG_MODE
 #include "DebuggingTools.hpp"
 #endif
@@ -66,6 +68,7 @@ void mainSetup(int argc, char *argv[])
 #ifdef _OPENMP
         pout() << " threads = " << omp_get_max_threads() << endl;
 #endif
+        pout() << " simd width (doubles) = " << simd_traits<double>::simd_len << endl;
     }
 
     const int required_argc = 2;


### PR DESCRIPTION
The code can now output the simd width at the beginning of the run so that users can check it is set correctly.