### PR TITLE
Add hook for post proc tool in restart

### DIFF
--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -658,7 +658,8 @@ void GRAMRLevel::writePlotLevel(HDF5Handle &a_handle) const
             pout() << header << endl;
 
         const DisjointBoxLayout &levelGrids = m_state_new.getBoxes();
-        LevelData<FArrayBox> plot_data(levelGrids, num_states);
+        IntVect iv_ghosts = m_num_ghosts * IntVect::Unit;
+        LevelData<FArrayBox> plot_data(levelGrids, num_states, iv_ghosts);
 
         for (int comp = 0; comp < num_states; comp++)
         {

--- a/Source/GRChomboCore/GRAMRLevel.hpp
+++ b/Source/GRChomboCore/GRAMRLevel.hpp
@@ -143,6 +143,9 @@ class GRAMRLevel : public AMRLevel, public InterpSource
     /// Specify which variables to write at plot intervals
     virtual void
     specificWritePlotHeader(std::vector<int> &plot_states) const {};
+
+    /// Things to do immediately after restart from checkpoint
+    virtual void postRestart() {}
 #endif
 
     virtual void specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,


### PR DESCRIPTION
- This hook allows us to do operations on the hdf5 files after opening them for restart, without calling amr.run().
- A corresponding amendment was made in Chombo AMRLevel() and AMR.H.
- This should not break old code, as it simply adds an additional virtual function which by default does nothing.
- I have also amended the output of plotfiles, so that the ghosts are defined. This means that they can in principle be used as restart files (one just needs to provide a correct UserVariables.hpp definition, and set the remaining c_nums that are requested to some arbitrary values).