### PR TITLE
Add first step condition in SmallDataIO

### DIFF
--- a/Source/utils/SmallDataIO.cpp
+++ b/Source/utils/SmallDataIO.cpp
@@ -3,12 +3,7 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-#if !defined(SMALLDATAIO_HPP_)
-#error "This file should only be included through SmallDataIO.hpp"
-#endif
-
-#ifndef SMALLDATAIO_IMPL_HPP_
-#define SMALLDATAIO_IMPL_HPP_
+#include "SmallDataIO.hpp"
 
 void SmallDataIO::write_header_line(
     const std::vector<std::string> &a_header_strings,
@@ -97,7 +92,7 @@ void SmallDataIO::remove_duplicate_time_data()
     if (m_rank == 0 && m_restart_time > 0. && m_mode == APPEND &&
         m_time < m_restart_time + m_dt + epsilon)
     {
-        // copy lines with time <= restart_time into a temporary file
+        // copy lines with time < m_time into a temporary file
         std::string line;
         std::string temp_filename = m_filename + ".temp";
         std::ofstream temp_file(temp_filename);
@@ -107,8 +102,8 @@ void SmallDataIO::remove_duplicate_time_data()
             {
                 temp_file << line << "\n";
             }
-            else if (std::stod(line.substr(0, m_coords_width)) <=
-                     m_restart_time + epsilon)
+            else if (std::stod(line.substr(0, m_coords_width)) <
+                     m_time - epsilon)
             {
                 temp_file << line << "\n";
             }
@@ -125,5 +120,3 @@ void SmallDataIO::remove_duplicate_time_data()
         m_file.open(m_filename, std::ios::app);
     }
 }
-
-#endif /* SMALLDATAIO_IMPL_HPP_ */

--- a/Source/utils/WeylExtraction.hpp
+++ b/Source/utils/WeylExtraction.hpp
@@ -29,6 +29,7 @@ class WeylExtraction
     const int m_im_comp = c_Weyl4_Im;
     const double m_dt;
     const double m_time;
+    const bool m_first_step;
     const double m_restart_time;
     const int m_num_points; // number of points per extraction radius
     const double m_dphi;
@@ -37,14 +38,24 @@ class WeylExtraction
   public:
     //! The constructor
     WeylExtraction(extraction_params_t a_params, double a_dt, double a_time,
-                   double a_restart_time = 0.0)
+                   bool a_first_step, double a_restart_time = 0.0)
         : m_params(a_params), m_dt(a_dt), m_time(a_time),
-          m_restart_time(a_restart_time),
+          m_first_step(a_first_step), m_restart_time(a_restart_time),
           m_num_points(m_params.num_points_phi * m_params.num_points_theta),
           m_dphi(2.0 * M_PI / m_params.num_points_phi),
           m_dtheta(M_PI / m_params.num_points_theta)
     {
     }
+
+    //! The old constructor which assumes it is called in specificPostTimeStep
+    //! so the first time step is when m_time == m_dt
+    WeylExtraction(extraction_params_t a_params, double a_dt, double a_time,
+                   double a_restart_time = 0.0)
+        : WeylExtraction(a_params, a_dt, a_time, (a_dt == a_time),
+                         a_restart_time)
+    {
+    }
+
 
     //! Destructor
     ~WeylExtraction() {}

--- a/Source/utils/WeylExtraction.impl.hpp
+++ b/Source/utils/WeylExtraction.impl.hpp
@@ -169,15 +169,13 @@ WeylExtraction::write_integral(const std::vector<double> a_integral_re,
     CH_TIME("WeylExtraction::write_integral");
     // open file for writing
     SmallDataIO integral_file(a_filename, m_dt, m_time, m_restart_time,
-                              SmallDataIO::APPEND);
+                              SmallDataIO::APPEND, m_first_step);
 
     // remove any duplicate data if this is a restart
-    // note that this only does something if this is the first timestep after
-    // a restart
     integral_file.remove_duplicate_time_data();
 
     // need to write headers if this is the first timestep
-    if (m_time == m_dt)
+    if (m_first_step)
     {
         // make header strings
         std::vector<std::string> header1_strings(2 *
@@ -224,7 +222,7 @@ WeylExtraction::write_extraction(std::string a_file_prefix,
 {
     CH_TIME("WeylExtraction::write_extraction");
     SmallDataIO extraction_file(a_file_prefix, m_dt, m_time, m_restart_time,
-                                SmallDataIO::NEW);
+                                SmallDataIO::NEW, m_first_step);
 
     for (int iradius = 0; iradius < m_params.num_extraction_radii; ++iradius)
     {


### PR DESCRIPTION
This change allows the user to set their own condition for the first
step (when the header lines are printed) which means that `SmallDataIO`
can be used in a different place to `specificPostTimeStep`. The
`WeylExtraction` class has been correspondingly updated but old
constructors are kept for backward compatibility.

The member function definitions have also been moved to a cpp file since
there's no templating.

This should be the same as COSMOS-CTC-Cambridge/GRChombo#182.