### PR TITLE
Bug Fixed: Scalar Field Example had its center as 'centerSF' and only…

### DIFF
--- a/Examples/ScalarField/SimulationParameters.hpp
+++ b/Examples/ScalarField/SimulationParameters.hpp
@@ -31,7 +31,7 @@ class SimulationParameters : public SimulationParametersBase
 
         // Fill in the Matter Parameters
         initial_params.amplitudeSF = amplitudeSF;
-        initial_params.centerSF = centerSF;
+        initial_params.centerSF = center; //already read in SimulationParametersBase
         initial_params.widthSF = widthSF;
         initial_params.r_zero = r_zero;
 
@@ -61,7 +61,6 @@ class SimulationParameters : public SimulationParametersBase
     // Initial data for matter and potential
     double G_Newton;
     Real amplitudeSF, widthSF, r_zero, scalar_mass;
-    std::array<double, CH_SPACEDIM> centerSF;
     // Relaxation params
     Real relaxtime, relaxspeed;
 

--- a/Examples/ScalarField/params.txt
+++ b/Examples/ScalarField/params.txt
@@ -74,7 +74,7 @@ r_zero = 5.0
 scalar_mass = 0.001
 # parameter for bubble centre - defaulted to center of grid
 # so only uncomment if you want to place it off center
-#centerSF = 32 32 32
+#center = 32 32 32
 
 # Relaxation paramters
 # how long and how fast to relax


### PR DESCRIPTION
Bug Fixed: Scalar Field Example had its center as 'centerSF' and only 'center' was being read at SimulationParametersBase. Deleted parameter 'centerSF' and 'center' read instead. Deleted parameter 'centerSF' and 'center' read instead.