### PR TITLE
More GW extraction parameters

### DIFF
--- a/Examples/BinaryBH/params_expensive.txt
+++ b/Examples/BinaryBH/params_expensive.txt
@@ -71,3 +71,7 @@ extraction_radii = 10. 30. 50.
 extraction_levels = 2 1 1
 num_points_phi = 16
 num_points_theta = 24
+num_modes = 3
+modes = 2 0 # l m for spherical harmonics
+        2 1
+        2 2

--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -324,7 +324,7 @@ void GRAMRLevel::regrid(const Vector<Box> &a_new_grids)
 void GRAMRLevel::postRegrid(int a_base_level)
 {
     // set m_restart_time to same as the coarser level
-    if(m_level > a_base_level && m_coarser_level_ptr != nullptr)
+    if (m_level > a_base_level && m_coarser_level_ptr != nullptr)
     {
         GRAMRLevel *coarser_gr_amr_level_ptr = gr_cast(m_coarser_level_ptr);
         m_restart_time = coarser_gr_amr_level_ptr->m_restart_time;

--- a/Source/GRChomboCore/SimulationParametersBase.hpp
+++ b/Source/GRChomboCore/SimulationParametersBase.hpp
@@ -95,16 +95,16 @@ class SimulationParametersBase : public ChomboParameters
         if (pp.contains("modes"))
         {
             pp.load("num_modes", extraction_params.num_modes);
-            std::vector<int> extraction_modes_vect(
-                                2 * extraction_params.num_modes);
+            std::vector<int> extraction_modes_vect(2 *
+                                                   extraction_params.num_modes);
             pp.load("modes", extraction_modes_vect,
                     2 * extraction_params.num_modes);
             extraction_params.modes.resize(extraction_params.num_modes);
-            for(int i = 0; i < extraction_params.num_modes; ++i)
+            for (int i = 0; i < extraction_params.num_modes; ++i)
             {
                 extraction_params.modes[i].first = extraction_modes_vect[2 * i];
                 extraction_params.modes[i].second =
-                                            extraction_modes_vect[2 * i + 1];
+                    extraction_modes_vect[2 * i + 1];
             }
         }
         else
@@ -112,7 +112,7 @@ class SimulationParametersBase : public ChomboParameters
             // by default extraction (l,m) = (2,0), (2,1) and (2,2)
             extraction_params.num_modes = 3;
             extraction_params.modes.resize(3);
-            for(int i = 0; i < 3; ++i)
+            for (int i = 0; i < 3; ++i)
             {
                 extraction_params.modes[i].first = 2;
                 extraction_params.modes[i].second = i;

--- a/Source/GRChomboCore/SimulationParametersBase.hpp
+++ b/Source/GRChomboCore/SimulationParametersBase.hpp
@@ -19,7 +19,10 @@ struct extraction_params_t
     std::array<double, CH_SPACEDIM> extraction_center;
     int num_points_phi;
     int num_points_theta;
+    int num_modes;
+    std::vector<std::pair<int, int>> modes; // l = first, m = second
     std::vector<int> extraction_levels;
+    bool write_extraction;
     int min_extraction_level;
 };
 
@@ -89,6 +92,34 @@ class SimulationParametersBase : public ChomboParameters
         pp.load("num_points_theta", extraction_params.num_points_theta, 4);
         pp.load("extraction_center", extraction_params.extraction_center,
                 {0.5 * L, 0.5 * L, 0.5 * L});
+        if (pp.contains("modes"))
+        {
+            pp.load("num_modes", extraction_params.num_modes);
+            std::vector<int> extraction_modes_vect(
+                                2 * extraction_params.num_modes);
+            pp.load("modes", extraction_modes_vect,
+                    2 * extraction_params.num_modes);
+            extraction_params.modes.resize(extraction_params.num_modes);
+            for(int i = 0; i < extraction_params.num_modes; ++i)
+            {
+                extraction_params.modes[i].first = extraction_modes_vect[2 * i];
+                extraction_params.modes[i].second =
+                                            extraction_modes_vect[2 * i + 1];
+            }
+        }
+        else
+        {
+            // by default extraction (l,m) = (2,0), (2,1) and (2,2)
+            extraction_params.num_modes = 3;
+            extraction_params.modes.resize(3);
+            for(int i = 0; i < 3; ++i)
+            {
+                extraction_params.modes[i].first = 2;
+                extraction_params.modes[i].second = i;
+            }
+        }
+
+        pp.load("write_extraction", extraction_params.write_extraction, false);
 
         // Work out the minimum extraction level
         auto min_extraction_level_it =

--- a/Source/utils/WeylExtraction.impl.hpp
+++ b/Source/utils/WeylExtraction.impl.hpp
@@ -62,16 +62,16 @@ inline void WeylExtraction::execute_query(
 
     for (int imode = 0; imode < m_params.num_modes; ++imode)
     {
-        const std::pair<int, int>& mode = m_params.modes[imode];
+        const std::pair<int, int> &mode = m_params.modes[imode];
         auto integral = integrate_surface(-2, mode.first, mode.second,
                                           interp_re_part, interp_im_part);
-        std::string integral_filename = "Weyl_integral_"
-                                        + std::to_string(mode.first)
-                                        + std::to_string(mode.second);
+        std::string integral_filename = "Weyl_integral_" +
+                                        std::to_string(mode.first) +
+                                        std::to_string(mode.second);
         write_integral(integral.first, integral.second, integral_filename);
     }
 
-    if(m_params.write_extraction)
+    if (m_params.write_extraction)
     {
         write_extraction("ExtractionOut_", interp_re_part, interp_im_part);
     }

--- a/Source/utils/WeylExtraction.impl.hpp
+++ b/Source/utils/WeylExtraction.impl.hpp
@@ -60,22 +60,21 @@ inline void WeylExtraction::execute_query(
     // submit the query
     a_interpolator->interp(query);
 
-    // calculate the integral over the surface -currently only 20, 21 and 22
-    // modes implemented here, but easily extended if more required
-    auto integrals20 =
-        integrate_surface(-2, 2, 0, interp_re_part, interp_im_part);
-    auto integrals21 =
-        integrate_surface(-2, 2, 1, interp_re_part, interp_im_part);
-    auto integrals22 =
-        integrate_surface(-2, 2, 2, interp_re_part, interp_im_part);
+    for (int imode = 0; imode < m_params.num_modes; ++imode)
+    {
+        const std::pair<int, int>& mode = m_params.modes[imode];
+        auto integral = integrate_surface(-2, mode.first, mode.second,
+                                          interp_re_part, interp_im_part);
+        std::string integral_filename = "Weyl_integral_"
+                                        + std::to_string(mode.first)
+                                        + std::to_string(mode.second);
+        write_integral(integral.first, integral.second, integral_filename);
+    }
 
-    // Output the result to a single file over the whole run
-    write_integral(integrals20.first, integrals20.second, "Weyl_integral_20");
-    write_integral(integrals21.first, integrals21.second, "Weyl_integral_21");
-    write_integral(integrals22.first, integrals22.second, "Weyl_integral_22");
-
-    // This generates a lot of output so is commented out
-    // write_extraction("ExtractionOut_", interp_re_part, interp_im_part);
+    if(m_params.write_extraction)
+    {
+        write_extraction("ExtractionOut_", interp_re_part, interp_im_part);
+    }
 }
 
 //! integrate over a spherical shell with given harmonics for each extraction


### PR DESCRIPTION
This just adds some extra parameters to allow the user to choose which modes of the Weyl4 scalar to calculate the integral for and also whether to write the extracted values out at every timestep. The default behaviour, if the parameters are not specified, is to do what is currently done (i.e. (l,m) = (2,0), (2,1) and (2,2) and no output of the extracted values).