### PR TITLE
All makefiles now set GRCHOMBO_SOURCE environment variable.

### DIFF
--- a/Examples/BinaryBH/GNUmakefile
+++ b/Examples/BinaryBH/GNUmakefile
@@ -6,10 +6,7 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally (e.g. export CHOMBO_HOME=... in bash)
 
-ifndef GRCHOMBO_SOURCE
-    $(error Please define GRCHOMBO_SOURCE - see installation instructions.)
-endif
-
+GRCHOMBO_SOURCE = ../../Source
 
 ebase := Main_BinaryBH
 

--- a/Examples/KerrBH/GNUmakefile
+++ b/Examples/KerrBH/GNUmakefile
@@ -6,6 +6,8 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally (e.g. export CHOMBO_HOME=... in bash)
 
+GRCHOMBO_SOURCE = ../../Source
+
 ebase := Main_KerrBH
 
 LibNames := AMRTimeDependent AMRTools BoxTools

--- a/Examples/ScalarField/GNUmakefile
+++ b/Examples/ScalarField/GNUmakefile
@@ -6,6 +6,8 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally (e.g. export CHOMBO_HOME=... in bash)
 
+GRCHOMBO_SOURCE = ../../Source
+
 ebase := Main_ScalarField
 
 LibNames := AMRTimeDependent AMRTools BoxTools

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -8,9 +8,7 @@ RealCleanExampleDirs := $(ExampleDirs:%=realclean-%)
 .PHONY: all run $(TestDirs) $(ExampleDirs)
 
 
-ifndef GRCHOMBO_SOURCE
-    $(error Please define GRCHOMBO_SOURCE - see installation instructions.)
-endif
+export GRCHOMBO_SOURCE = $(shell pwd)/Source
 
 test: $(TestDirs)
 

--- a/Tests/BasicAMRInterpolatorTest/GNUmakefile
+++ b/Tests/BasicAMRInterpolatorTest/GNUmakefile
@@ -6,6 +6,8 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally (e.g. export CHOMBO_HOME=... in bash)
 
+GRCHOMBO_SOURCE = $(shell pwd)/../../Source
+
 ebase := AMRInterpolatorTest
 
 LibNames := AMRTimeDependent AMRTools BoxTools

--- a/Tests/Ccz4GeometryUnitTests/GNUmakefile
+++ b/Tests/Ccz4GeometryUnitTests/GNUmakefile
@@ -6,6 +6,8 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally(e.g. export CHOMBO_HOME=... in bash)
 
+GRCHOMBO_SOURCE = $(shell pwd)/../../Source
+
 ebase := CCZ4GeometryUnitTest
 
 LibNames := BoxTools

--- a/Tests/CppChFComparison/GNUmakefile
+++ b/Tests/CppChFComparison/GNUmakefile
@@ -6,6 +6,8 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally(e.g. export CHOMBO_HOME=... in bash)
 
+GRCHOMBO_SOURCE = $(shell pwd)/../../Source
+
 ebase := CCZ4Test
 
 LibNames := BoxTools

--- a/Tests/CppChFConstraintComparison/GNUmakefile
+++ b/Tests/CppChFConstraintComparison/GNUmakefile
@@ -6,6 +6,8 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally(e.g. export CHOMBO_HOME=... in bash)
 
+GRCHOMBO_SOURCE = $(shell pwd)/../../Source
+
 ebase := ConstraintTest
 
 LibNames := BoxTools

--- a/Tests/DerivativeUnitTests/GNUmakefile
+++ b/Tests/DerivativeUnitTests/GNUmakefile
@@ -6,6 +6,8 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally(e.g. export CHOMBO_HOME=... in bash)
 
+GRCHOMBO_SOURCE = $(shell pwd)/../../Source
+
 ebase := DerivativeUnitTests
 
 LibNames := BoxTools

--- a/Tests/KclBssnTests/GNUmakefile
+++ b/Tests/KclBssnTests/GNUmakefile
@@ -6,6 +6,8 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally(e.g. export CHOMBO_HOME=... in bash)
 
+GRCHOMBO_SOURCE = $(shell pwd)/../../Source
+
 ebase := BSSNTest
 
 LibNames := BoxTools

--- a/Tests/KclWeyl4Test/GNUmakefile
+++ b/Tests/KclWeyl4Test/GNUmakefile
@@ -6,6 +6,8 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally(e.g. export CHOMBO_HOME=... in bash)
 
+GRCHOMBO_SOURCE = $(shell pwd)/../../Source
+
 ebase := Weyl4Test
 
 LibNames := BoxTools

--- a/Tests/PositiveChiAndAlphaUnitTest/GNUmakefile
+++ b/Tests/PositiveChiAndAlphaUnitTest/GNUmakefile
@@ -6,6 +6,8 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally(e.g. export CHOMBO_HOME=... in bash)
 
+GRCHOMBO_SOURCE = $(shell pwd)/../../Source
+
 ebase := PositiveChiAndAlphaUnitTest
 
 LibNames := BoxTools

--- a/Tests/SetValueUnitTest/GNUmakefile
+++ b/Tests/SetValueUnitTest/GNUmakefile
@@ -6,6 +6,8 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally(e.g. export CHOMBO_HOME=... in bash)
 
+GRCHOMBO_SOURCE = $(shell pwd)/../../Source
+
 ebase := SetValueUnitTest
 
 LibNames := BoxTools

--- a/Tests/SimdFunctionsUnitTests/GNUmakefile
+++ b/Tests/SimdFunctionsUnitTests/GNUmakefile
@@ -6,11 +6,13 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally(e.g. export CHOMBO_HOME=... in bash)
 
+GRCHOMBO_SOURCE = $(shell pwd)/../../Source
+
 ebase := SimdFunctionsUnitTest
 
 LibNames := BoxTools
 
 src_dirs := $(GRCHOMBO_SOURCE)/utils \
-            $(GRCHOMBO_SOURCE)/simd 
+            $(GRCHOMBO_SOURCE)/simd
 
 include $(CHOMBO_HOME)/mk/Make.test

--- a/Tests/SphericalHarmonicTest/GNUmakefile
+++ b/Tests/SphericalHarmonicTest/GNUmakefile
@@ -6,6 +6,8 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally(e.g. export CHOMBO_HOME=... in bash)
 
+GRCHOMBO_SOURCE = $(shell pwd)/../../Source
+
 ebase := SphericalHarmonicTest
 
 LibNames := BoxTools

--- a/Tests/VariableStoreTest/GNUmakefile
+++ b/Tests/VariableStoreTest/GNUmakefile
@@ -6,6 +6,8 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally(e.g. export CHOMBO_HOME=... in bash)
 
+GRCHOMBO_SOURCE = $(shell pwd)/../../Source
+
 ebase := VariableStoreTest
 
 LibNames := BoxTools


### PR DESCRIPTION
This is a relatively minor pull request which removes the need to set the `GRCHOMBO_SOURCE` environment variable as each makefile now sets it. This is very similar to how the Chombo makefiles work.

When this is merged, I will try to remember to update the wiki accordingly.