### PR TITLE
Amend PositiveChiAndAlpha and minor bugs

### DIFF
--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -31,7 +31,8 @@
 void ScalarFieldLevel::specificAdvance()
 {
     // Enforce trace free A_ij and positive chi and alpha
-    BoxLoops::loop(make_compute_pack(TraceARemoval(), PositiveChiAndAlpha()),
+    BoxLoops::loop(make_compute_pack(TraceARemoval(), 
+                       PositiveChiAndAlpha(m_p.min_chi, m_p.min_lapse)),
                    m_state_new, m_state_new, INCLUDE_GHOST_CELLS);
 
     // Check for nan's
@@ -93,8 +94,9 @@ void ScalarFieldLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
 
         // Enforce trace free A_ij and positive chi and alpha
         BoxLoops::loop(
-            make_compute_pack(TraceARemoval(), PositiveChiAndAlpha()), a_soln,
-            a_soln, INCLUDE_GHOST_CELLS);
+            make_compute_pack(TraceARemoval(), 
+                              PositiveChiAndAlpha(m_p.min_chi, m_p.min_lapse)), 
+            a_soln, a_soln, INCLUDE_GHOST_CELLS);
 
         // Calculate MatterCCZ4 right hand side with matter_t = ScalarField
         // We don't want undefined values floating around in the constraints so

--- a/Examples/ScalarField/params.txt
+++ b/Examples/ScalarField/params.txt
@@ -65,7 +65,7 @@ vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
 # Set up time steps
 # dt will be dx*dt_multiplier on each grid level
 # HDF5files are written every dt = L/N*dt_multiplier*checkpoint_interval
-checkpoint_interval = 1
+checkpoint_interval = 100
 plot_interval = 10
 dt_multiplier = 0.25
 stop_time = 10.0
@@ -104,5 +104,7 @@ scalar_mass = 0.001
 
 # Relaxation paramters
 # how long and how fast to relax
+# (should be non zero if starting from phi data
+# for which constraints not solved)
 relaxtime = 0.0
 relaxspeed = 0.01

--- a/Source/CCZ4/PositiveChiAndAlpha.hpp
+++ b/Source/CCZ4/PositiveChiAndAlpha.hpp
@@ -13,14 +13,24 @@
 
 class PositiveChiAndAlpha
 {
+  private:
+    const double m_min_chi;
+    const double m_min_lapse;
+
   public:
+    //! Constructor for class
+    PositiveChiAndAlpha(const double a_min_chi = 1e-4, 
+                        const double a_min_lapse = 1e-4) 
+                        : m_min_chi(a_min_chi), m_min_lapse(a_min_lapse)
+    {}
+
     template <class data_t> void compute(Cell<data_t> current_cell) const
     {
         auto chi = current_cell.load_vars(c_chi);
         auto lapse = current_cell.load_vars(c_lapse);
 
-        chi = simd_max(chi, 1e-4);
-        lapse = simd_max(lapse, 1e-4);
+        chi = simd_max(chi, m_min_chi);
+        lapse = simd_max(lapse, m_min_lapse);
 
         current_cell.store_vars(chi, c_chi);
         current_cell.store_vars(lapse, c_lapse);

--- a/Source/GRChomboCore/SimulationParametersBase.hpp
+++ b/Source/GRChomboCore/SimulationParametersBase.hpp
@@ -56,8 +56,10 @@ class SimulationParametersBase : public ChomboParameters
         // Dissipation
         pp.load("sigma", sigma, 0.1);
 
-        // Nan Check
+        // Nan Check and min chi and lapse values
         pp.load("nan_check", nan_check, 1);
+        pp.load("min_chi", min_chi, 1e-4);
+        pp.load("min_lapse", min_lapse, 1e-4);
 
         // extraction params
         dx.fill(coarsest_dx);
@@ -132,6 +134,8 @@ class SimulationParametersBase : public ChomboParameters
     double sigma; // Kreiss-Oliger dissipation parameter
 
     int nan_check;
+
+    double min_chi, min_lapse;
 
     int formulation; // Whether to use BSSN or CCZ4
 

--- a/Source/InitialConditions/ScalarFields/ScalarBubble.impl.hpp
+++ b/Source/InitialConditions/ScalarFields/ScalarBubble.impl.hpp
@@ -45,7 +45,7 @@ data_t ScalarBubble::compute_phi(Coordinates<data_t> coords) const
     data_t rr = coords.get_radius();
     data_t rr2 = rr * rr;
     data_t out_phi = m_params.amplitudeSF * rr2 *
-                     exp(-pow(rr - m_params.r_zero / m_params.widthSF, 2.0));
+                     exp(-pow((rr - m_params.r_zero) / m_params.widthSF, 2.0));
 
     return out_phi;
 }


### PR DESCRIPTION
- I have added a constructor to the PositiveChiAndAlpha which permits the user to override the default values as suggested in issue #56. Defaults are set so old code still works, but an example of the usage to override these is provided in the ScalarField Example - one needs to pass the sim_params values to the class constructor and set them in the params file if a different value is required.

- I have also fixed the minor bugs identified in #60 and #61.

(Note - clean version of cancelled request #62)