### PR TITLE
Add GRParmParse::load for vectors with a default

### DIFF
--- a/Source/utils/GRParmParse.hpp
+++ b/Source/utils/GRParmParse.hpp
@@ -94,10 +94,10 @@ class GRParmParse : public ParmParse
     }
 
     /// Loads a vector with num_comp components from the parameter file, if the
-    /// vector isn't defined it sets all components to the supplied default
+    /// vector isn't defined, it is set to the supplied default
     template <class data_t>
     void load(const char *name, std::vector<data_t> &vector, const int num_comp,
-              const data_t default_value) const
+              const std::vector<data_t> &default_vector) const
     {
         if (contains(name))
         {
@@ -105,11 +105,20 @@ class GRParmParse : public ParmParse
         }
         else
         {
-            vector.resize(num_comp);
-            vector.assign(num_comp, default_value);
+            vector = default_vector;
             pout() << "Parameter: " << name << " not found in parameter file. "
                    << "It has been set to its default value." << std::endl;
         }
+    }
+
+    /// Loads a vector with num_comp components from the parameter file, if the
+    /// vector isn't defined it sets all components to the supplied default
+    template <class data_t>
+    void load(const char *name, std::vector<data_t> &vector, const int num_comp,
+              const data_t default_value) const
+    {
+        load(name, vector, num_comp,
+             std::vector<data_t>(num_comp, default_value));
     }
 };
 


### PR DESCRIPTION
Pretty much in the title. Currently, it's only possible to supply a single default value for `std::vector` parameters so the whole vector will have all elements the same by default This PR just allows the user to supply a full default vector which can have different elements.