### PR TITLE
Improve binary example

### DIFF
--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -8,15 +8,18 @@
 #include "BoxLoops.hpp"
 #include "CCZ4.hpp"
 #include "ChiExtractionTaggingCriterion.hpp"
+#include "ChiPunctureExtractionTaggingCriterion.hpp"
 #include "ComputePack.hpp"
 #include "Constraints.hpp"
 #include "NanCheck.hpp"
 #include "PositiveChiAndAlpha.hpp"
+#include "PunctureTracker.hpp"
 #include "SetValue.hpp"
 #include "TraceARemoval.hpp"
 #include "Weyl4.hpp"
 #include "WeylExtraction.hpp"
 
+// Things to do during the advance step after RK4 steps
 void BinaryBHLevel::specificAdvance()
 {
     // Enforce the trace free A_ij condition and positive chi and alpha
@@ -29,6 +32,8 @@ void BinaryBHLevel::specificAdvance()
                        m_state_new, EXCLUDE_GHOST_CELLS, disable_simd());
 }
 
+// This initial data uses an approximation for the metric which
+// is valid for small boosts
 void BinaryBHLevel::initialData()
 {
     CH_TIME("BinaryBHLevel::initialData");
@@ -38,19 +43,50 @@ void BinaryBHLevel::initialData()
     // Set up the compute class for the BinaryBH initial data
     BinaryBH binary(m_p.bh1_params, m_p.bh2_params, m_dx);
 
+    // setup initial puncture coords for tracking
+    // do puncture tracking, just set them once, so on level 0
+    if (m_p.track_punctures == 1 && m_level == 0)
+    {
+        const double coarsest_dt = m_p.coarsest_dx * m_p.dt_multiplier;
+        PunctureTracker my_punctures(m_time, m_restart_time, coarsest_dt,
+                                     m_p.checkpoint_prefix);
+        my_punctures.set_initial_punctures(m_bh_amr,
+                                           m_p.initial_puncture_coords);
+    }
+
     // First set everything to zero (to avoid undefinded values in constraints)
     // then calculate initial data
     BoxLoops::loop(make_compute_pack(SetValue(0.), binary), m_state_new,
                    m_state_new, INCLUDE_GHOST_CELLS);
 }
 
+// Things to do after a restart
+void BinaryBHLevel::postRestart()
+{
+    // do puncture tracking, just set them once, so on the top level
+    if (m_p.track_punctures == 1 && m_level == m_p.max_level)
+    {
+        // need to set a temporary interpolator for finding the shift
+        // as the happens in setupAMRObject() not amr.run()
+        AMRInterpolator<Lagrange<4>> interpolator(m_bh_amr, m_p.origin, m_p.dx,
+                                                  m_p.verbosity);
+        m_bh_amr.set_interpolator(&interpolator);
+        PunctureTracker my_punctures(m_time, m_restart_time, m_dt,
+                                     m_p.checkpoint_prefix);
+        my_punctures.restart_punctures(m_bh_amr, m_p.initial_puncture_coords);
+    }
+}
+
+// Things to do before writing checkpoints
 void BinaryBHLevel::preCheckpointLevel()
 {
+    // Calculate and assing values of Ham and Mom constraints on grid
     fillAllGhosts();
     BoxLoops::loop(Constraints(m_dx), m_state_new, m_state_new,
                    EXCLUDE_GHOST_CELLS);
 }
 
+// Calculate RHS during RK4 substeps
 void BinaryBHLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
                                     const double a_time)
 {
@@ -66,6 +102,7 @@ void BinaryBHLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
         a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
 }
 
+// enforce trace removal during RK4 substeps
 void BinaryBHLevel::specificUpdateODE(GRLevelData &a_soln,
                                       const GRLevelData &a_rhs, Real a_dt)
 {
@@ -73,12 +110,29 @@ void BinaryBHLevel::specificUpdateODE(GRLevelData &a_soln,
     BoxLoops::loop(TraceARemoval(), a_soln, a_soln, INCLUDE_GHOST_CELLS);
 }
 
+// specify the cells to tag
 void BinaryBHLevel::computeTaggingCriterion(FArrayBox &tagging_criterion,
                                             const FArrayBox &current_state)
 {
-    BoxLoops::loop(
-        ChiExtractionTaggingCriterion(m_dx, m_level, m_p.extraction_params),
-        current_state, tagging_criterion);
+    if (m_p.track_punctures == true)
+    {
+        const vector<double> puncture_masses = {m_p.bh1_params.mass,
+                                                m_p.bh2_params.mass};
+        std::vector<std::array<double, CH_SPACEDIM>> puncture_coords =
+            m_bh_amr.get_puncture_coords();
+        BoxLoops::loop(ChiPunctureExtractionTaggingCriterion(
+                           m_dx, m_level, m_p.max_level, m_p.extraction_params,
+                           puncture_coords, m_p.activate_extraction,
+                           m_p.track_punctures, puncture_masses),
+                       current_state, tagging_criterion);
+    }
+    else
+    {
+        BoxLoops::loop(ChiExtractionTaggingCriterion(
+                           m_dx, m_level, m_p.max_level, m_p.extraction_params,
+                           m_p.activate_extraction),
+                       current_state, tagging_criterion);
+    }
 }
 
 void BinaryBHLevel::specificPostTimeStep()
@@ -94,12 +148,30 @@ void BinaryBHLevel::specificPostTimeStep()
         // Do the extraction on the min extraction level
         if (m_level == m_p.extraction_params.min_extraction_level)
         {
+            CH_TIME("WeylExtraction");
             // Now refresh the interpolator and do the interpolation
             m_gr_amr.m_interpolator->refresh();
             WeylExtraction my_extraction(m_p.extraction_params, m_dt, m_time,
                                          m_restart_time);
             my_extraction.execute_query(m_gr_amr.m_interpolator);
         }
+    }
+
+    // do puncture tracking on finest but one level
+    if (m_p.track_punctures == 1 && m_level == m_p.max_level - 1)
+    {
+        CH_TIME("PunctureTracking");
+        // only do the write out for every coarsest level timestep
+        bool write_punctures = false;
+        const double coarsest_dt = m_p.coarsest_dx * m_p.dt_multiplier;
+        const double remainder = fmod(m_time, coarsest_dt);
+        PunctureTracker my_punctures(m_time, m_restart_time, m_dt,
+                                     m_p.checkpoint_prefix);
+        if (min(abs(remainder), abs(remainder - coarsest_dt)) < 1.0e-8)
+        {
+            write_punctures = true;
+        }
+        my_punctures.execute_tracking(m_bh_amr, write_punctures);
     }
 }
 

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -158,7 +158,7 @@ void BinaryBHLevel::specificPostTimeStep()
     }
 
     // do puncture tracking on finest but one level
-    if (m_p.track_punctures == 1 && m_level == m_p.max_level - 1)
+    if (m_p.track_punctures == 1 && m_level == m_p.max_level - 4)
     {
         CH_TIME("PunctureTracking");
         // only do the write out for every coarsest level timestep

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -157,8 +157,8 @@ void BinaryBHLevel::specificPostTimeStep()
         }
     }
 
-    // do puncture tracking on finest but one level
-    if (m_p.track_punctures == 1 && m_level == m_p.max_level - 4)
+    // do puncture tracking on requested level
+    if (m_p.track_punctures == 1 && m_level == m_p.puncture_tracking_level)
     {
         CH_TIME("PunctureTracking");
         // only do the write out for every coarsest level timestep

--- a/Examples/BinaryBH/BinaryBHLevel.hpp
+++ b/Examples/BinaryBH/BinaryBHLevel.hpp
@@ -6,6 +6,7 @@
 #ifndef BINARYBHLEVEL_HPP_
 #define BINARYBHLEVEL_HPP_
 
+#include "BHAMR.hpp"
 #include "DefaultLevelFactory.hpp"
 #include "GRAMRLevel.hpp"
 
@@ -15,12 +16,17 @@ class BinaryBHLevel : public GRAMRLevel
     // Inherit the contructors from GRAMRLevel
     using GRAMRLevel::GRAMRLevel;
 
+    BHAMR &m_bh_amr = dynamic_cast<BHAMR &>(m_gr_amr);
+
     /// Things to do at every full timestep
     ///(might include several substeps, e.g. in RK4)
     virtual void specificAdvance() override;
 
     /// Initial data calculation
     virtual void initialData() override;
+
+    /// Things to do after a restart
+    virtual void postRestart() override;
 
     /// Any actions that should happen just before checkpointing
     virtual void preCheckpointLevel() override;

--- a/Examples/BinaryBH/Main_BinaryBH.cpp
+++ b/Examples/BinaryBH/Main_BinaryBH.cpp
@@ -8,8 +8,8 @@
 #include <chrono>
 #include <iostream>
 
+#include "BHAMR.hpp"
 #include "DefaultLevelFactory.hpp"
-#include "GRAMR.hpp"
 #include "GRParmParse.hpp"
 #include "SetupFunctions.hpp"
 #include "SimulationParameters.hpp"
@@ -28,7 +28,7 @@ int runGRChombo(int argc, char *argv[])
     // The line below selects the problem that is simulated
     // (To simulate a different problem, define a new child of AMRLevel
     // and an associated LevelFactory)
-    GRAMR gr_amr;
+    BHAMR gr_amr;
     DefaultLevelFactory<BinaryBHLevel> binary_bh_level_fact(gr_amr, sim_params);
     setupAMRObject(gr_amr, binary_bh_level_fact);
 

--- a/Examples/BinaryBH/SimulationParameters.hpp
+++ b/Examples/BinaryBH/SimulationParameters.hpp
@@ -26,20 +26,39 @@ class SimulationParameters : public SimulationParametersBase
     {
         // Initial data
         pp.load("massA", bh1_params.mass);
-        pp.load("centerA", bh1_params.center);
         pp.load("momentumA", bh1_params.momentum);
         pp.load("massB", bh2_params.mass);
-        pp.load("centerB", bh2_params.center);
         pp.load("momentumB", bh2_params.momentum);
-        pp.load("activate_extraction", activate_extraction, 0);
+
+        // Get the centers of the BHs either explicitly or as
+        // an offset (not both, or they will be offset from center
+        // provided)
+        std::array<double, CH_SPACEDIM> centerA, centerB;
+        std::array<double, CH_SPACEDIM> offsetA, offsetB;
+        pp.load("centerA", centerA, center);
+        pp.load("centerB", centerB, center);
+        pp.load("offsetA", offsetA, {0.0, 0.0, 0.0});
+        pp.load("offsetB", offsetB, {0.0, 0.0, 0.0});
+        FOR1(idir)
+        {
+            bh1_params.center[idir] = centerA[idir] + offsetA[idir];
+            bh2_params.center[idir] = centerB[idir] + offsetB[idir];
+        }
+
+        // Do we want Weyl extraction and puncture tracking?
+        pp.load("activate_extraction", activate_extraction, false);
+        pp.load("track_punctures", track_punctures, false);
+
+        // hard code num punctures to 2 for now
+        int num_punctures = 2;
+        initial_puncture_coords.resize(num_punctures);
+        initial_puncture_coords[0] = bh1_params.center;
+        initial_puncture_coords[1] = bh2_params.center;
     }
 
     // Initial data
-    int activate_extraction;
-    Real massA, massB;
-    std::array<double, CH_SPACEDIM> centerA, centerB;
-    std::array<double, CH_SPACEDIM> momentumA, momentumB;
-
+    bool activate_extraction, track_punctures;
+    std::vector<std::array<double, CH_SPACEDIM>> initial_puncture_coords;
     // Collection of parameters necessary for initial conditions
     BoostedBH::params_t bh2_params;
     BoostedBH::params_t bh1_params;

--- a/Examples/BinaryBH/SimulationParameters.hpp
+++ b/Examples/BinaryBH/SimulationParameters.hpp
@@ -48,6 +48,7 @@ class SimulationParameters : public SimulationParametersBase
         // Do we want Weyl extraction and puncture tracking?
         pp.load("activate_extraction", activate_extraction, false);
         pp.load("track_punctures", track_punctures, false);
+        pp.load("puncture_tracking_level", puncture_tracking_level, max_level);
 
         // hard code num punctures to 2 for now
         int num_punctures = 2;
@@ -58,6 +59,7 @@ class SimulationParameters : public SimulationParametersBase
 
     // Initial data
     bool activate_extraction, track_punctures;
+    int puncture_tracking_level;
     std::vector<std::array<double, CH_SPACEDIM>> initial_puncture_coords;
     // Collection of parameters necessary for initial conditions
     BoostedBH::params_t bh2_params;

--- a/Examples/BinaryBH/params.txt
+++ b/Examples/BinaryBH/params.txt
@@ -1,0 +1,121 @@
+# See the wiki page for an explanation of the params!
+# https://github.com/GRChombo/GRChombo/wiki/Guide-to-parameters
+# and a guide to this specific example at
+# https://github.com/GRChombo/GRChombo/wiki/Running-the-BBH-example
+
+# location / naming of output files (must give full path)
+verbosity = 0
+chk_prefix = BinaryBHChk_
+plot_prefix = BinaryBHPlot_
+#restart_file = BinaryBHChk_000000.3d.hdf5
+
+# Set up coarsest level number of grid points in each dir
+# NB - the values need to be multiples of block_factor
+N1 = 64
+N2 = 64
+N3 = 64
+
+# Length of the longest N side
+# (This sets dx in all directions)
+L = 512
+
+# Defaults to center of grid L/2
+# uncomment to change
+#center = 256.0 256.0 256.0
+
+# BH params, use puncture tracking to
+# ensure horizons resolved
+track_punctures = 1
+massA = 0.48847892320123
+offsetA = 0.0 6.10679 0.0
+momentumA = -0.0841746 -0.000510846 0.0
+massB = 0.48847892320123
+offsetB = 0.0 -6.10679 0.0
+momentumB =  0.0841746  0.000510846 0.0
+
+# regridding control, specify frequency on each level
+# so need max_level + 1 entries for interval
+regrid_threshold = 0.05
+max_level = 9
+regrid_interval = 0 0 0 64 64 64 64 64 64 0
+
+# Max and min box sizes
+max_grid_size = 16
+block_factor = 16
+
+# Set up time steps
+# dt will be dx*dt_multiplier on each grid level
+# HDF5files are written every dt = L/N*dt_multiplier*checkpoint_interval
+checkpoint_interval = 50
+# set to zero to turn off plot files, comps defined in BinaryBHLevel.cpp
+plot_interval = 0
+dt_multiplier = 0.20
+stop_time = 2500.0
+
+# boundaries and periodicity of grid
+# Periodic directions - 0 = false, 1 = true
+isPeriodic = 0 0 0
+# if not periodic, then specify the boundary type
+# 0 = static, 1 = sommerfeld, 2 = reflective
+# (see BoundaryConditions.hpp for details)
+hi_boundary = 1 1 1
+lo_boundary = 1 1 1
+
+# if reflective boundaries selected, must set
+# parity of all vars (in order given by UserVariables.hpp)
+# 0 = even
+# 1,2,3 = odd x, y, z
+# 4,5,6 = odd xy, yz, xz
+vars_parity            = 0 0 4 6 0 5 0    #chi and hij
+                         0 0 4 6 0 5 0    #K and Aij
+                         0 1 2 3          #Theta and Gamma
+                         0 1 2 3 1 2 3    #lapse shift and B
+                         0 1 2 3          #Ham and Mom
+                         0 0              #Weyl
+
+# if sommerfeld boundaries selected, must select
+# asymptotic values (in order given by UserVariables.hpp)
+vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
+                         0.0 0.0 0.0 0.0 0.0 0.0 0.0 #K and Aij
+                         0.0 0.0 0.0 0.0             #Theta and Gamma
+                         1.0 0.0 0.0 0.0 0.0 0.0 0.0 #lapse shift and B
+                         0.0 0.0 0.0 0.0             #Ham and Mom
+                         0.0 0.0                     #Weyl
+
+# Lapse evolution
+lapse_advec_coeff = 1.0
+lapse_coeff = 2.0
+lapse_power = 1.0
+
+# Shift evolution
+shift_advec_coeff = 0.0
+shift_Gamma_coeff = 0.75
+eta = 1.0
+
+# CCZ4 parameters
+kappa1 = 0.1
+kappa2 = 0
+kappa3 = 1.0
+covariantZ4 = 1 # 0: default. 1: dampk1 -> dampk1/lapse
+
+# coefficient for KO numerical dissipation
+sigma = 1.0
+
+# extraction params
+# default of extraction_center is center, uncomment to change
+#extraction_center = 256 256 256
+activate_extraction = 1
+num_extraction_radii = 2
+extraction_radii = 50.0 100.0
+extraction_levels = 2 1
+num_points_phi = 24
+num_points_theta = 36
+num_modes = 8
+modes = 2 0 # l m for spherical harmonics
+        2 1
+        2 2
+        4 0
+        4 1
+        4 2
+        4 3
+        4 4

--- a/Examples/BinaryBH/params.txt
+++ b/Examples/BinaryBH/params.txt
@@ -46,11 +46,11 @@ block_factor = 16
 # Set up time steps
 # dt will be dx*dt_multiplier on each grid level
 # HDF5files are written every dt = L/N*dt_multiplier*checkpoint_interval
-checkpoint_interval = 50
+checkpoint_interval = 100
 # set to zero to turn off plot files, comps defined in BinaryBHLevel.cpp
-plot_interval = 0
-dt_multiplier = 0.20
-stop_time = 2500.0
+plot_interval = 10
+dt_multiplier = 0.25
+stop_time = 2200.0
 
 # boundaries and periodicity of grid
 # Periodic directions - 0 = false, 1 = true

--- a/Examples/BinaryBH/params.txt
+++ b/Examples/BinaryBH/params.txt
@@ -26,6 +26,7 @@ L = 512
 # BH params, use puncture tracking to
 # ensure horizons resolved
 track_punctures = 1
+puncture_tracking_level = 5
 massA = 0.48847892320123
 offsetA = 0.0 6.10679 0.0
 momentumA = -0.0841746 -0.000510846 0.0

--- a/Source/CCZ4/PunctureTracker.hpp
+++ b/Source/CCZ4/PunctureTracker.hpp
@@ -1,0 +1,71 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef PUNCTURETRACKER_HPP_
+#define PUNCTURETRACKER_HPP_
+
+#include "AMRInterpolator.hpp"
+#include "BHAMR.hpp"
+#include "InterpolationQuery.hpp"
+#include "Lagrange.hpp"
+#include "SimulationParametersBase.hpp"
+#include "SmallDataIO.hpp"   // for writing data
+#include "UserVariables.hpp" // Needs c_shift etc
+
+//!  The class tracks the puncture locations by integrating the shift at
+//!  The puncture position
+class PunctureTracker
+{
+  private:
+    //! Params for puncture tracking
+    const int m_num_punctures;
+    const double m_time;
+    const double m_restart_time;
+    const double m_dt;
+    const std::string m_punctures_filename;
+
+  public:
+    //! The constructor
+    PunctureTracker(const double a_time, const double a_restart_time,
+                    const double a_dt, const std::string a_checkpoint_prefix,
+                    const int a_num_punctures = 2)
+        : m_num_punctures(a_num_punctures), m_time(a_time),
+          m_punctures_filename(a_checkpoint_prefix + "Punctures"),
+          m_restart_time(a_restart_time), m_dt(a_dt)
+    {
+    }
+
+    //! set puncture locations on restart
+    void restart_punctures(BHAMR &a_gramr,
+                           std::vector<std::array<double, CH_SPACEDIM>>
+                               initial_puncture_coords) const;
+
+    //! set and write initial puncture locations
+    void set_initial_punctures(BHAMR &a_gramr,
+                               std::vector<std::array<double, CH_SPACEDIM>>
+                                   initial_puncture_coords) const;
+
+    //! Set punctures post restart if m_time > 0
+    void read_in_punctures(BHAMR &a_gramr) const;
+
+    //! Execute the tracking and write out
+    void execute_tracking(BHAMR &a_gramr,
+                          const bool write_punctures = true) const;
+
+    //! Use the interpolator to get the value of the shift at
+    //! given coords
+    void get_interp_shift(
+        std::vector<std::array<double, CH_SPACEDIM>> &interp_shift,
+        BHAMR &a_gramr,
+        std::vector<std::array<double, CH_SPACEDIM>> puncture_coords) const;
+
+    //! Get a vector of the puncture coords - used for write out
+    std::vector<double> get_puncture_vector(
+        std::vector<std::array<double, CH_SPACEDIM>> puncture_coords) const;
+};
+
+#include "PunctureTracker.impl.hpp"
+
+#endif /* PUNCTURETRACKER_HPP_ */

--- a/Source/CCZ4/PunctureTracker.hpp
+++ b/Source/CCZ4/PunctureTracker.hpp
@@ -38,27 +38,27 @@ class PunctureTracker
     }
 
     //! set puncture locations on restart
-    void restart_punctures(BHAMR &a_gramr,
+    void restart_punctures(BHAMR &a_bhamr,
                            std::vector<std::array<double, CH_SPACEDIM>>
                                initial_puncture_coords) const;
 
     //! set and write initial puncture locations
-    void set_initial_punctures(BHAMR &a_gramr,
+    void set_initial_punctures(BHAMR &a_bhamr,
                                std::vector<std::array<double, CH_SPACEDIM>>
                                    initial_puncture_coords) const;
 
     //! Set punctures post restart if m_time > 0
-    void read_in_punctures(BHAMR &a_gramr) const;
+    void read_in_punctures(BHAMR &a_bhamr) const;
 
     //! Execute the tracking and write out
-    void execute_tracking(BHAMR &a_gramr,
+    void execute_tracking(BHAMR &a_bhamr,
                           const bool write_punctures = true) const;
 
     //! Use the interpolator to get the value of the shift at
     //! given coords
     void get_interp_shift(
         std::vector<std::array<double, CH_SPACEDIM>> &interp_shift,
-        BHAMR &a_gramr,
+        BHAMR &a_bhamr,
         std::vector<std::array<double, CH_SPACEDIM>> puncture_coords) const;
 
     //! Get a vector of the puncture coords - used for write out

--- a/Source/CCZ4/PunctureTracker.impl.hpp
+++ b/Source/CCZ4/PunctureTracker.impl.hpp
@@ -1,0 +1,225 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#if !defined(PUNCTURETRACKER_HPP_)
+#error "This file should only be included through PunctureTracker.hpp"
+#endif
+
+#ifndef PUNCTURETRACKER_IMPL_HPP_
+#define PUNCTURETRACKER_IMPL_HPP_
+
+//! Set punctures post restart
+void PunctureTracker::restart_punctures(
+    BHAMR &a_gramr,
+    std::vector<std::array<double, CH_SPACEDIM>> initial_puncture_coords) const
+{
+    if (m_time == 0)
+    {
+        // if it is the first timestep, use the param values
+        // rather than look for the output file, e.g. for when
+        // restart from IC solver checkpoint
+        set_initial_punctures(a_gramr, initial_puncture_coords);
+    }
+    else
+    {
+        // look for the current puncture location in the
+        // puncture output file (it needs to exist!)
+        read_in_punctures(a_gramr);
+    }
+}
+
+//! set and write initial puncture locations
+void PunctureTracker::set_initial_punctures(
+    BHAMR &a_gramr,
+    std::vector<std::array<double, CH_SPACEDIM>> initial_puncture_coords) const
+{
+    // first set the puncture data, initial shift is always zero
+    std::vector<std::array<double, CH_SPACEDIM>> initial_shift;
+    initial_shift.resize(m_num_punctures);
+    for (int ipuncture = 0; ipuncture < m_num_punctures; ipuncture++)
+    {
+        FOR1(i) { initial_shift[ipuncture][i] = 0.0; }
+    }
+    a_gramr.set_puncture_data(initial_puncture_coords, initial_shift);
+
+    // now the write out to a new file
+    bool first_step = true;
+    SmallDataIO punctures_file(m_punctures_filename, m_dt, m_time,
+                               m_restart_time, SmallDataIO::APPEND, first_step);
+    std::vector<std::string> header1_strings(CH_SPACEDIM * m_num_punctures);
+    for (int ipuncture = 0; ipuncture < m_num_punctures; ipuncture++)
+    {
+        header1_strings[CH_SPACEDIM * ipuncture + 0] = "x";
+        header1_strings[CH_SPACEDIM * ipuncture + 1] = "y";
+        header1_strings[CH_SPACEDIM * ipuncture + 2] = "z";
+    }
+    punctures_file.write_header_line(header1_strings);
+
+    // use a vector for the write out
+    std::vector<double> puncture_vector =
+        get_puncture_vector(initial_puncture_coords);
+    punctures_file.write_time_data_line(puncture_vector);
+}
+
+//! Set punctures post restart
+void PunctureTracker::read_in_punctures(BHAMR &a_gramr) const
+{
+    std::vector<std::array<double, CH_SPACEDIM>> puncture_coords;
+    puncture_coords.resize(m_num_punctures);
+
+    // read them in from the Punctures file at current time m_time
+    // NB opening in APPEND mode allows reading where m_restart_time
+    // is greater than zero and m_time < m_restart_time + m_dt
+    bool first_step = false;
+    SmallDataIO punctures_file(m_punctures_filename, m_dt, m_time,
+                               m_restart_time, SmallDataIO::APPEND, first_step);
+    // NB need to give the get function an empty vector to fill
+    std::vector<double> puncture_vector;
+    punctures_file.get_specific_data_line(puncture_vector, m_time);
+    // check the data returned is the right size
+    CH_assert(puncture_vector.size() == m_num_punctures * CH_SPACEDIM);
+    // remove any duplicate data from the file
+    const bool keep_m_time_data = true;
+    punctures_file.remove_duplicate_time_data(keep_m_time_data);
+
+    // convert vector to list of coords
+    for (int ipuncture = 0; ipuncture < m_num_punctures; ipuncture++)
+    {
+        puncture_coords[ipuncture] = {
+            puncture_vector[ipuncture * CH_SPACEDIM + 0],
+            puncture_vector[ipuncture * CH_SPACEDIM + 1],
+            puncture_vector[ipuncture * CH_SPACEDIM + 2]};
+    }
+
+    // set the coordinates and get the current shift
+    std::vector<std::array<double, CH_SPACEDIM>> current_shift;
+    get_interp_shift(current_shift, a_gramr, puncture_coords);
+    a_gramr.set_puncture_data(puncture_coords, current_shift);
+
+    // print out values into pout files
+    for (int ipuncture = 0; ipuncture < m_num_punctures; ipuncture++)
+    {
+        pout() << "Puncture " << ipuncture
+               << " restarted at : " << puncture_coords[ipuncture][0] << " "
+               << puncture_coords[ipuncture][1] << " "
+               << puncture_coords[ipuncture][2] << endl;
+        pout() << " with shift vector : " << current_shift[ipuncture][0] << " "
+               << current_shift[ipuncture][1] << " "
+               << current_shift[ipuncture][2] << endl;
+        pout() << "at time = " << m_time << endl;
+    }
+}
+
+//! Execute the tracking and write out
+void PunctureTracker::execute_tracking(BHAMR &a_gramr,
+                                       const bool write_punctures) const
+{
+    CH_TIME("PunctureTracker::execute_tracking");
+    // get puncture coordinates and old shift value
+    std::vector<std::array<double, CH_SPACEDIM>> puncture_coords =
+        a_gramr.get_puncture_coords();
+    std::vector<std::array<double, CH_SPACEDIM>> old_shift =
+        a_gramr.get_puncture_shift();
+    CH_assert(puncture_coords.size() == m_num_punctures); // sanity check
+
+    // new shift value
+    std::vector<std::array<double, CH_SPACEDIM>> new_shift;
+    get_interp_shift(new_shift, a_gramr, puncture_coords);
+
+    // update puncture locations using second order update
+    for (int ipuncture = 0; ipuncture < m_num_punctures; ipuncture++)
+    {
+        FOR1(i)
+        {
+            puncture_coords[ipuncture][i] +=
+                -0.5 * m_dt *
+                (new_shift[ipuncture][i] + old_shift[ipuncture][i]);
+        }
+    }
+    a_gramr.set_puncture_data(puncture_coords, new_shift);
+
+    // print them out
+    if (write_punctures)
+    {
+        bool first_step = false;
+        SmallDataIO punctures_file(m_punctures_filename, m_dt, m_time,
+                                   m_restart_time, SmallDataIO::APPEND,
+                                   first_step);
+
+        // use a vector for the write out
+        std::vector<double> puncture_vector =
+            get_puncture_vector(puncture_coords);
+        punctures_file.write_time_data_line(puncture_vector);
+    }
+}
+
+//! Use the interpolator to get the value of the shift at
+//! given coords
+void PunctureTracker::get_interp_shift(
+    std::vector<std::array<double, CH_SPACEDIM>> &interp_shift, BHAMR &a_gramr,
+    std::vector<std::array<double, CH_SPACEDIM>> puncture_coords) const
+{
+    CH_TIME("PunctureTracker::get_interp_shift");
+    // resize the vector to the number of punctures
+    interp_shift.resize(m_num_punctures);
+
+    // refresh interpolator
+    a_gramr.m_interpolator->refresh();
+
+    // set up shift and coordinate holders
+    std::vector<double> interp_shift1(m_num_punctures);
+    std::vector<double> interp_shift2(m_num_punctures);
+    std::vector<double> interp_shift3(m_num_punctures);
+    std::vector<double> interp_x(m_num_punctures);
+    std::vector<double> interp_y(m_num_punctures);
+    std::vector<double> interp_z(m_num_punctures);
+
+    for (int ipuncture = 0; ipuncture < m_num_punctures; ipuncture++)
+    {
+        interp_x[ipuncture] = puncture_coords[ipuncture][0];
+        interp_y[ipuncture] = puncture_coords[ipuncture][1];
+        interp_z[ipuncture] = puncture_coords[ipuncture][2];
+    }
+
+    // setup query
+    InterpolationQuery query(m_num_punctures);
+    query.setCoords(0, interp_x.data())
+        .setCoords(1, interp_y.data())
+        .setCoords(2, interp_z.data())
+        .addComp(c_shift1, interp_shift1.data())
+        .addComp(c_shift2, interp_shift2.data())
+        .addComp(c_shift3, interp_shift3.data());
+
+    // engage!
+    a_gramr.m_interpolator->interp(query);
+
+    // put the shift values into the output array
+    for (int ipuncture = 0; ipuncture < m_num_punctures; ipuncture++)
+    {
+        interp_shift[ipuncture] = {interp_shift1[ipuncture],
+                                   interp_shift2[ipuncture],
+                                   interp_shift3[ipuncture]};
+    }
+}
+
+//! get a vector of the puncture coords - used for write out
+std::vector<double> PunctureTracker::get_puncture_vector(
+    std::vector<std::array<double, CH_SPACEDIM>> puncture_coords) const
+{
+    std::vector<double> puncture_vector;
+    puncture_vector.resize(m_num_punctures * CH_SPACEDIM);
+    for (int ipuncture = 0; ipuncture < m_num_punctures; ipuncture++)
+    {
+        puncture_vector[ipuncture * CH_SPACEDIM + 0] =
+            puncture_coords[ipuncture][0];
+        puncture_vector[ipuncture * CH_SPACEDIM + 1] =
+            puncture_coords[ipuncture][1];
+        puncture_vector[ipuncture * CH_SPACEDIM + 2] =
+            puncture_coords[ipuncture][2];
+    }
+    return puncture_vector;
+}
+
+#endif /* PUNCTURETRACKER_IMPL_HPP_ */

--- a/Source/CCZ4/PunctureTracker.impl.hpp
+++ b/Source/CCZ4/PunctureTracker.impl.hpp
@@ -12,7 +12,7 @@
 
 //! Set punctures post restart
 void PunctureTracker::restart_punctures(
-    BHAMR &a_gramr,
+    BHAMR &a_bhamr,
     std::vector<std::array<double, CH_SPACEDIM>> initial_puncture_coords) const
 {
     if (m_time == 0)
@@ -20,19 +20,19 @@ void PunctureTracker::restart_punctures(
         // if it is the first timestep, use the param values
         // rather than look for the output file, e.g. for when
         // restart from IC solver checkpoint
-        set_initial_punctures(a_gramr, initial_puncture_coords);
+        set_initial_punctures(a_bhamr, initial_puncture_coords);
     }
     else
     {
         // look for the current puncture location in the
         // puncture output file (it needs to exist!)
-        read_in_punctures(a_gramr);
+        read_in_punctures(a_bhamr);
     }
 }
 
 //! set and write initial puncture locations
 void PunctureTracker::set_initial_punctures(
-    BHAMR &a_gramr,
+    BHAMR &a_bhamr,
     std::vector<std::array<double, CH_SPACEDIM>> initial_puncture_coords) const
 {
     // first set the puncture data, initial shift is always zero
@@ -42,7 +42,7 @@ void PunctureTracker::set_initial_punctures(
     {
         FOR1(i) { initial_shift[ipuncture][i] = 0.0; }
     }
-    a_gramr.set_puncture_data(initial_puncture_coords, initial_shift);
+    a_bhamr.set_puncture_data(initial_puncture_coords, initial_shift);
 
     // now the write out to a new file
     bool first_step = true;
@@ -64,7 +64,7 @@ void PunctureTracker::set_initial_punctures(
 }
 
 //! Set punctures post restart
-void PunctureTracker::read_in_punctures(BHAMR &a_gramr) const
+void PunctureTracker::read_in_punctures(BHAMR &a_bhamr) const
 {
     std::vector<std::array<double, CH_SPACEDIM>> puncture_coords;
     puncture_coords.resize(m_num_punctures);
@@ -95,8 +95,8 @@ void PunctureTracker::read_in_punctures(BHAMR &a_gramr) const
 
     // set the coordinates and get the current shift
     std::vector<std::array<double, CH_SPACEDIM>> current_shift;
-    get_interp_shift(current_shift, a_gramr, puncture_coords);
-    a_gramr.set_puncture_data(puncture_coords, current_shift);
+    get_interp_shift(current_shift, a_bhamr, puncture_coords);
+    a_bhamr.set_puncture_data(puncture_coords, current_shift);
 
     // print out values into pout files
     for (int ipuncture = 0; ipuncture < m_num_punctures; ipuncture++)
@@ -113,20 +113,20 @@ void PunctureTracker::read_in_punctures(BHAMR &a_gramr) const
 }
 
 //! Execute the tracking and write out
-void PunctureTracker::execute_tracking(BHAMR &a_gramr,
+void PunctureTracker::execute_tracking(BHAMR &a_bhamr,
                                        const bool write_punctures) const
 {
     CH_TIME("PunctureTracker::execute_tracking");
     // get puncture coordinates and old shift value
     std::vector<std::array<double, CH_SPACEDIM>> puncture_coords =
-        a_gramr.get_puncture_coords();
+        a_bhamr.get_puncture_coords();
     std::vector<std::array<double, CH_SPACEDIM>> old_shift =
-        a_gramr.get_puncture_shift();
+        a_bhamr.get_puncture_shift();
     CH_assert(puncture_coords.size() == m_num_punctures); // sanity check
 
     // new shift value
     std::vector<std::array<double, CH_SPACEDIM>> new_shift;
-    get_interp_shift(new_shift, a_gramr, puncture_coords);
+    get_interp_shift(new_shift, a_bhamr, puncture_coords);
 
     // update puncture locations using second order update
     for (int ipuncture = 0; ipuncture < m_num_punctures; ipuncture++)
@@ -138,7 +138,7 @@ void PunctureTracker::execute_tracking(BHAMR &a_gramr,
                 (new_shift[ipuncture][i] + old_shift[ipuncture][i]);
         }
     }
-    a_gramr.set_puncture_data(puncture_coords, new_shift);
+    a_bhamr.set_puncture_data(puncture_coords, new_shift);
 
     // print them out
     if (write_punctures)
@@ -158,7 +158,7 @@ void PunctureTracker::execute_tracking(BHAMR &a_gramr,
 //! Use the interpolator to get the value of the shift at
 //! given coords
 void PunctureTracker::get_interp_shift(
-    std::vector<std::array<double, CH_SPACEDIM>> &interp_shift, BHAMR &a_gramr,
+    std::vector<std::array<double, CH_SPACEDIM>> &interp_shift, BHAMR &a_bhamr,
     std::vector<std::array<double, CH_SPACEDIM>> puncture_coords) const
 {
     CH_TIME("PunctureTracker::get_interp_shift");
@@ -166,7 +166,7 @@ void PunctureTracker::get_interp_shift(
     interp_shift.resize(m_num_punctures);
 
     // refresh interpolator
-    a_gramr.m_interpolator->refresh();
+    a_bhamr.m_interpolator->refresh();
 
     // set up shift and coordinate holders
     std::vector<double> interp_shift1(m_num_punctures);
@@ -193,7 +193,7 @@ void PunctureTracker::get_interp_shift(
         .addComp(c_shift3, interp_shift3.data());
 
     // engage!
-    a_gramr.m_interpolator->interp(query);
+    a_bhamr.m_interpolator->interp(query);
 
     // put the shift values into the output array
     for (int ipuncture = 0; ipuncture < m_num_punctures; ipuncture++)

--- a/Source/GRChomboCore/BHAMR.hpp
+++ b/Source/GRChomboCore/BHAMR.hpp
@@ -1,0 +1,60 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef BHAMR_HPP_
+#define BHAMR_HPP_
+
+#include "AMRInterpolator.hpp"
+#include "GRAMR.hpp"
+#include "Lagrange.hpp"
+#include <chrono>
+#include <ratio>
+
+/// A child of Chombo's AMR class to interface with tools which require
+/// access to the whole AMR hierarchy, and those of GRAMR
+/**
+ * This object inherits from GRAMR and adds tools required for BH spacetimes
+ */
+class BHAMR : public GRAMR
+{
+  private:
+    // the info for the puncture tracks
+    int m_num_punctures;
+    std::vector<std::array<double, CH_SPACEDIM>> m_puncture_coords;
+    std::vector<std::array<double, CH_SPACEDIM>> m_puncture_shift;
+
+  public:
+    BHAMR()
+    {
+        m_num_punctures = 2; // default to 2 for now
+        m_puncture_coords.resize(m_num_punctures);
+        m_puncture_shift.resize(m_num_punctures);
+    }
+
+    // function to set punctures
+    void set_puncture_data(
+        std::vector<std::array<double, CH_SPACEDIM>> &a_puncture_coords,
+        std::vector<std::array<double, CH_SPACEDIM>> &a_puncture_shift)
+    {
+        m_puncture_coords = a_puncture_coords;
+        m_puncture_shift = a_puncture_shift;
+    }
+
+    // function to get punctures
+    const std::vector<std::array<double, CH_SPACEDIM>>
+    get_puncture_coords() const
+    {
+        return m_puncture_coords;
+    }
+
+    // function to get shift at puncture on previous timestep
+    const std::vector<std::array<double, CH_SPACEDIM>>
+    get_puncture_shift() const
+    {
+        return m_puncture_shift;
+    }
+};
+
+#endif /* BHAMR_HPP_ */

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -93,12 +93,14 @@ class ChomboParameters
         coarsest_dx = L / max_N;
 
         pp.load("max_level", max_level, 0);
-        // the reference ratio is hard coded to 2
+        // the reference ratio is hard coded to 2 on all levels
         // in principle it can be set to other values, but this is
         // not recommended since we do not test GRChombo with other
         // refinement ratios - use other values at your own risk
         ref_ratios.resize(max_level + 1);
         ref_ratios.assign(2);
+        // read in frequency of regrid on each levels, needs
+        // max_level + 1 entries (although never regrids on max_level+1)
         pp.getarr("regrid_interval", regrid_interval, 0, max_level + 1);
 
         // time stepping outputs and regrid data

--- a/Source/GRChomboCore/GRAMR.hpp
+++ b/Source/GRChomboCore/GRAMR.hpp
@@ -28,7 +28,7 @@ class GRAMR : public AMR
   public:
     AMRInterpolator<Lagrange<4>> *m_interpolator; //!< The interpolator pointer
 
-    GRAMR() { m_interpolator = nullptr; } // constructor
+    GRAMR() { m_interpolator = nullptr; }
 
     auto get_walltime()
     {

--- a/Source/GRChomboCore/SimulationParametersBase.hpp
+++ b/Source/GRChomboCore/SimulationParametersBase.hpp
@@ -93,7 +93,7 @@ class SimulationParametersBase : public ChomboParameters
         pp.load("num_points_phi", extraction_params.num_points_phi, 2);
         pp.load("num_points_theta", extraction_params.num_points_theta, 4);
         pp.load("extraction_center", extraction_params.extraction_center,
-                {0.5 * L, 0.5 * L, 0.5 * L});
+                center); // default to center of the grid
         if (pp.contains("modes"))
         {
             pp.load("num_modes", extraction_params.num_modes);

--- a/Source/TaggingCriteria/ChiExtractionTaggingCriterion.hpp
+++ b/Source/TaggingCriteria/ChiExtractionTaggingCriterion.hpp
@@ -13,14 +13,19 @@
 #include "SimulationParametersBase.hpp"
 #include "Tensor.hpp"
 
+//! This class tags cells based on two criteria - the
+//! value of the second derivs and the extraction regions
 class ChiExtractionTaggingCriterion
 {
   protected:
     const double m_dx;
-    const FourthOrderDerivatives m_deriv;
-    const extraction_params_t m_params;
     const int m_level;
+    const int m_max_level;
+    const bool m_activate_extraction;
+    const extraction_params_t m_params;
+    const FourthOrderDerivatives m_deriv;
 
+  public:
     template <class data_t> struct Vars
     {
         data_t chi; //!< Conformal factor
@@ -34,39 +39,49 @@ class ChiExtractionTaggingCriterion
         }
     };
 
-  public:
+    // The constructor
     ChiExtractionTaggingCriterion(const double dx, const int a_level,
-                                  const extraction_params_t a_params)
-        : m_dx(dx), m_deriv(dx), m_params(a_params), m_level(a_level){};
+                                  const int a_max_level,
+                                  const extraction_params_t a_params,
+                                  const bool activate_extraction = false)
+        : m_dx(dx), m_deriv(dx), m_params(a_params), m_level(a_level),
+          m_max_level(a_max_level),
+          m_activate_extraction(activate_extraction){};
 
     template <class data_t> void compute(Cell<data_t> current_cell) const
     {
+        // first test the gradients for regions of high curvature
         const auto d2 = m_deriv.template diff2<Vars>(current_cell);
-
         data_t mod_d2_chi = 0;
         FOR2(idir, jdir)
         {
             mod_d2_chi += d2.chi[idir][jdir] * d2.chi[idir][jdir];
         }
-
         data_t criterion = m_dx * sqrt(mod_d2_chi);
 
-        for (int iradius = 0; iradius < m_params.num_extraction_radii;
-             ++iradius)
+        // if extracting weyl data at a given radius, enforce a given resolution
+        // there
+        if (m_activate_extraction)
         {
-            // regrid if within extraction level and not at required refinement
-            if (m_level < m_params.extraction_levels[iradius])
+            for (int iradius = 0; iradius < m_params.num_extraction_radii;
+                 ++iradius)
             {
-                const Coordinates<data_t> coords(current_cell, m_dx,
-                                                 m_params.extraction_center);
-                const data_t r = coords.get_radius();
-                // add a 20% buffer to extraction zone so not too near to
-                // boundary
-                auto regrid = simd_compare_lt(
-                    r, 1.2 * m_params.extraction_radii[iradius]);
-                criterion = simd_conditional(regrid, 100.0, criterion);
+                // regrid if within extraction level and not at required
+                // refinement
+                if (m_level < m_params.extraction_levels[iradius])
+                {
+                    const Coordinates<data_t> coords(
+                        current_cell, m_dx, m_params.extraction_center);
+                    const data_t r = coords.get_radius();
+                    // add a 20% buffer to extraction zone so not too near to
+                    // boundary
+                    auto regrid = simd_compare_lt(
+                        r, 1.2 * m_params.extraction_radii[iradius]);
+                    criterion = simd_conditional(regrid, 100.0, criterion);
+                }
             }
         }
+
         // Write back into the flattened Chombo box
         current_cell.store_vars(criterion, 0);
     }

--- a/Source/TaggingCriteria/ChiPunctureExtractionTaggingCriterion.hpp
+++ b/Source/TaggingCriteria/ChiPunctureExtractionTaggingCriterion.hpp
@@ -1,0 +1,130 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef CHIPUNCTUREEXTRACTIONTAGGINGCRITERION_HPP_
+#define CHIPUNCTUREEXTRACTIONTAGGINGCRITERION_HPP_
+
+#include "Cell.hpp"
+#include "Coordinates.hpp"
+#include "DimensionDefinitions.hpp"
+#include "FourthOrderDerivatives.hpp"
+#include "SimulationParametersBase.hpp"
+#include "Tensor.hpp"
+
+//! This class tags cells based on three criteria - the
+//! value of the second derivs, the extraction regions
+//! and the puncture horizons (which must be covered to
+//! a given level
+class ChiPunctureExtractionTaggingCriterion
+{
+  protected:
+    const double m_dx;
+    const int m_level;
+    const int m_max_level;
+    const bool m_activate_extraction;
+    const bool m_track_punctures;
+    const std::vector<double> m_puncture_masses;
+    const extraction_params_t m_params;
+    const FourthOrderDerivatives m_deriv;
+    const std::vector<std::array<double, CH_SPACEDIM>> m_puncture_coords;
+
+  public:
+    template <class data_t> struct Vars
+    {
+        data_t chi; //!< Conformal factor
+
+        template <typename mapping_function_t>
+        void enum_mapping(mapping_function_t mapping_function)
+        {
+            using namespace VarsTools; // define_enum_mapping is part of
+                                       // VarsTools
+            define_enum_mapping(mapping_function, c_chi, chi);
+        }
+    };
+
+    // The constructor
+    ChiPunctureExtractionTaggingCriterion(
+        const double dx, const int a_level, const int a_max_level,
+        const extraction_params_t a_params,
+        const std::vector<std::array<double, CH_SPACEDIM>> a_puncture_coords,
+        const bool activate_extraction = false,
+        const bool track_punctures = false,
+        const std::vector<double> a_puncture_masses = {1.0, 1.0})
+        : m_dx(dx), m_deriv(dx), m_params(a_params), m_level(a_level),
+          m_max_level(a_max_level), m_track_punctures(track_punctures),
+          m_activate_extraction(activate_extraction),
+          m_puncture_masses(a_puncture_masses),
+          m_puncture_coords(a_puncture_coords)
+    {
+        // check that the number of punctures is consistent
+        CH_assert(m_puncture_masses.size() == m_puncture_coords.size());
+    };
+
+    template <class data_t> void compute(Cell<data_t> current_cell) const
+    {
+        // first test the gradients for regions of high curvature
+        const auto d2 = m_deriv.template diff2<Vars>(current_cell);
+        data_t mod_d2_chi = 0;
+        FOR2(idir, jdir)
+        {
+            mod_d2_chi += d2.chi[idir][jdir] * d2.chi[idir][jdir];
+        }
+        data_t criterion = m_dx * sqrt(mod_d2_chi);
+
+        // if extracting weyl data at a given radius, enforce a given resolution
+        // there
+        if (m_activate_extraction)
+        {
+            for (int iradius = 0; iradius < m_params.num_extraction_radii;
+                 ++iradius)
+            {
+                // regrid if within extraction level and not at required
+                // refinement
+                if (m_level < m_params.extraction_levels[iradius])
+                {
+                    const Coordinates<data_t> coords(
+                        current_cell, m_dx, m_params.extraction_center);
+                    const data_t r = coords.get_radius();
+                    // add a 20% buffer to extraction zone so not too near to
+                    // boundary
+                    auto regrid = simd_compare_lt(
+                        r, 1.2 * m_params.extraction_radii[iradius]);
+                    criterion = simd_conditional(regrid, 100.0, criterion);
+                }
+            }
+        }
+
+        // ensure that the horizons of the punctures are covered
+        // by the max level - for this we need
+        // only check the puncture locations on the top 2 levels
+        // which regrid (ie, max_level - 1 to max_level - 2)
+        // (just the top level would be ok, but doing two ensures
+        // the top levels are well spaced)
+        if ((m_level > (m_max_level - 3)) && (m_track_punctures == 1))
+        {
+            // we want each level to be double the innermost one in size
+            const double factor = pow(2.0, m_max_level - m_level - 1);
+            // loop over puncture masses
+            for (int ipuncture = 0; ipuncture < m_puncture_masses.size();
+                 ++ipuncture)
+            {
+                // where am i?
+                const Coordinates<data_t> coords(current_cell, m_dx,
+                                                 m_puncture_coords[ipuncture]);
+                const data_t r = coords.get_radius();
+                // decide whether to tag based on distance to horizon
+                // plus a fudge factor of 1.5
+                auto regrid = simd_compare_lt(
+                    r, 1.5 * factor * m_puncture_masses[ipuncture]);
+                criterion = simd_conditional(regrid, 100.0, criterion);
+            }
+        }
+
+        // Write back into the flattened Chombo box
+        current_cell.store_vars(criterion, 0);
+    }
+};
+
+#endif /* CHIPUNCTUREEXTRACTIONTAGGINGCRITERION_HPP_ */

--- a/Source/utils/SmallDataIO.cpp
+++ b/Source/utils/SmallDataIO.cpp
@@ -5,6 +5,8 @@
 
 #include "SmallDataIO.hpp"
 
+// ------------ Writing Functions ------------
+
 void SmallDataIO::write_header_line(
     const std::vector<std::string> &a_header_strings,
     const std::string &a_pre_header_string)
@@ -86,16 +88,22 @@ void SmallDataIO::line_break()
     }
 }
 
-void SmallDataIO::remove_duplicate_time_data()
+void SmallDataIO::remove_duplicate_time_data(const bool keep_m_time_data)
 {
     constexpr double epsilon = 1.0e-8;
     if (m_rank == 0 && m_restart_time > 0. && m_mode == APPEND &&
         m_time < m_restart_time + m_dt + epsilon)
     {
         // copy lines with time < m_time into a temporary file
+        m_file.seekg(0);
         std::string line;
         std::string temp_filename = m_filename + ".temp";
         std::ofstream temp_file(temp_filename);
+        int sign = -1;
+        if (keep_m_time_data)
+        {
+            sign = 1;
+        }
         while (std::getline(m_file, line))
         {
             if (!(line.find("#") == std::string::npos))
@@ -103,7 +111,7 @@ void SmallDataIO::remove_duplicate_time_data()
                 temp_file << line << "\n";
             }
             else if (std::stod(line.substr(0, m_coords_width)) <
-                     m_time - epsilon)
+                     m_time + sign * epsilon)
             {
                 temp_file << line << "\n";
             }
@@ -119,4 +127,64 @@ void SmallDataIO::remove_duplicate_time_data()
         // reopen the file in append mode
         m_file.open(m_filename, std::ios::app);
     }
+}
+
+// ------------ Reading Functions ------------
+
+void SmallDataIO::get_specific_data_line(std::vector<double> &a_out_data,
+                                         const std::vector<double> a_coords)
+{
+    if (m_rank == 0)
+    {
+        bool line_found = false;
+        // first set the current position to the beginning of the file
+        m_file.seekg(0);
+
+        // get a string of the coords as they are in the file
+        std::stringstream coords_ss;
+        coords_ss << std::fixed << std::setprecision(m_coords_precision);
+        for (double coord : a_coords)
+        {
+            coords_ss << std::setw(m_coords_width) << coord;
+        }
+        std::string coords_string = coords_ss.str();
+
+        // now search for lines that start with coords_string and put the data
+        // in a_out_data
+        std::string line;
+        while (std::getline(m_file, line))
+        {
+            if (!(line.find(coords_string) == std::string::npos))
+            {
+                for (int ichar = a_coords.size() * m_coords_width;
+                     ichar < line.size(); ichar += m_data_width)
+                {
+                    double data_value =
+                        std::stod(line.substr(ichar, m_data_width));
+                    a_out_data.push_back(data_value);
+                }
+                line_found = true;
+                // only want the first occurrence so break the while loop
+                break;
+            }
+        }
+        if (!line_found)
+        {
+            MayDay::Error(
+                "SmallDataIO : Data to be read in at coord not found in file");
+        }
+    }
+    // now broadcast the vector to all ranks using Chombo broadcast function
+    // need to convert std::vector to Vector first
+    Vector<double> data_Vect(a_out_data);
+    int broadcast_rank = 0;
+    broadcast(data_Vect, broadcast_rank);
+    a_out_data = data_Vect.stdVector();
+}
+
+void SmallDataIO::get_specific_data_line(std::vector<double> &a_out_data,
+                                         const double a_coord)
+{
+    std::vector<double> coords(1, a_coord);
+    get_specific_data_line(a_out_data, coords);
 }

--- a/Source/utils/WeylExtraction.impl.hpp
+++ b/Source/utils/WeylExtraction.impl.hpp
@@ -138,6 +138,7 @@ WeylExtraction::integrate_surface(int es, int el, int em,
                         a_re_part[idx] * Y_lm.Real + a_im_part[idx] * Y_lm.Im;
                     double integrand_im =
                         a_im_part[idx] * Y_lm.Real - a_re_part[idx] * Y_lm.Im;
+
                     // note the multiplication by radius here
                     double f_theta_phi_re = m_params.extraction_radii[iradius] *
                                             integrand_re * sin(theta);


### PR DESCRIPTION
This update aims to make the BBH example a better example of a full inspiral and merger. The key changes are:
- Using momentum and position data which gives initially circular orbits (thanks Dr Khan @Cyberface).
- Adding puncture tracking which drives regridding around the horizon (important for stability)
- The introduction of a BHAMR class which inherits from GRAMR but adds BH specific members which need to be defined above the level structure (e.g. for the puncture tracking)
- General tweaks to params and additional comments

A wiki page has been also been created here:
https://github.com/GRChombo/GRChombo/wiki/Running-the-BinaryBH-example
Which shows the outputs and provides details of typical set up and run speeds.