### PR TITLE
Fix checkpoint restart with periodic BCs

### DIFF
--- a/Source/AMRInterpolator/AMRInterpolator.impl.hpp
+++ b/Source/AMRInterpolator/AMRInterpolator.impl.hpp
@@ -139,8 +139,8 @@ void AMRInterpolator<InterpAlgo>::computeLevelLayouts()
     m_origin.resize(num_levels);
     m_dx.resize(num_levels);
 
-    IntVect prev_small_end;
-    IntVect prev_big_end;
+    IntVect prev_small_end = IntVect::Zero;
+    IntVect prev_big_end = IntVect::Zero;
 
     for (int level_idx = 0; level_idx < num_levels; ++level_idx)
     {

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -108,8 +108,7 @@ class ChomboParameters
         pp.load("plot_prefix", plot_prefix);
         pp.load("stop_time", stop_time, 1.0);
         pp.load("max_steps", max_steps, 1000000);
-        pp.load("write_plot_ghosts", write_plot_ghosts,
-                nonperiodic_boundaries_exist);
+        pp.load("write_plot_ghosts", write_plot_ghosts, false);
 
         // alias the weird chombo names to something more descriptive
         // for these box params, and default to some reasonable values

--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -471,12 +471,8 @@ void GRAMRLevel::writeCheckpointLevel(HDF5Handle &a_handle) const
 
     write(a_handle, m_state_new.boxLayout());
 
-    // only need to write ghosts when non periodic BCs exist
-    IntVect ghost_vector = IntVect::Zero;
-    if (m_p.nonperiodic_boundaries_exist)
-    {
-        ghost_vector = m_num_ghosts * IntVect::Unit;
-    }
+    // Always write ghost cells even for periodic BCs
+    IntVect ghost_vector = m_num_ghosts * IntVect::Unit;
     write(a_handle, m_state_new, "data", ghost_vector);
 }
 


### PR DESCRIPTION
This fixes #53 by making the HDF5 read function not redefine `GRLevelData m_state_new`. Previously this object was being redefined by inferring the number of ghosts from the data in the checkpoint file. In the case of periodic BCs, where no ghosts are outputted (since they are not needed), this meant that `m_state_new` was redefined to have no ghosts!

I have also set the writing of ghost cells in plot files to be off by default as this was causing issues with visualisation software (VisIt and ParaView) and initialised some IntVects (to zero) in the `AMRInterpolator` to remove some compiler warnings.