### PR TITLE
Create argo.Make.defs.local

### DIFF
--- a/InstallNotes/MakeDefsLocalExamples/argo.Make.defs.local
+++ b/InstallNotes/MakeDefsLocalExamples/argo.Make.defs.local
@@ -1,0 +1,17 @@
+DIM             = 3
+DEBUG           = FALSE
+OPT             = HIGH
+PRECISION       = DOUBLE
+FC              = ifort
+CXX             = icpc -std=c++14 -qopenmp -I${MKLROOT}/include -no-multibyte-chars
+MPI             = TRUE
+MPICXX          = mpicxx -std=c++14 -qopenmp -I${MKLROOT}/include -no-multibyte-chars
+OPENMPCC        = TRUE
+USE_HDF         = TRUE
+HDFINCFLAGS     = -I${HDF5_INC}
+HDFLIBFLAGS     = -L${HDF5_LIB} -lhdf5 -lz
+HDFMPIINCFLAGS  = -I${HDF5_INC} 
+HDFMPILIBFLAGS  = -L${HDF5_LIB} -lhdf5 -lz
+syslibflags     = -L${MKLROOT}/lib/intel64 -lmkl_intel_lp64 -lmkl_sequential -lmkl_core
+cxxoptflags     = -O3 -xSSE4.2 -axAVX 
+foptflags       = -O3 -xSSE4.2 -axAVX

--- a/InstallNotes/MakeDefsLocalExamples/argo.modules.sh
+++ b/InstallNotes/MakeDefsLocalExamples/argo.modules.sh
@@ -1,0 +1,5 @@
+module load gcc/4.9.0
+module load openmpi/1.10.2/intel/2016
+module load intel-mkl/2017
+module load intel/2016
+module load gnu-openmpi/phdf5/1.8.17


### PR DESCRIPTION
This is make.defs.local file for compiling Chombo in argo: cluster of ICTP (International Center for Theoretical Physics) 