### PR TITLE
Add test-clang-format github action

### DIFF
--- a/.github/workflows/test-clang-format.yml
+++ b/.github/workflows/test-clang-format.yml
@@ -1,0 +1,15 @@
+name: test-clang-format
+
+on: [pull_request]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: DoozyX/clang-format-lint-action@v0.5
+      with:
+        source: '.'
+        extensions: 'hpp,cpp'
+        clangFormatVersion: 6


### PR DESCRIPTION
This currently uses the clang-format lint action from [DoozyX/clang-format-lint-action](https://github.com/DoozyX/clang-format-lint-action) with clang-format version 6 as this was the version I was using on my laptop and version 9 formatted a few things differently. I've currently set it to only run on pull requests.