### PR TITLE
Added missing includes.

### DIFF
--- a/Source/AMRInterpolator/Derivative.hpp
+++ b/Source/AMRInterpolator/Derivative.hpp
@@ -6,6 +6,8 @@
 #ifndef DERIVATIVE_HPP_
 #define DERIVATIVE_HPP_
 
+#include <array>
+
 class Derivative : public std::array<int, CH_SPACEDIM>
 {
   private:

--- a/Source/AMRInterpolator/DerivativeSetup.hpp
+++ b/Source/AMRInterpolator/DerivativeSetup.hpp
@@ -6,6 +6,8 @@
 #ifndef DERIVATIVESETUP_HPP_
 #define DERIVATIVESETUP_HPP_
 
+#include "Derivative.hpp"
+
 const Derivative Derivative::LOCAL;
 
 const Derivative Derivative::dx(0);

--- a/Source/AMRInterpolator/InterpSource.hpp
+++ b/Source/AMRInterpolator/InterpSource.hpp
@@ -6,8 +6,8 @@
 #ifndef INTERPSOURCE_H_
 #define INTERPSOURCE_H_
 
-#include <array>
 #include "LevelData.H"
+#include <array>
 
 // Abstrace base class to get the FABs out of an AMRLevel
 class InterpSource

--- a/Source/AMRInterpolator/InterpSource.hpp
+++ b/Source/AMRInterpolator/InterpSource.hpp
@@ -6,6 +6,9 @@
 #ifndef INTERPSOURCE_H_
 #define INTERPSOURCE_H_
 
+#include <array>
+#include "LevelData.H"
+
 // Abstrace base class to get the FABs out of an AMRLevel
 class InterpSource
 {

--- a/Source/AMRInterpolator/InterpolationAlgorithm.hpp
+++ b/Source/AMRInterpolator/InterpolationAlgorithm.hpp
@@ -6,8 +6,8 @@
 #ifndef INTERPOLATIONALGORITHM_HPP_
 #define INTERPOLATIONALGORITHM_HPP_
 
-#include <array>
 #include "FArrayBox.H"
+#include <array>
 
 class InterpolationAlgorithm
 {

--- a/Source/AMRInterpolator/InterpolationAlgorithm.hpp
+++ b/Source/AMRInterpolator/InterpolationAlgorithm.hpp
@@ -6,6 +6,9 @@
 #ifndef INTERPOLATIONALGORITHM_HPP_
 #define INTERPOLATIONALGORITHM_HPP_
 
+#include <array>
+#include "FArrayBox.H"
+
 class InterpolationAlgorithm
 {
   public:

--- a/Source/AMRInterpolator/InterpolationLayout.hpp
+++ b/Source/AMRInterpolator/InterpolationLayout.hpp
@@ -6,6 +6,8 @@
 #ifndef INTERPOLATIONLAYOUT_HPP_
 #define INTERPOLATIONLAYOUT_HPP_
 
+#include <vector>
+
 class InterpolationLayout
 {
   private:

--- a/Source/AMRInterpolator/InterpolationQuery.hpp
+++ b/Source/AMRInterpolator/InterpolationQuery.hpp
@@ -6,17 +6,18 @@
 #ifndef INTERPOLATIONQUERY_HPP_
 #define INTERPOLATIONQUERY_HPP_
 
-#include <utility>
-#include <map>
-#include <vector>
 #include "Derivative.hpp"
+#include <map>
+#include <utility>
+#include <vector>
 
 class InterpolationQuery
 {
   public:
     typedef std::pair<int, double *> out_t;
     typedef std::map<Derivative, std::vector<out_t>> comp_map_t;
-    typedef typename std::map<Derivative, std::vector<out_t>>::iterator iterator;
+    typedef
+        typename std::map<Derivative, std::vector<out_t>>::iterator iterator;
 
     const int m_num_points;
 

--- a/Source/AMRInterpolator/InterpolationQuery.hpp
+++ b/Source/AMRInterpolator/InterpolationQuery.hpp
@@ -6,14 +6,17 @@
 #ifndef INTERPOLATIONQUERY_HPP_
 #define INTERPOLATIONQUERY_HPP_
 
+#include <utility>
+#include <map>
+#include <vector>
 #include "Derivative.hpp"
 
 class InterpolationQuery
 {
   public:
-    typedef pair<int, double *> out_t;
-    typedef map<Derivative, std::vector<out_t>> comp_map_t;
-    typedef typename map<Derivative, std::vector<out_t>>::iterator iterator;
+    typedef std::pair<int, double *> out_t;
+    typedef std::map<Derivative, std::vector<out_t>> comp_map_t;
+    typedef typename std::map<Derivative, std::vector<out_t>>::iterator iterator;
 
     const int m_num_points;
 
@@ -45,7 +48,7 @@ class InterpolationQuery
         if (result == m_comps.end())
         {
             result = m_comps
-                         .insert(pair<Derivative, std::vector<out_t>>(
+                         .insert(std::pair<Derivative, std::vector<out_t>>(
                              deriv, std::vector<out_t>()))
                          .first;
         }

--- a/Source/AMRInterpolator/MPIContext.hpp
+++ b/Source/AMRInterpolator/MPIContext.hpp
@@ -6,8 +6,8 @@
 #ifndef MPICONTEXT_HPP_
 #define MPICONTEXT_HPP_
 
-#include <vector>
 #include "MPILayout.hpp"
+#include <vector>
 
 class MPIContext
 {

--- a/Source/AMRInterpolator/MPIContext.hpp
+++ b/Source/AMRInterpolator/MPIContext.hpp
@@ -6,6 +6,7 @@
 #ifndef MPICONTEXT_HPP_
 #define MPICONTEXT_HPP_
 
+#include <vector>
 #include "MPILayout.hpp"
 
 class MPIContext

--- a/Source/AMRInterpolator/MPILayout.hpp
+++ b/Source/AMRInterpolator/MPILayout.hpp
@@ -6,6 +6,8 @@
 #ifndef MPILAYOUT_HPP_
 #define MPILAYOUT_HPP_
 
+#include <vector>
+
 class MPILayout
 {
 

--- a/Source/BoxUtils/BoxLoops.impl.hpp
+++ b/Source/BoxUtils/BoxLoops.impl.hpp
@@ -27,9 +27,9 @@ BoxLoops::innermost_loop(const ComputePack<compute_ts...> &compute_pack,
         simd_width * (((loop_hi_x - loop_lo_x + 1) / simd_width) - 1);
 // SIMD LOOP
 #ifdef __INTEL_COMPILER
-    #pragma novector
+#pragma novector
 #else
-    #pragma omp simd safelen(1)
+#pragma omp simd safelen(1)
 #endif /* __INTEL_COMPILER */
     for (int ix = loop_lo_x; ix <= x_simd_max; ix += simd_width)
     {

--- a/Source/GRChomboCore/BoundaryConditions.cpp
+++ b/Source/GRChomboCore/BoundaryConditions.cpp
@@ -3,14 +3,13 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
+#include "BoundaryConditions.hpp"
+#include "FArrayBox.H"
+#include "ProblemDomain.H"
+#include "RealVect.H"
 #include <array>
 #include <map>
 #include <string>
-#include "FArrayBox.H"
-#include "IntVect.H"
-#include "RealVect.H"
-#include "ProblemDomain.H"
-#include "BoundaryConditions.hpp"
 
 /// define function sets members and is_defined set to true
 void BoundaryConditions::define(double a_dx,

--- a/Source/GRChomboCore/BoundaryConditions.cpp
+++ b/Source/GRChomboCore/BoundaryConditions.cpp
@@ -3,6 +3,13 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
+#include <array>
+#include <map>
+#include <string>
+#include "FArrayBox.H"
+#include "IntVect.H"
+#include "RealVect.H"
+#include "ProblemDomain.H"
 #include "BoundaryConditions.hpp"
 
 /// define function sets members and is_defined set to true

--- a/Source/GRChomboCore/SetupFunctions.hpp
+++ b/Source/GRChomboCore/SetupFunctions.hpp
@@ -128,7 +128,7 @@ void setupAMRObject(GRAMR &gr_amr, AMRLevelFactory &a_factory)
     // set checkpoint and plot intervals and prefixes
     gr_amr.checkpointInterval(chombo_params.checkpoint_interval);
     gr_amr.checkpointPrefix(chombo_params.checkpoint_prefix);
-    if(chombo_params.plot_interval != 0)
+    if (chombo_params.plot_interval != 0)
     {
         gr_amr.plotInterval(chombo_params.plot_interval);
         gr_amr.plotPrefix(chombo_params.plot_prefix);

--- a/Source/TaggingCriteria/ChiExtractionTaggingCriterion.hpp
+++ b/Source/TaggingCriteria/ChiExtractionTaggingCriterion.hpp
@@ -7,6 +7,7 @@
 #define CHIEXTRACTIONTAGGINGCRITERION_HPP_
 
 #include "Cell.hpp"
+#include "Coordinates.hpp"
 #include "DimensionDefinitions.hpp"
 #include "FourthOrderDerivatives.hpp"
 #include "SimulationParametersBase.hpp"

--- a/Source/utils/VarsTools.hpp
+++ b/Source/utils/VarsTools.hpp
@@ -8,8 +8,8 @@
 
 #include "GRInterval.hpp"
 #include "Tensor.hpp"
-#include "parstream.H" //Gives us pout()
 #include "UserVariables.hpp"
+#include "parstream.H" //Gives us pout()
 
 namespace VarsTools
 {

--- a/Source/utils/VarsTools.hpp
+++ b/Source/utils/VarsTools.hpp
@@ -9,6 +9,7 @@
 #include "GRInterval.hpp"
 #include "Tensor.hpp"
 #include "parstream.H" //Gives us pout()
+#include "UserVariables.hpp"
 
 namespace VarsTools
 {

--- a/Tests/KclWeyl4Test/GravWavDecF.ChF
+++ b/Tests/KclWeyl4Test/GravWavDecF.ChF
@@ -6,7 +6,7 @@ C    Please refer to Copyright.txt, in Chombo's root directory.
 
 c    GravWaveDec.ChF ----------------------------
 c    File containing the Gravitational Wave Detector
-c    --- written by Thomas Helfer and James Cook --- 
+c    --- written by Thomas Helfer and James Cook ---
 
 #include "CONSTANTS.H"
 
@@ -67,7 +67,7 @@ c ----------------------------------------------------------------
 
 c ----- i, ii, jj - index for boxes
 
-c ----- xx, yy, zz cartesian coords 
+c ----- xx, yy, zz cartesian coords
 c ----- rho2, rho ecc - spherical stuff
 c ----- dxinv - 1/dx where dx is grid spacing
 c ----- dxinv2 - 1/dx^2
@@ -94,7 +94,7 @@ c ----- Ktsr - Extrinsic Curvature Tensor
 c ----- CovKstr - covariant derivative of Extrinsic Curvature
 c ----- dKtsrdx - Spatial Derivative of Extrinsic Curvature
 c ----- dKscalardx - dKdx
-c ----- dKdx - spacial derivate of trace of extrinsic curvate 
+c ----- dKdx - spacial derivate of trace of extrinsic curvate
 c ----- Vphi - Value of Potential
 c ----- Vt - Lagrangian
 c ----- dphidx - Derivative of the Scalar Field
@@ -110,13 +110,13 @@ c ----- trSten - trSten
 c ----- Svec - S_i = n^a T_ai
 c ----- dAdx - spacial derivative of decomposed extrinsic curvature
 c ----- levi - Projected levi civita on hypersurfarce (lowered,raised,raised)
-c ----- levi44d - 4d levi tensor 
+c ----- levi44d - 4d levi tensor
 c ----- levi34d - Projected levi civita on hypersurfarce (lowered,lowered,lowered)
-c ----- E - Electroic field 
+c ----- E - Electroic field
 c ----- B - Magnetic field
 c ----- er - normal vector in r direction (renormalised for metric)
 c ----- ephi - normal vector in phi direction (renormalised for metric)
-c ----- etheta - normal vector in theta direction (renormalised for metric) 
+c ----- etheta - normal vector in theta direction (renormalised for metric)
 c ----- norm? - norm of vector
 
 c ----- d% - Integers for loops
@@ -144,6 +144,7 @@ c ----- IDX - maps indices from matrix to vector
       REAL_T CovKtsr(0:2,0:2,0:CH_SPACEDIM-1)
       REAL_T dKtsrdx(0:2,0:2,0:CH_SPACEDIM-1)
       REAL_T dKscalardx(0:CH_SPACEDIM-1)
+      REAL_T alp, s
       REAL_T Vphi, Vt
       REAL_T dphidx(0:2)
       REAL_T betaidiphi
@@ -180,7 +181,7 @@ c ----------------------------------------------------------------
 
       dxinv  = one/dx
       dxinv2 = one/(dx*dx)
-      null = 0 
+      null = 0
 
 c ----------------------------------------------------------------
 c        Start of loop over box
@@ -590,7 +591,9 @@ c -----------------------------------------------------------------
 c      Calculate the Stess Energy Tensor T_ij
 c -----------------------------------------------------------------
 
-         call GETV(Vphi, phi(CHF_AUTOIX[i]), phi0, mass)
+         alp = 0
+         s = 0
+         call GETV(Vphi, phi(CHF_AUTOIX[i]), phi0, alp, s, mass)
 
          Vt = -phiM(CHF_AUTOIX[i])**2 + 2*Vphi
          do d0 = 0,CH_SPACEDIM-1; do d1 = 0,CH_SPACEDIM-1
@@ -720,69 +723,69 @@ c ---- Levi
          levi44d(3,2,1,0) = 1
          levi44d(3,2,0,1) = -1
          levi44d(3,0,2,1) = 1
-        
-c ---- Projection of levi civita on hypersurface (8.3.17) Alcubierre 
+
+c ---- Projection of levi civita on hypersurface (8.3.17) Alcubierre
 
          do d0=0,2; do d1=0,2; do d2=0,2
           levi34d(d0,d1,d2) = 0
-         enddo; enddo; enddo 
+         enddo; enddo; enddo
 
          do d0=0,2; do d1=0,2; do d2=0,2; do d3=0,3
           levi34d(d0,d1,d2) = levi34d(d0,d1,d2) + nu(d3)*levi44d(d0,d1,d2,d3)*lapse/chi2**1.5
          enddo; enddo; enddo; enddo
 
-         
+
 c ---- raising levi cevita
 
          do d0=0,2; do d1=0,2; do d2=0,2
           levi(d0,d1,d2) = 0
-         enddo; enddo; enddo 
+         enddo; enddo; enddo
 
-         do d0=0,2; do d1=0,2; do d2=0,2; do d3=0,2; do d4=0,2 
+         do d0=0,2; do d1=0,2; do d2=0,2; do d3=0,2; do d4=0,2
           levi(d0,d1,d2) = levi(d0,d1,d2) + levi34d(d0,d3,d4)
      &                *gu(d3,d1)*chi2*gu(d4,d2)*chi2
          enddo; enddo; enddo; enddo; enddo
 
 c ---- Convariant derivative K_ij
-        
+
         do d0=0,2; do d1 =0,2;do d2=0,2
           CovKtsr(d0,d1,d2) = dKtsrdx(d0,d1,d2)
-        enddo;enddo;enddo 
-        
+        enddo;enddo;enddo
+
         do d0=0,2; do d1=0,2; do d2=0,2 ; do d3=0,2
           CovKtsr(d0,d1,d2) = CovKtsr(d0,d1,d2) - chriss(d3,d2,d0)*Ktsr(d3,d1)
      &          - chriss(d3,d2,d1)*Ktsr(d0,d3)
-        enddo;enddo;enddo; enddo  
+        enddo;enddo;enddo; enddo
 
 c ---- Calculation of electric and magnetic fields
- 
+
         do d0=0,2; do d1 =0,2
           E(d0,d1) = 0
-          B(d0,d1) = 0 
-        enddo;enddo 
+          B(d0,d1) = 0
+        enddo;enddo
 
 
         do d0=0,2; do d1 =0,2; do d2 =0,2; do d3 = 0,2
           B(d0,d1) = B(d0,d1)+levi(d0,d2,d3)*(CovKtsr(d3,d1,d2)
-     &                - 4.*Pi*g(d1,d2)/chi2*Svec(d3))                    
-        enddo;enddo;enddo;enddo 
+     &                - 4.*Pi*g(d1,d2)/chi2*Svec(d3))
+        enddo;enddo;enddo;enddo
 
         do d0=0,2; do d1 =0,2
           E(d0,d1) = E(d0,d1)+Rfull(d0,d1) + K(CHF_AUTOIX[i])
      &               *Ktsr(d0,d1) - 4.*Pi*(Sten(d0,d1)+1./3.*g(d0,d1)/chi2
      &                *(4.*rho(CHF_AUTOIX[i])-trSten))
         enddo;enddo
-        
+
         do d0=0,2; do d1=0,2; do d2=0,2 ; do d3=0,2
           E(d0,d1) = E(d0,d1) - Ktsr(d0,d2)*Ktsr(d3,d1)
      &               *gu(d2,d3)*chi2
-        enddo; enddo; enddo; enddo 
+        enddo; enddo; enddo; enddo
 
 c -----------------------------------------------------------
-c ---- Calculating Weyl tensor 
+c ---- Calculating Weyl tensor
 c ---- Weyl1 - ReWeyl , Weyl2 - ImWeyl
 c -----------------------------------------------------------
-c ----- tetrat calculation 
+c ----- tetrat calculation
 
         xx = dx*(i0+0.5) - centerx
         yy = dx*(i1+0.5) - centery
@@ -801,33 +804,33 @@ c ----- tetrat calculation
         cosph2 = cosph*cosph
         sinph2 = sinph*sinph
 
- 
-        do d0 = 0,2 
+
+        do d0 = 0,2
           er(d0) = 0
           ephi(d0) = 0
-          etheta(d0) = 0 
+          etheta(d0) = 0
         enddo
- 
-        er(0) = cosph*sinth  
+
+        er(0) = cosph*sinth
         er(1) = sinph*sinth
         er(2) =  costh
 
         ephi(0)= cosph*costh
         ephi(1)= sinph*costh
         ephi(2)= -sinth
-        
+
         etheta(0)= -sinph
         etheta(1)= cosph
-        etheta(2)= 0 
+        etheta(2)= 0
 
 c ------Alternative tetrats-------
         x = (dx*(i0+0.5) - centerx)
         y = (dx*(i1+0.5) - centery)
         z = (dx*(i2+0.5) - centerz)
 
-        do d0=0,2; do d1=0,2; do d2=0,2 
-           epsilon_tensor(d0,d1,d2) = 0 
-        enddo; enddo; enddo 
+        do d0=0,2; do d1=0,2; do d2=0,2
+           epsilon_tensor(d0,d1,d2) = 0
+        enddo; enddo; enddo
 
 
         epsilon_tensor(0,1,2) = 1
@@ -854,9 +857,9 @@ c        v3 = null;
         v3(1) = 0
         v3(2) = 0
 
-        do d0=0,2; do d1=0,2; do d2=0,2; do d3 = 0,2 
+        do d0=0,2; do d1=0,2; do d2=0,2; do d3 = 0,2
           v3(d3) = v3(d3) + chi1**(-1.)*gu(d3,d0)*epsilon_tensor(d0,d1,d2)*v1(d1)*v2(d2)
-        enddo; enddo; enddo; enddo 
+        enddo; enddo; enddo; enddo
 
 c        !gram-schmidt
         omega11 = 0
@@ -894,25 +897,25 @@ c        !gram-schmidt
         do d0 = 0,2
            ephi(d0) = v1(d0)
            er(d0) = v2(d0)
-           etheta(d0) = v3(d0) 
-        enddo 
-        
+           etheta(d0) = v3(d0)
+        enddo
 
-        weyl1(CHF_AUTOIX[i]) = 0 
-        weyl2(CHF_AUTOIX[i]) = 0 
+
+        weyl1(CHF_AUTOIX[i]) = 0
+        weyl2(CHF_AUTOIX[i]) = 0
 
 
 
         do d0 = 0,CH_SPACEDIM-1; do d1 = 0,CH_SPACEDIM-1
 
-           weyl1(CHF_AUTOIX[i]) = weyl1(CHF_AUTOIX[i]) 
-     &                            + 0.5*(E(d0,d1)*(etheta(d0)*etheta(d1) 
+           weyl1(CHF_AUTOIX[i]) = weyl1(CHF_AUTOIX[i])
+     &                            + 0.5*(E(d0,d1)*(etheta(d0)*etheta(d1)
      &                            - ephi(d0)*ephi(d1)) -
      &                            2.*B(d0,d1)*etheta(d0)*ephi(d1))
-     
 
-           weyl2(CHF_AUTOIX[i]) = weyl2(CHF_AUTOIX[i]) 
-     &                            + 0.5*(B(d0,d1)*(- etheta(d0)*etheta(d1) 
+
+           weyl2(CHF_AUTOIX[i]) = weyl2(CHF_AUTOIX[i])
+     &                            + 0.5*(B(d0,d1)*(- etheta(d0)*etheta(d1)
      &                            + ephi(d0)*ephi(d1)) -
      &                            2.*E(d0,d1)*etheta(d0)*ephi(d1))
 

--- a/Tests/KclWeyl4Test/Weyl4Test.cpp
+++ b/Tests/KclWeyl4Test/Weyl4Test.cpp
@@ -211,10 +211,6 @@ int main()
 
     std::array<double, CH_SPACEDIM> centerGW = {0, 0, 0};
 
-    int formulation = 1;
-    double G_Newton = 1.0;
-    double sigma = 0.1;
-
     struct timeval begin, end;
     gettimeofday(&begin, NULL);
 

--- a/Tests/PositiveChiAndAlphaUnitTest/UserVariables.hpp
+++ b/Tests/PositiveChiAndAlphaUnitTest/UserVariables.hpp
@@ -16,7 +16,8 @@ enum
 namespace UserVariables
 {
 static constexpr char const *variable_names[NUM_VARS] = {
-    "chi", "lapse",
+    "chi",
+    "lapse",
 };
 }
 

--- a/Tests/SimdFunctionsUnitTests/SimdFunctionsUnitTest.cpp
+++ b/Tests/SimdFunctionsUnitTests/SimdFunctionsUnitTest.cpp
@@ -31,9 +31,9 @@ bool sv_test(const char *name, sop_t sop, vop_t vop)
     auto simd_out = vop(simd_in);
 
 #ifdef __INTEL_COMPILER
-    #pragma novector
+#pragma novector
 #else
-    #pragma omp simd safelen(1)
+#pragma omp simd safelen(1)
 #endif /* __INTEL_COMPILER */
     for (int i = 0; i < simd_length; i++)
         vals[i] = sop(static_cast<t>(i + 1));
@@ -63,9 +63,9 @@ bool rv_test(const char *name, op_t op, rev_op_t rev_op)
     t vals[simd_length];
 
 #ifdef __INTEL_COMPILER
-    #pragma novector
+#pragma novector
 #else
-    #pragma omp simd safelen(1)
+#pragma omp simd safelen(1)
 #endif /* __INTEL_COMPILER */
     for (int i = 0; i < simd_length; i++)
         vals[i] = op(i + 1);

--- a/Tests/VariableStoreTest/UserVariables.hpp
+++ b/Tests/VariableStoreTest/UserVariables.hpp
@@ -16,7 +16,8 @@ enum
 namespace UserVariables
 {
 static constexpr char const *variable_names[NUM_VARS] = {
-    "var", "sym_var",
+    "var",
+    "sym_var",
 };
 }
 


### PR DESCRIPTION
Hey, 

while reviewing the PR last month, I noticed that we had missing include statements in some files, especially in the AMRInterpolator. These missing includes didn't cause any compile errors in the examples or tests, but there was a danger that they would cause errors if a new example or test is written or the imports are reordered. This PR ensures that all files can be compiled directly.