### PR TITLE
Add Github action to run tests

### DIFF
--- a/.github/workflows/run-grchombo-tests.yml
+++ b/.github/workflows/run-grchombo-tests.yml
@@ -1,0 +1,47 @@
+name: Run GRChombo Tests
+
+on: [pull_request]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    env:
+      CHOMBO_HOME: ${{ github.workspace }}/Chombo/lib
+      OMP_NUM_THREADS: 1
+
+    steps:
+    - name: Checkout Chombo
+      uses: actions/checkout@v2
+      with:
+        repository: GRChombo/Chombo
+        path: Chombo
+
+    - name: Checkout GRChombo
+      uses: actions/checkout@v2
+      with:
+        path: GRChombo
+
+    - name: Install Chombo dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get -y --no-install-recommends install csh make gfortran-8 g++-8 cpp-8 libhdf5-dev libhdf5-openmpi-dev openmpi-bin libblas-dev liblapack-dev libgetopt-complete-perl ssh
+
+    - name: Set Compilers
+      run: |
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 80
+        sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-8 80
+        sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-8 80
+
+    - name: Build Chombo
+      run: |
+        cp $GITHUB_WORKSPACE/GRChombo/InstallNotes/MakeDefsLocalExamples/ubuntu-18.04.Make.defs.local $CHOMBO_HOME/mk/Make.defs.local
+        make -j 4 AMRTimeDependent AMRTools BaseTools BoxTools
+      working-directory: ${{ env.CHOMBO_HOME }}
+
+    - name: Build GRChombo Tests
+      run: make test -j 4
+      working-directory: ${{ github.workspace }}/GRChombo
+
+    - name: Run GRChombo Tests
+      run: make run -j 2
+      working-directory: ${{ github.workspace }}/GRChombo

--- a/.github/workflows/test-clang-format.yml
+++ b/.github/workflows/test-clang-format.yml
@@ -1,4 +1,4 @@
-name: test-clang-format
+name: Check Clang Format
 
 on: [pull_request]
 
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - uses: DoozyX/clang-format-lint-action@v0.5
       with:
         source: '.'

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ jobscript*
 pout.*
 .bashrc
 *.pbs
-*.sh
 *.s
 d
 o

--- a/InstallNotes/MakeDefsLocalExamples/ubuntu-18.04.Make.defs.local
+++ b/InstallNotes/MakeDefsLocalExamples/ubuntu-18.04.Make.defs.local
@@ -1,0 +1,29 @@
+#begin  -- dont change this line
+# This is used for the github action that runs the tests
+# Dependencies can be installed with the command:
+# sudo apt-get install csh make gfortran-8 g++-8 cpp-8 libhdf5-dev \
+# libhdf5-openmpi-dev openmpi-bin libblas-dev liblapack-dev \
+# libgetopt-complete-perl ssh
+
+DIM            = 3
+DEBUG          = TRUE
+PRECISION      = DOUBLE
+OPT            = TRUE
+PROFILE        = FALSE
+CXX            = g++
+FC             = gfortran
+MPI            = TRUE
+OPENMPCC       = TRUE
+MPICXX         = mpicxx
+USE_64         = TRUE
+USE_HDF        = TRUE
+HDFINCFLAGS    = -I/usr/lib/x86_64-linux-gnu/hdf5/serial/include
+HDFLIBFLAGS    = -L/usr/lib/x86_64-linux-gnu/hdf5/serial/lib -lhdf5 -lz
+HDFMPIINCFLAGS = -I/usr/lib/x86_64-linux-gnu/hdf5/openmpi/include
+HDFMPILIBFLAGS = -L/usr/lib/x86_64-linux-gnu/hdf5/openmpi/lib -lhdf5 -lz
+USE_MT         = FALSE
+cxxoptflags    = -march=native -O3
+foptflags      = -march=native -O3
+syslibflags    = -lblas -llapack
+
+#end  -- dont change this line


### PR DESCRIPTION
This PR adds a Github action workflow which builds Chombo and the GRChombo tests and then runs these tests when pull requests are made and when new commits are pushed to pull request branches. Sorry for the excessive number of commits; unfortunately I couldn't figure out of way of testing this without pushing to Github. This should therefore probably be rebased into 1 commit before merging.
Some things to note:
- I've also added a `Make.defs.local` for a basic Ubuntu 18.04 machine including a list of package dependencies. This is used by the Github runners (which currently run on Ubuntu 18.04) to build Chombo.
- Note that this only uses GCC to build and test and we have had issues that have only appeared with the Intel compilers so please be aware of that.
- For some reason I couldn't get GCC v9 to work as `gfortran` kept getting killed by the OS (see [this failed action from a previous commit](https://github.com/GRChombo/GRChombo/actions/runs/56841610)) so I have stuck with GCC v8.
- I believe we have 10,000 Github action minutes per month (see [here](https://help.github.com/en/github/setting-up-and-managing-billing-and-payments-on-github/about-billing-for-github-actions)) as the GRChombo organisation is a Github "Team". Given that this whole action seems to take a bit less than 10 minutes, and we definitely push fewer than 1000 commits on pull request branches, this should be more than enough.