### PR TITLE
Feature/time coeff floating point solution

### DIFF
--- a/Examples/BinaryBH/GNUmakefile
+++ b/Examples/BinaryBH/GNUmakefile
@@ -6,6 +6,10 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally (e.g. export CHOMBO_HOME=... in bash)
 
+ifndef GRCHOMBO_SOURCE
+    $(error Please define GRCHOMBO_SOURCE - see installation instructions.)
+endif
+
 ebase := Main_BinaryBH
 
 LibNames := AMRTimeDependent AMRTools BoxTools

--- a/Examples/KerrBH/KerrBHLevel.cpp
+++ b/Examples/KerrBH/KerrBHLevel.cpp
@@ -27,8 +27,8 @@ void KerrBHLevel::specificAdvance()
 
     // Check for nan's
     if (m_p.nan_check)
-        BoxLoops::loop(NanCheck(), m_state_new, m_state_new, EXCLUDE_GHOST_CELLS,
-                       disable_simd());
+        BoxLoops::loop(NanCheck(), m_state_new, m_state_new,
+                       EXCLUDE_GHOST_CELLS, disable_simd());
 }
 
 void KerrBHLevel::initialData()

--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -36,8 +36,8 @@ void ScalarFieldLevel::specificAdvance()
 
     // Check for nan's
     if (m_p.nan_check)
-        BoxLoops::loop(NanCheck(), m_state_new, m_state_new, EXCLUDE_GHOST_CELLS,
-                       disable_simd());
+        BoxLoops::loop(NanCheck(), m_state_new, m_state_new,
+                       EXCLUDE_GHOST_CELLS, disable_simd());
 }
 
 // Initial data for field and metric variables

--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -157,6 +157,8 @@ void GRAMRLevel::postTimeStep()
         GRAMRLevel *finer_gr_amr_level_ptr = gr_cast(m_finer_level_ptr);
         finer_gr_amr_level_ptr->m_coarse_average.averageToCoarse(
             m_state_new, finer_gr_amr_level_ptr->m_state_new);
+        // Synchronise times to avoid floating point errors for finer levels
+        finer_gr_amr_level_ptr->time(m_time);
     }
 
     specificPostTimeStep();
@@ -726,23 +728,28 @@ void GRAMRLevel::evalRHS(GRLevelData &rhs, GRLevelData &soln,
 
     if (oldCrseSoln.isDefined())
     {
-        // Fraction "a_time" falls between the old and the new coarse times
+        // "time" falls between the old and the new coarse times
         Real alpha = (time - oldCrseTime) / (newCrseTime - oldCrseTime);
 
-        // Truncate the fraction to the range [0,1] to remove floating-point
-        // subtraction roundoff effects
-        Real eps = 0.04 * m_dt / m_ref_ratio;
-        if (Abs(alpha) < eps)
+        // Assuming RK4, we know that there can only be 5 different alpha so fix
+        // them with tolerance to prevent floating point problems
+        Real eps = 0.01;
+        if (abs(alpha) < eps)
             alpha = 0.0;
-        else if (Abs(1.0 - alpha) < eps)
+        else if (abs(alpha - 0.25) < eps)
+            alpha = 0.25;
+        else if (abs(alpha - 0.5) < eps)
+            alpha = 0.5;
+        else if (abs(alpha - 0.75) < eps)
+            alpha = 0.75;
+        else if (abs(alpha - 1.) < eps)
             alpha = 1.0;
-
-        // Current time before old coarse time
-        if (alpha < 0.0)
-            MayDay::Error("GRAMRLevel::evalRHS: alpha < 0.0");
-        // Current time after new coarse time
-        if (alpha > 1.0)
-            MayDay::Error("GRAMRLevel::evalRHS: alpha > 1.0");
+        else
+        {
+            pout() << "alpha: " << alpha << endl;
+            MayDay::Error(
+                "Time interpolation coefficient is incompatible with RK4.");
+        }
 
         // Interpolate ghost cells from next coarser level in space and time
         m_patcher.fillInterp(soln, alpha, 0, 0, NUM_VARS);

--- a/Source/GRChomboCore/SetupFunctions.hpp
+++ b/Source/GRChomboCore/SetupFunctions.hpp
@@ -68,7 +68,8 @@ void mainSetup(int argc, char *argv[])
 #ifdef _OPENMP
         pout() << " threads = " << omp_get_max_threads() << endl;
 #endif
-        pout() << " simd width (doubles) = " << simd_traits<double>::simd_len << endl;
+        pout() << " simd width (doubles) = " << simd_traits<double>::simd_len
+               << endl;
     }
 
     const int required_argc = 2;


### PR DESCRIPTION
Hey everyone,

as promised a while ago, I have added a solution to the floating point issue with the time interpolation coefficient for very deep mesh hierarchies. The problem was that even though the time steps were very large compared to floating point precision, we do so many of them on finer levels that the levels got out of sync. The solution is to synchronise the times between levels whenever we average to coarse. That way two levels can never go out of sync by more than the floating point error for one step, which is tiny.

I have also ensured that the RK4 coefficient always snaps to the correct value. That actually shouldn't be necessary anymore with the change above but it is still good book keeping I think.

Let me know what you think!

Thanks!
Markus