### PR TITLE
Write boundary ghosts in plot files

### DIFF
--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -108,6 +108,8 @@ class ChomboParameters
         pp.load("plot_prefix", plot_prefix);
         pp.load("stop_time", stop_time, 1.0);
         pp.load("max_steps", max_steps, 1000000);
+        pp.load("write_plot_ghosts", write_plot_ghosts,
+                nonperiodic_boundaries_exist);
 
         // alias the weird chombo names to something more descriptive
         // for these box params, and default to some reasonable values
@@ -148,6 +150,7 @@ class ChomboParameters
     int max_grid_size, block_factor;        // max and min box sizes
     double fill_ratio; // determines how fussy the regridding is about tags
     std::string checkpoint_prefix, plot_prefix; // naming of files
+    bool write_plot_ghosts;
 
     // Boundary conditions
     std::array<bool, CH_SPACEDIM> isPeriodic;     // periodicity

--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -719,7 +719,7 @@ void GRAMRLevel::writePlotLevel(HDF5Handle &a_handle) const
 
         // only need to write ghosts when non periodic BCs exist
         IntVect ghost_vector = IntVect::Zero;
-        if (m_p.nonperiodic_boundaries_exist)
+        if (m_p.write_plot_ghosts)
         {
             ghost_vector = m_num_ghosts * IntVect::Unit;
         }

--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -717,9 +717,16 @@ void GRAMRLevel::writePlotLevel(HDF5Handle &a_handle) const
 
         plot_data.exchange(plot_data.interval());
 
+        // only need to write ghosts when non periodic BCs exist
+        IntVect ghost_vector = IntVect::Zero;
+        if (m_p.nonperiodic_boundaries_exist)
+        {
+            ghost_vector = m_num_ghosts * IntVect::Unit;
+        }
+
         // Write the data for this level
         write(a_handle, levelGrids);
-        write(a_handle, plot_data, "data");
+        write(a_handle, plot_data, "data", ghost_vector);
     }
 }
 


### PR DESCRIPTION
This ensures that the boundary ghosts are written to the plot files so that they can restart as for checkpoint files (e.g. for post-processing). 

In principle, only the boundary ghosts need to be written (the others can be filled via a ghost exchange) but this amendment writes them all. This is somewhat inefficient and we may want to change it in the future, but the performance hit is not significant so the effort required to do it properly outweighed the potential gain :-) !