### PR TITLE
Remove unused precision datatype from SimdFunctionsUnitTest

### DIFF
--- a/Tests/SimdFunctionsUnitTests/SimdFunctionsUnitTest.cpp
+++ b/Tests/SimdFunctionsUnitTests/SimdFunctionsUnitTest.cpp
@@ -3,6 +3,7 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
+#include "REAL.H"
 #include "simd.hpp"
 #include <cmath>
 #include <iomanip>
@@ -114,15 +115,11 @@ bool rv_test(const char *name, op_t op, rev_op_t rev_op)
         }                                                                      \
     } while (0);
 
-#define SV_TEST(op)                                                            \
-    SV_TEST_T(double, op);                                                     \
-    SV_TEST_T(float, op);
+#define SV_TEST(op) SV_TEST_T(Real, op);
 
 #define RV_TEST(op, rev_op)                                                    \
-    RV_TEST_T(double, op, rev_op);                                             \
-    RV_TEST_T(float, op, rev_op);                                              \
-    RV_TEST_T(double, rev_op, op);                                             \
-    RV_TEST_T(float, rev_op, op);
+    RV_TEST_T(Real, op, rev_op);                                               \
+    RV_TEST_T(Real, rev_op, op);
 
 int main()
 {
@@ -142,10 +139,8 @@ int main()
     SV_TEST(cosh(x));
     SV_TEST(tanh(x));
 
-    SV_TEST_T(double, simd_min(x, 0.5));
-    SV_TEST_T(float, simd_min(x, 0.5f));
-    SV_TEST_T(double, simd_max(x, 0.5));
-    SV_TEST_T(float, simd_max(x, 0.5f));
+    SV_TEST_T(Real, simd_min(x, (Real)0.5));
+    SV_TEST_T(Real, simd_max(x, (Real)0.5));
 
     RV_TEST(exp(x), log(x));
     // RV_TEST(pow(x,(decltype(x))2),sqrt(x));


### PR DESCRIPTION
Now Chombo's `Real` type is used which is `double` or `float` depending on what the Makefile variable `PRECISION` is set to. As far as I'm aware, we all use double precision so this is effectively removing the checking of the float simd intrinsics.