### PR TITLE
Make Constraints::constraints_t a Vars object

### DIFF
--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -31,9 +31,10 @@
 void ScalarFieldLevel::specificAdvance()
 {
     // Enforce trace free A_ij and positive chi and alpha
-    BoxLoops::loop(make_compute_pack(TraceARemoval(), 
-                       PositiveChiAndAlpha(m_p.min_chi, m_p.min_lapse)),
-                   m_state_new, m_state_new, INCLUDE_GHOST_CELLS);
+    BoxLoops::loop(
+        make_compute_pack(TraceARemoval(),
+                          PositiveChiAndAlpha(m_p.min_chi, m_p.min_lapse)),
+        m_state_new, m_state_new, INCLUDE_GHOST_CELLS);
 
     // Check for nan's
     if (m_p.nan_check)
@@ -94,8 +95,8 @@ void ScalarFieldLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
 
         // Enforce trace free A_ij and positive chi and alpha
         BoxLoops::loop(
-            make_compute_pack(TraceARemoval(), 
-                              PositiveChiAndAlpha(m_p.min_chi, m_p.min_lapse)), 
+            make_compute_pack(TraceARemoval(),
+                              PositiveChiAndAlpha(m_p.min_chi, m_p.min_lapse)),
             a_soln, a_soln, INCLUDE_GHOST_CELLS);
 
         // Calculate MatterCCZ4 right hand side with matter_t = ScalarField

--- a/Source/CCZ4/Constraints.hpp
+++ b/Source/CCZ4/Constraints.hpp
@@ -29,10 +29,20 @@ class Constraints
     template <class data_t>
     using Diff2Vars = BSSNVars::Diff2VarsNoGauge<data_t>;
 
-    template <class data_t> struct constraints_t
+    /// Vars object for Constraints
+    template <class data_t> struct ConstraintsVars
     {
         data_t Ham;
         Tensor<1, data_t> Mom;
+
+        template <typename mapping_function_t>
+        void enum_mapping(mapping_function_t mapping_function)
+        {
+            using namespace VarsTools;
+            define_enum_mapping(mapping_function, c_Ham, Ham);
+            define_enum_mapping(mapping_function, GRInterval<c_Mom1, c_Mom3>(),
+                                Mom);
+        }
     };
 
     Constraints(double dx, double cosmological_constant = 0);
@@ -45,7 +55,7 @@ class Constraints
 
     template <class data_t, template <typename> class vars_t,
               template <typename> class diff2_vars_t>
-    constraints_t<data_t>
+    ConstraintsVars<data_t>
     constraint_equations(const vars_t<data_t> &vars,
                          const vars_t<Tensor<1, data_t>> &d1,
                          const diff2_vars_t<Tensor<2, data_t>> &d2) const;

--- a/Source/CCZ4/Constraints.hpp
+++ b/Source/CCZ4/Constraints.hpp
@@ -23,14 +23,14 @@ class Constraints
 {
   public:
     /// CCZ4 variables
-    template <class data_t> using Vars = BSSNVars::VarsNoGauge<data_t>;
+    template <class data_t> using BSSNVars = BSSNVars::VarsNoGauge<data_t>;
 
     /// CCZ4 variables
     template <class data_t>
     using Diff2Vars = BSSNVars::Diff2VarsNoGauge<data_t>;
 
     /// Vars object for Constraints
-    template <class data_t> struct ConstraintsVars
+    template <class data_t> struct Vars
     {
         data_t Ham;
         Tensor<1, data_t> Mom;
@@ -55,7 +55,7 @@ class Constraints
 
     template <class data_t, template <typename> class vars_t,
               template <typename> class diff2_vars_t>
-    ConstraintsVars<data_t>
+    Vars<data_t>
     constraint_equations(const vars_t<data_t> &vars,
                          const vars_t<Tensor<1, data_t>> &d1,
                          const diff2_vars_t<Tensor<2, data_t>> &d2) const;

--- a/Source/CCZ4/Constraints.impl.hpp
+++ b/Source/CCZ4/Constraints.impl.hpp
@@ -23,11 +23,11 @@ inline Constraints::Constraints(double dx,
 template <class data_t>
 void Constraints::compute(Cell<data_t> current_cell) const
 {
-    const auto vars = current_cell.template load_vars<Vars>();
-    const auto d1 = m_deriv.template diff1<Vars>(current_cell);
+    const auto vars = current_cell.template load_vars<BSSNVars>();
+    const auto d1 = m_deriv.template diff1<BSSNVars>(current_cell);
     const auto d2 = m_deriv.template diff2<Diff2Vars>(current_cell);
 
-    ConstraintsVars<data_t> out = constraint_equations(vars, d1, d2);
+    Vars<data_t> out = constraint_equations(vars, d1, d2);
 
     // Write the rhs into the output FArrayBox
     current_cell.store_vars(out);
@@ -35,11 +35,11 @@ void Constraints::compute(Cell<data_t> current_cell) const
 
 template <class data_t, template <typename> class vars_t,
           template <typename> class diff2_vars_t>
-Constraints::ConstraintsVars<data_t> Constraints::constraint_equations(
+Constraints::Vars<data_t> Constraints::constraint_equations(
     const vars_t<data_t> &vars, const vars_t<Tensor<1, data_t>> &d1,
     const diff2_vars_t<Tensor<2, data_t>> &d2) const
 {
-    ConstraintsVars<data_t> out;
+    Vars<data_t> out;
 
     const data_t chi_regularised = simd_max(1e-6, vars.chi);
 

--- a/Source/CCZ4/Constraints.impl.hpp
+++ b/Source/CCZ4/Constraints.impl.hpp
@@ -27,20 +27,19 @@ void Constraints::compute(Cell<data_t> current_cell) const
     const auto d1 = m_deriv.template diff1<Vars>(current_cell);
     const auto d2 = m_deriv.template diff2<Diff2Vars>(current_cell);
 
-    constraints_t<data_t> out = constraint_equations(vars, d1, d2);
+    ConstraintsVars<data_t> out = constraint_equations(vars, d1, d2);
 
     // Write the rhs into the output FArrayBox
-    current_cell.store_vars(out.Ham, c_Ham);
-    current_cell.store_vars(out.Mom, GRInterval<c_Mom1, c_Mom3>());
+    current_cell.store_vars(out);
 }
 
 template <class data_t, template <typename> class vars_t,
           template <typename> class diff2_vars_t>
-Constraints::constraints_t<data_t> Constraints::constraint_equations(
+Constraints::ConstraintsVars<data_t> Constraints::constraint_equations(
     const vars_t<data_t> &vars, const vars_t<Tensor<1, data_t>> &d1,
     const diff2_vars_t<Tensor<2, data_t>> &d2) const
 {
-    constraints_t<data_t> out;
+    ConstraintsVars<data_t> out;
 
     const data_t chi_regularised = simd_max(1e-6, vars.chi);
 

--- a/Source/CCZ4/PositiveChiAndAlpha.hpp
+++ b/Source/CCZ4/PositiveChiAndAlpha.hpp
@@ -19,10 +19,11 @@ class PositiveChiAndAlpha
 
   public:
     //! Constructor for class
-    PositiveChiAndAlpha(const double a_min_chi = 1e-4, 
-                        const double a_min_lapse = 1e-4) 
-                        : m_min_chi(a_min_chi), m_min_lapse(a_min_lapse)
-    {}
+    PositiveChiAndAlpha(const double a_min_chi = 1e-4,
+                        const double a_min_lapse = 1e-4)
+        : m_min_chi(a_min_chi), m_min_lapse(a_min_lapse)
+    {
+    }
 
     template <class data_t> void compute(Cell<data_t> current_cell) const
     {

--- a/Source/Matter/MatterConstraints.hpp
+++ b/Source/Matter/MatterConstraints.hpp
@@ -32,14 +32,15 @@ template <class matter_t> class MatterConstraints : public Constraints
 
     // Inherit the variable definitions from CCZ4 + matter_t
     template <class data_t>
-    struct Vars : public Constraints::Vars<data_t>, public MatterVars<data_t>
+    struct BSSNMatterVars : public Constraints::BSSNVars<data_t>,
+                            public MatterVars<data_t>
     {
         /// Defines the mapping between members of Vars and Chombo grid
         /// variables (enum in User_Variables)
         template <typename mapping_function_t>
         void enum_mapping(mapping_function_t mapping_function)
         {
-            Constraints::Vars<data_t>::enum_mapping(mapping_function);
+            Constraints::BSSNVars<data_t>::enum_mapping(mapping_function);
             MatterVars<data_t>::enum_mapping(mapping_function);
         }
     };

--- a/Source/Matter/MatterConstraints.impl.hpp
+++ b/Source/Matter/MatterConstraints.impl.hpp
@@ -29,7 +29,7 @@ void MatterConstraints<matter_t>::compute(Cell<data_t> current_cell) const
     const auto d2 = m_deriv.template diff2<Vars>(current_cell);
 
     // Get the non matter terms for the constraints
-    constraints_t<data_t> out = constraint_equations(vars, d1, d2);
+    ConstraintsVars<data_t> out = constraint_equations(vars, d1, d2);
 
     // Inverse metric and Christoffel symbol
     const auto h_UU = TensorAlgebra::compute_inverse_sym(vars.h);

--- a/Source/Matter/MatterConstraints.impl.hpp
+++ b/Source/Matter/MatterConstraints.impl.hpp
@@ -24,12 +24,12 @@ template <class data_t>
 void MatterConstraints<matter_t>::compute(Cell<data_t> current_cell) const
 {
     // Load local vars and calculate derivs
-    const auto vars = current_cell.template load_vars<Vars>();
-    const auto d1 = m_deriv.template diff1<Vars>(current_cell);
-    const auto d2 = m_deriv.template diff2<Vars>(current_cell);
+    const auto vars = current_cell.template load_vars<BSSNMatterVars>();
+    const auto d1 = m_deriv.template diff1<BSSNMatterVars>(current_cell);
+    const auto d2 = m_deriv.template diff2<BSSNMatterVars>(current_cell);
 
     // Get the non matter terms for the constraints
-    ConstraintsVars<data_t> out = constraint_equations(vars, d1, d2);
+    Vars<data_t> out = constraint_equations(vars, d1, d2);
 
     // Inverse metric and Christoffel symbol
     const auto h_UU = TensorAlgebra::compute_inverse_sym(vars.h);
@@ -44,9 +44,8 @@ void MatterConstraints<matter_t>::compute(Cell<data_t> current_cell) const
     // Momentum constraints
     FOR1(i) { out.Mom[i] += -8.0 * M_PI * m_G_Newton * emtensor.Si[i]; }
 
-    // Write the rhs into the output FArrayBox
-    current_cell.store_vars(out.Ham, c_Ham);
-    current_cell.store_vars(out.Mom, GRInterval<c_Mom1, c_Mom3>());
+    // Write the constraints into the output FArrayBox
+    current_cell.store_vars(out);
 }
 
 #endif /* MATTERCONSTRAINTS_IMPL_HPP_ */


### PR DESCRIPTION
A very small PR that makes `Constraints::constraints_t` into a Vars object with an `enum_mapping`.

I have also clang-formatted the code hence some other minor changes.