### PR TITLE
Add User Restart feature

### DIFF
--- a/Examples/BinaryBH/Main_BinaryBH.cpp
+++ b/Examples/BinaryBH/Main_BinaryBH.cpp
@@ -31,29 +31,29 @@ int runGRChombo(int argc, char *argv[])
         // The line below selects the problem that is simulated
         // (To simulate a different problem, define a new child of AMRLevel
         // and an associated LevelFactory)
-        BHAMR gr_amr;
-        DefaultLevelFactory<BinaryBHLevel> binary_bh_level_fact(gr_amr,
+        BHAMR bh_amr;
+        DefaultLevelFactory<BinaryBHLevel> binary_bh_level_fact(bh_amr,
                                                                 sim_params);
-        setupAMRObject(gr_amr, binary_bh_level_fact);
+        setupAMRObject(bh_amr, binary_bh_level_fact);
 
         // call this after amr object setup so grids known
         // and need it to stay in scope throughout run
         AMRInterpolator<Lagrange<4>> interpolator(
-            gr_amr, sim_params.origin, sim_params.dx, sim_params.verbosity);
-        gr_amr.set_interpolator(&interpolator);
+            bh_amr, sim_params.origin, sim_params.dx, sim_params.verbosity);
+        bh_amr.set_interpolator(&interpolator);
 
         using Clock = std::chrono::steady_clock;
         using Minutes = std::chrono::duration<double, std::ratio<60, 1>>;
 
         std::chrono::time_point<Clock> start_time = Clock::now();
 
-        gr_amr.run(sim_params.stop_time, sim_params.max_steps);
+        bh_amr.run(sim_params.stop_time, sim_params.max_steps);
 
         auto now = Clock::now();
         auto duration = std::chrono::duration_cast<Minutes>(now - start_time);
         pout() << "Total simulation time (mins): " << duration.count() << ".\n";
 
-        gr_amr.conclude();
+        bh_amr.conclude();
 
         CH_TIMER_REPORT(); // Report results when running with Chombo timers.
     } while (UserRestart::activate());

--- a/Examples/BinaryBH/Main_BinaryBH.cpp
+++ b/Examples/BinaryBH/Main_BinaryBH.cpp
@@ -7,6 +7,7 @@
 #include "parstream.H" //Gives us pout()
 #include <chrono>
 #include <iostream>
+#include <unistd.h>
 
 #include "BHAMR.hpp"
 #include "DefaultLevelFactory.hpp"
@@ -19,40 +20,43 @@
 
 int runGRChombo(int argc, char *argv[])
 {
-    // Load the parameter file and construct the SimulationParameter class
-    // To add more parameters edit the SimulationParameters file.
-    char *in_file = argv[1];
-    GRParmParse pp(argc - 2, argv + 2, NULL, in_file);
-    SimulationParameters sim_params(pp);
+    do
+    {
+        // Load the parameter file and construct the SimulationParameter class
+        // To add more parameters edit the SimulationParameters file.
+        char *in_file = argv[1];
+        GRParmParse pp(argc - 2, argv + 2, NULL, in_file);
+        SimulationParameters sim_params(pp);
 
-    // The line below selects the problem that is simulated
-    // (To simulate a different problem, define a new child of AMRLevel
-    // and an associated LevelFactory)
-    BHAMR gr_amr;
-    DefaultLevelFactory<BinaryBHLevel> binary_bh_level_fact(gr_amr, sim_params);
-    setupAMRObject(gr_amr, binary_bh_level_fact);
+        // The line below selects the problem that is simulated
+        // (To simulate a different problem, define a new child of AMRLevel
+        // and an associated LevelFactory)
+        BHAMR gr_amr;
+        DefaultLevelFactory<BinaryBHLevel> binary_bh_level_fact(gr_amr,
+                                                                sim_params);
+        setupAMRObject(gr_amr, binary_bh_level_fact);
 
-    // call this after amr object setup so grids known
-    // and need it to stay in scope throughout run
-    AMRInterpolator<Lagrange<4>> interpolator(
-        gr_amr, sim_params.origin, sim_params.dx, sim_params.verbosity);
-    gr_amr.set_interpolator(&interpolator);
+        // call this after amr object setup so grids known
+        // and need it to stay in scope throughout run
+        AMRInterpolator<Lagrange<4>> interpolator(
+            gr_amr, sim_params.origin, sim_params.dx, sim_params.verbosity);
+        gr_amr.set_interpolator(&interpolator);
 
-    using Clock = std::chrono::steady_clock;
-    using Minutes = std::chrono::duration<double, std::ratio<60, 1>>;
+        using Clock = std::chrono::steady_clock;
+        using Minutes = std::chrono::duration<double, std::ratio<60, 1>>;
 
-    std::chrono::time_point<Clock> start_time = Clock::now();
+        std::chrono::time_point<Clock> start_time = Clock::now();
 
-    gr_amr.run(sim_params.stop_time, sim_params.max_steps);
+        gr_amr.run(sim_params.stop_time, sim_params.max_steps);
 
-    auto now = Clock::now();
-    auto duration = std::chrono::duration_cast<Minutes>(now - start_time);
-    pout() << "Total simulation time (mins): " << duration.count() << ".\n";
+        auto now = Clock::now();
+        auto duration = std::chrono::duration_cast<Minutes>(now - start_time);
+        pout() << "Total simulation time (mins): " << duration.count() << ".\n";
 
-    gr_amr.conclude();
+        gr_amr.conclude();
 
-    CH_TIMER_REPORT(); // Report results when running with Chombo timers.
-
+        CH_TIMER_REPORT(); // Report results when running with Chombo timers.
+    } while (UserRestart::activate());
     return 0;
 }
 

--- a/Examples/BinaryBH/params.txt
+++ b/Examples/BinaryBH/params.txt
@@ -42,7 +42,7 @@ regrid_threshold = 0.05
 max_level = 9
 regrid_interval = 0 0 0 64 64 64 64 64 64 0
 # Determines how exactly regridding tries to fit the tagging
-#fill_ration = 0.75
+#fill_ratio = 0.75
 #tag_buffer_size = 3
 
 # Max and min box sizes
@@ -107,6 +107,7 @@ kappa3 = 1.0
 covariantZ4 = 1 # 0: default. 1: dampk1 -> dampk1/lapse
 
 # coefficient for KO numerical dissipation
+# See Alcubierre p344
 sigma = 1.0
 
 # extraction params

--- a/Examples/BinaryBH/params.txt
+++ b/Examples/BinaryBH/params.txt
@@ -8,6 +8,8 @@ verbosity = 0
 chk_prefix = BinaryBHChk_
 plot_prefix = BinaryBHPlot_
 #restart_file = BinaryBHChk_000000.3d.hdf5
+allow_user_restart = 1
+#restart_trigger_file = GRCHOMBO_RESTART
 
 # Set up coarsest level number of grid points in each dir
 # NB - the values need to be multiples of block_factor
@@ -39,10 +41,13 @@ momentumB =  0.0841746  0.000510846 0.0
 regrid_threshold = 0.05
 max_level = 9
 regrid_interval = 0 0 0 64 64 64 64 64 64 0
+# Determines how exactly regridding tries to fit the tagging
+#fill_ration = 0.75
+#tag_buffer_size = 3
 
 # Max and min box sizes
-max_grid_size = 16
-block_factor = 16
+max_box_size = 16
+min_box_size = 16
 
 # Set up time steps
 # dt will be dx*dt_multiplier on each grid level
@@ -82,6 +87,8 @@ vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
                          1.0 0.0 0.0 0.0 0.0 0.0 0.0 #lapse shift and B
                          0.0 0.0 0.0 0.0             #Ham and Mom
                          0.0 0.0                     #Weyl
+
+#nan_check = 1
 
 # Lapse evolution
 lapse_advec_coeff = 1.0

--- a/Examples/BinaryBH/params_expensive.txt
+++ b/Examples/BinaryBH/params_expensive.txt
@@ -2,6 +2,7 @@ verbosity = 0
 chk_prefix = BinaryBH_
 plot_prefix = BinaryBHPlot_
 #restart_file = BinaryBH_000360.3d.hdf5
+allow_user_restart = 1
 
 # Set up grid spacings and regrid params
 # NB - the N values need to be multiples of block_factor

--- a/Examples/BinaryBH/params_expensive.txt
+++ b/Examples/BinaryBH/params_expensive.txt
@@ -3,6 +3,7 @@ chk_prefix = BinaryBH_
 plot_prefix = BinaryBHPlot_
 #restart_file = BinaryBH_000360.3d.hdf5
 allow_user_restart = 1
+#restart_trigger_file = GRCHOMBO_RESTART
 
 # Set up grid spacings and regrid params
 # NB - the N values need to be multiples of block_factor
@@ -24,12 +25,13 @@ momentumB = 0. 0.1 0.0
 regrid_threshold = 0.20
 max_level = 5
 regrid_interval = 512 256 32 16 8 4 2 2 2
-isPeriodic = 1 1 1
+# Determines how exactly regridding tries to fit the tagging
+#fill_ration = 0.75
+#tag_buffer_size = 3
 
 #Max and min box sizes
-max_grid_size = 32
-block_factor = 16
-tag_buffer_size = 3
+max_box_size = 32
+min_box_size = 16
 
 # Set up time steps
 # dt will be dx*dt_multiplier on each grid level
@@ -41,6 +43,36 @@ plot_interval = 0
 dt_multiplier = 0.25
 stop_time = 1.0
 max_steps = 2
+
+# boundaries and periodicity of grid
+# Periodic directions - 0 = false, 1 = true
+isPeriodic = 1 1 1
+# if not periodic, then specify the boundary type
+# 0 = static, 1 = sommerfeld, 2 = reflective
+# (see BoundaryConditions.hpp for details)
+hi_boundary = 1 1 1
+lo_boundary = 1 1 1
+
+# if reflective boundaries selected, must set
+# parity of all vars (in order given by UserVariables.hpp)
+# 0 = even
+# 1,2,3 = odd x, y, z
+# 4,5,6 = odd xy, yz, xz
+vars_parity            = 0 0 4 6 0 5 0    #chi and hij
+                         0 0 4 6 0 5 0    #K and Aij
+                         0 1 2 3          #Theta and Gamma
+                         0 1 2 3 1 2 3    #lapse shift and B
+                         0 1 2 3          #Ham and Mom
+                         0 0              #Weyl
+
+# if sommerfeld boundaries selected, must select
+# asymptotic values (in order given by UserVariables.hpp)
+vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
+                         0.0 0.0 0.0 0.0 0.0 0.0 0.0 #K and Aij
+                         0.0 0.0 0.0 0.0             #Theta and Gamma
+                         1.0 0.0 0.0 0.0 0.0 0.0 0.0 #lapse shift and B
+                         0.0 0.0 0.0 0.0             #Ham and Mom
+                         0.0 0.0                     #Weyl
 
 nan_check = 1
 

--- a/Examples/BinaryBH/params_expensive.txt
+++ b/Examples/BinaryBH/params_expensive.txt
@@ -93,6 +93,7 @@ kappa3 = 1.
 covariantZ4 = 1 # 0: default. 1: dampk1 -> dampk1/lapse
 
 #coefficient for KO numerical dissipation
+# See Alcubierre p344
 sigma = 0.3
 
 #extraction params

--- a/Examples/BinaryBH/params_very_cheap.txt
+++ b/Examples/BinaryBH/params_very_cheap.txt
@@ -2,6 +2,7 @@ verbosity = 0
 chk_prefix = BinaryBH_
 plot_prefix = BinaryBHPlot_
 #restart_file = BinaryBH_000360.3d.hdf5
+allow_user_restart = 1
 
 # Set up grid spacings and regrid params
 # NB - the N values need to be multiples of block_factor
@@ -55,7 +56,7 @@ eta = 1.82
 kappa1 = 0.1
 kappa2 = 0
 kappa3 = 1.
-covariantZ4 = 1 # 0: default. 1: dampk1 -> dampk1/lapse  
+covariantZ4 = 1 # 0: default. 1: dampk1 -> dampk1/lapse
 
 #coefficient for KO numerical dissipation
 sigma = 0.3

--- a/Examples/BinaryBH/params_very_cheap.txt
+++ b/Examples/BinaryBH/params_very_cheap.txt
@@ -3,6 +3,7 @@ chk_prefix = BinaryBH_
 plot_prefix = BinaryBHPlot_
 #restart_file = BinaryBH_000360.3d.hdf5
 allow_user_restart = 1
+#restart_trigger_file = GRCHOMBO_RESTART
 
 # Set up grid spacings and regrid params
 # NB - the N values need to be multiples of block_factor
@@ -26,8 +27,8 @@ max_level = 1
 regrid_interval = 1 1 1 1 0 0 0 0 0
 
 #Max and min box sizes
-max_grid_size = 32
-block_factor = 4
+max_box_size = 32
+min_box_size = 4
 tag_buffer_size = 3
 
 # Set up time steps
@@ -39,6 +40,36 @@ checkpoint_interval = 1
 plot_interval = 0
 dt_multiplier = 0.25
 stop_time = 10.0
+
+# boundaries and periodicity of grid
+# Periodic directions - 0 = false, 1 = true
+isPeriodic = 1 1 1
+# if not periodic, then specify the boundary type
+# 0 = static, 1 = sommerfeld, 2 = reflective
+# (see BoundaryConditions.hpp for details)
+hi_boundary = 1 1 1
+lo_boundary = 1 1 1
+
+# if reflective boundaries selected, must set
+# parity of all vars (in order given by UserVariables.hpp)
+# 0 = even
+# 1,2,3 = odd x, y, z
+# 4,5,6 = odd xy, yz, xz
+vars_parity            = 0 0 4 6 0 5 0    #chi and hij
+                         0 0 4 6 0 5 0    #K and Aij
+                         0 1 2 3          #Theta and Gamma
+                         0 1 2 3 1 2 3    #lapse shift and B
+                         0 1 2 3          #Ham and Mom
+                         0 0              #Weyl
+
+# if sommerfeld boundaries selected, must select
+# asymptotic values (in order given by UserVariables.hpp)
+vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
+                         0.0 0.0 0.0 0.0 0.0 0.0 0.0 #K and Aij
+                         0.0 0.0 0.0 0.0             #Theta and Gamma
+                         1.0 0.0 0.0 0.0 0.0 0.0 0.0 #lapse shift and B
+                         0.0 0.0 0.0 0.0             #Ham and Mom
+                         0.0 0.0                     #Weyl
 
 nan_check = 1
 

--- a/Examples/BinaryBH/params_very_cheap.txt
+++ b/Examples/BinaryBH/params_very_cheap.txt
@@ -90,4 +90,5 @@ kappa3 = 1.
 covariantZ4 = 1 # 0: default. 1: dampk1 -> dampk1/lapse
 
 #coefficient for KO numerical dissipation
+# See Alcubierre p344
 sigma = 0.3

--- a/Examples/KerrBH/Main_KerrBH.cpp
+++ b/Examples/KerrBH/Main_KerrBH.cpp
@@ -3,7 +3,9 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
+#include "CH_Timer.H"
 #include "parstream.H" //Gives us pout()
+#include <chrono>
 #include <iostream>
 
 #include "DefaultLevelFactory.hpp"
@@ -17,28 +19,37 @@
 
 int runGRChombo(int argc, char *argv[])
 {
-    // Load the parameter file and construct the SimulationParameter class
-    // To add more parameters edit the SimulationParameters file.
-    char *in_file = argv[1];
-    GRParmParse pp(argc - 2, argv + 2, NULL, in_file);
-    SimulationParameters sim_params(pp);
+    do
+    {
+        // Load the parameter file and construct the SimulationParameter class
+        // To add more parameters edit the SimulationParameters file.
+        char *in_file = argv[1];
+        GRParmParse pp(argc - 2, argv + 2, NULL, in_file);
+        SimulationParameters sim_params(pp);
 
-    // The line below selects the problem that is simulated
-    // (To simulate a different problem, define a new child of AMRLevel
-    // and an associated LevelFactory)
-    GRAMR gr_amr;
-    DefaultLevelFactory<KerrBHLevel> kerr_bh_level_fact(gr_amr, sim_params);
-    setupAMRObject(gr_amr, kerr_bh_level_fact);
+        // The line below selects the problem that is simulated
+        // (To simulate a different problem, define a new child of AMRLevel
+        // and an associated LevelFactory)
+        GRAMR gr_amr;
+        DefaultLevelFactory<KerrBHLevel> kerr_bh_level_fact(gr_amr, sim_params);
+        setupAMRObject(gr_amr, kerr_bh_level_fact);
 
-    double stop_time;
-    pp.get("stop_time", stop_time);
-    int max_steps;
-    pp.get("max_steps", max_steps);
+        using Clock = std::chrono::steady_clock;
+        using Minutes = std::chrono::duration<double, std::ratio<60, 1>>;
 
-    gr_amr.run(stop_time, max_steps);
+        std::chrono::time_point<Clock> start_time = Clock::now();
 
-    gr_amr.conclude();
+        gr_amr.run(sim_params.stop_time, sim_params.max_steps);
 
+        auto now = Clock::now();
+        auto duration = std::chrono::duration_cast<Minutes>(now - start_time);
+        pout() << "Total simulation time (mins): " << duration.count() << ".\n";
+
+        gr_amr.conclude();
+
+        // Report results when running with Chombo timers
+        CH_TIMER_REPORT();
+    } while (UserRestart::activate());
     return 0;
 }
 

--- a/Examples/KerrBH/params.txt
+++ b/Examples/KerrBH/params.txt
@@ -4,6 +4,8 @@ verbosity = 0
 chk_prefix = KerrBH_
 plot_prefix = KerrBHp_
 #restart_file = KerrBH_000060.3d.hdf5
+allow_user_restart = 1
+#restart_trigger_file = GRCHOMBO_RESTART
 
 # Set up grid spacings and regrid params
 # NB - the N values need to be multiples of block_factor
@@ -33,14 +35,13 @@ max_level = 6 # There are (max_level+1) grids, so min is zero
 # Need one for each level, ie max_level+1 items
 # Generally you do not need to regrid frequently on every level
 regrid_interval = 50 25 5 5 5 5 5
-#Periodicity in each direction
-isPeriodic = 1 1 1
-# Max box sizes
-max_grid_size = 16
-# Min box size
-block_factor = 16
+
+# Max and min box sizes
+max_box_size = 16
+min_box_size = 16
 # Determines how exactly regridding tries to fit the tagging
 fill_ratio = 0.75
+#tag_buffer_size = 3
 
 # Set up time steps
 # dt will be dx*dt_multiplier on each grid level
@@ -49,7 +50,35 @@ checkpoint_interval = 50
 plot_interval = 10
 dt_multiplier = 0.25
 stop_time = 20.0
-max_steps = 10000000
+#max_steps = 10000000
+
+# boundaries and periodicity of grid
+# Periodic directions - 0 = false, 1 = true
+isPeriodic = 1 1 1
+# if not periodic, then specify the boundary type
+# 0 = static, 1 = sommerfeld, 2 = reflective
+# (see BoundaryConditions.hpp for details)
+hi_boundary = 1 1 1
+lo_boundary = 1 1 1
+
+# if reflective boundaries selected, must set
+# parity of all vars (in order given by UserVariables.hpp)
+# 0 = even
+# 1,2,3 = odd x, y, z
+# 4,5,6 = odd xy, yz, xz
+vars_parity            = 0 0 4 6 0 5 0    #chi and hij
+                         0 0 4 6 0 5 0    #K and Aij
+                         0 1 2 3          #Theta and Gamma
+                         0 1 2 3 1 2 3    #lapse shift and B
+                         0 1 2 3          #Ham and Mom
+
+# if sommerfeld boundaries selected, must select
+# asymptotic values (in order given by UserVariables.hpp)
+vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
+                         0.0 0.0 0.0 0.0 0.0 0.0 0.0 #K and Aij
+                         0.0 0.0 0.0 0.0             #Theta and Gamma
+                         1.0 0.0 0.0 0.0 0.0 0.0 0.0 #lapse shift and B
+                         0.0 0.0 0.0 0.0             #Ham and Mom
 
 #Lapse evolution
 lapse_power = 1.0
@@ -58,8 +87,8 @@ lapse_advec_coeff = 1 # 1 makes the lapse gauge 1+log slicing
 
 # Shift evolution coefficients
 shift_advec_coeff = 0 # Usually no advection for beta
-shift_Gamma_coeff = 0.75 # 
-eta = 1.0 # This is beta_driver, usually of order 1/M_ADM of spacetime
+shift_Gamma_coeff = 0.75 #
+eta = 1.0 # This is gamma driver, usually of order 1/M_ADM of spacetime
 
 # CCZ4 parameters
 # if using BSSN the kappa values should be zero
@@ -70,5 +99,4 @@ kappa3 = 0
 covariantZ4 = 0 # 0: default. 1: dampk1 -> dampk1/lapse
 
 # coefficient for KO numerical dissipation
-# NB must be less than 0.5 for stability
 sigma = 0.3

--- a/Examples/KerrBH/params.txt
+++ b/Examples/KerrBH/params.txt
@@ -99,4 +99,5 @@ kappa3 = 0
 covariantZ4 = 0 # 0: default. 1: dampk1 -> dampk1/lapse
 
 # coefficient for KO numerical dissipation
+# See Alcubierre p344
 sigma = 0.3

--- a/Examples/ScalarField/Main_ScalarField.cpp
+++ b/Examples/ScalarField/Main_ScalarField.cpp
@@ -3,7 +3,9 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
+#include "CH_Timer.H"
 #include "parstream.H" //Gives us pout()
+#include <chrono>
 #include <iostream>
 
 #include "DefaultLevelFactory.hpp"
@@ -17,24 +19,39 @@
 
 int runGRChombo(int argc, char *argv[])
 {
-    // Load the parameter file and construct the SimulationParameter class
-    // To add more parameters edit the SimulationParameters file.
-    char *in_file = argv[1];
-    GRParmParse pp(argc - 2, argv + 2, NULL, in_file);
-    SimulationParameters sim_params(pp);
+    do
+    {
+        // Load the parameter file and construct the SimulationParameter class
+        // To add more parameters edit the SimulationParameters file.
+        char *in_file = argv[1];
+        GRParmParse pp(argc - 2, argv + 2, NULL, in_file);
+        SimulationParameters sim_params(pp);
 
-    // The line below selects the problem that is simulated
-    // (To simulate a different problem, define a new child of AMRLevel
-    // and an associated LevelFactory)
-    GRAMR gr_amr;
-    DefaultLevelFactory<ScalarFieldLevel> scalar_field_level_fact(gr_amr,
-                                                                  sim_params);
-    setupAMRObject(gr_amr, scalar_field_level_fact);
+        // The line below selects the problem that is simulated
+        // (To simulate a different problem, define a new child of AMRLevel
+        // and an associated LevelFactory)
+        GRAMR gr_amr;
+        DefaultLevelFactory<ScalarFieldLevel> scalar_field_level_fact(
+            gr_amr, sim_params);
+        setupAMRObject(gr_amr, scalar_field_level_fact);
 
-    // Engage! Run the evolution
-    gr_amr.run(sim_params.stop_time, sim_params.max_steps);
-    gr_amr.conclude();
+        using Clock = std::chrono::steady_clock;
+        using Minutes = std::chrono::duration<double, std::ratio<60, 1>>;
 
+        std::chrono::time_point<Clock> start_time = Clock::now();
+
+        // Engage! Run the evolution
+        gr_amr.run(sim_params.stop_time, sim_params.max_steps);
+
+        auto now = Clock::now();
+        auto duration = std::chrono::duration_cast<Minutes>(now - start_time);
+        pout() << "Total simulation time (mins): " << duration.count() << ".\n";
+
+        gr_amr.conclude();
+
+        // Report results when running with Chombo timers
+        CH_TIMER_REPORT();
+    } while (UserRestart::activate());
     return 0;
 }
 

--- a/Examples/ScalarField/params.txt
+++ b/Examples/ScalarField/params.txt
@@ -95,7 +95,7 @@ kappa3 = 0
 covariantZ4 = 0 # 0: default. 1: dampk1 -> dampk1/lapse
 
 # coefficient for KO numerical dissipation
-# NB must be less than 0.5 for stability
+# See Alcubierre p344
 sigma = 0.3
 
 # Change the gravitational constant of the Universe!

--- a/Examples/ScalarField/params.txt
+++ b/Examples/ScalarField/params.txt
@@ -4,6 +4,8 @@ verbosity = 0
 chk_prefix = ScalarField_
 plot_prefix = ScalarFieldp_
 #restart_file = ScalarField_000000.3d.hdf5
+allow_user_restart = 1
+#restart_trigger_file = GRCHOMBO_RESTART
 
 # Set up grid spacings and regrid params
 # NB - the N values need to be multiples of block_factor
@@ -27,6 +29,10 @@ max_level = 2 # There are (max_level+1) grids, so min is zero
 # Need one for each level, ie max_level+1 items
 # Generally you do not need to regrid frequently on every level
 regrid_interval = 32 16 8 4
+# Determines how exactly regridding tries to fit the tagging
+#fill_ration = 0.75
+#tag_buffer_size = 3
+
 # Max and min box size - for load balancing
 max_box_size = 32
 min_box_size = 8
@@ -53,7 +59,7 @@ vars_parity            = 0 0 4 6 0 5 0    #chi and hij
                          0 0              #phi and Pi
                          0 1 2 3          #Ham and Mom
 
-# if sommerfeld boundaries selected, must select 
+# if sommerfeld boundaries selected, must select
 # asymptotic values (in order given by UserVariables.hpp)
 vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
                          0.0 0.0 0.0 0.0 0.0 0.0 0.0 #K and Aij
@@ -77,8 +83,8 @@ lapse_advec_coeff = 1 # 1 makes the lapse gauge 1+log slicing
 
 # Shift evolution coefficients
 shift_advec_coeff = 0 # Usually no advection for beta
-shift_Gamma_coeff = 0.75 # 
-eta = 1.0 # This is beta_driver, usually of order 1/M_ADM of spacetime
+shift_Gamma_coeff = 0.75 #
+eta = 1.0 # This is gamma driver, usually of order 1/M_ADM of spacetime
 
 # CCZ4 parameters
 # if using BSSN the kappa values should be zero

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -114,6 +114,10 @@ class ChomboParameters
         // Misc
         pp.load("ignore_checkpoint_name_mismatch",
                 ignore_checkpoint_name_mismatch, false);
+        pp.load("allow_user_restart", allow_user_restart, false);
+        std::string default_restart_trigger_file = "GRCHOMBO_RESTART";
+        pp.load("restart_trigger_file", restart_trigger_file,
+                default_restart_trigger_file);
 
         pp.load("max_level", max_level, 0);
         // the reference ratio is hard coded to 2 on all levels
@@ -176,6 +180,8 @@ class ChomboParameters
     double fill_ratio; // determines how fussy the regridding is about tags
     std::string checkpoint_prefix, plot_prefix; // naming of files
     bool write_plot_ghosts;
+    bool allow_user_restart;    // allows the user to restart the simulation.
+    std::string restart_trigger_file; // name of file to trigger user restart
 
     // Boundary conditions
     std::array<bool, CH_SPACEDIM> isPeriodic;     // periodicity

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -180,7 +180,7 @@ class ChomboParameters
     double fill_ratio; // determines how fussy the regridding is about tags
     std::string checkpoint_prefix, plot_prefix; // naming of files
     bool write_plot_ghosts;
-    bool allow_user_restart;    // allows the user to restart the simulation.
+    bool allow_user_restart; // allows the user to restart the simulation.
     std::string restart_trigger_file; // name of file to trigger user restart
 
     // Boundary conditions

--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -411,13 +411,14 @@ DisjointBoxLayout GRAMRLevel::loadBalance(const Vector<Box> &a_grids)
     return dbl;
 }
 
-bool GRAMRLevel::stopEvolution()
+bool GRAMRLevel::stopEvolution(bool &a_write_checkpoint)
 {
     if (m_p.allow_user_restart)
     {
         UserRestart::check(m_p.restart_trigger_file);
         if (UserRestart::activate())
         {
+            a_write_checkpoint = false;
             pout() << "GRChombo restarting..." << endl;
         }
         return UserRestart::activate();

--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -411,6 +411,23 @@ DisjointBoxLayout GRAMRLevel::loadBalance(const Vector<Box> &a_grids)
     return dbl;
 }
 
+bool GRAMRLevel::stopEvolution()
+{
+    if (m_p.allow_user_restart)
+    {
+        UserRestart::check(m_p.restart_trigger_file);
+        if (UserRestart::activate())
+        {
+            pout() << "GRChombo restarting..." << endl;
+        }
+        return UserRestart::activate();
+    }
+    else
+    {
+        return false;
+    }
+}
+
 // write checkpoint header
 #ifdef CH_USE_HDF5
 void GRAMRLevel::writeCheckpointHeader(HDF5Handle &a_handle) const

--- a/Source/GRChomboCore/GRAMRLevel.hpp
+++ b/Source/GRChomboCore/GRAMRLevel.hpp
@@ -81,8 +81,7 @@ class GRAMRLevel : public AMRLevel, public InterpSource
 
     /// return true on the coarsest level in order to stop the evolution
     /// currently implements user restarting
-    virtual bool stopEvolution();
-
+    virtual bool stopEvolution(bool &a_write_checkpoint);
 
 #ifdef CH_USE_HDF5
     virtual void writeCheckpointHeader(HDF5Handle &a_handle) const;

--- a/Source/GRChomboCore/GRAMRLevel.hpp
+++ b/Source/GRChomboCore/GRAMRLevel.hpp
@@ -16,6 +16,7 @@
 #include "LevelFluxRegister.H" //We don't actually use flux conservation but Chombo assumes we do
 #include "LevelRK4.H"
 #include "SimulationParameters.hpp"
+#include "UserRestart.hpp"
 #include "UserVariables.hpp" // need NUM_VARS
 #include <sys/time.h>
 
@@ -77,6 +78,11 @@ class GRAMRLevel : public AMRLevel, public InterpSource
     virtual Real computeInitialDt();
 
     DisjointBoxLayout loadBalance(const Vector<Box> &a_grids);
+
+    /// return true on the coarsest level in order to stop the evolution
+    /// currently implements user restarting
+    virtual bool stopEvolution();
+
 
 #ifdef CH_USE_HDF5
     virtual void writeCheckpointHeader(HDF5Handle &a_handle) const;

--- a/Source/GRChomboCore/SetupFunctions.hpp
+++ b/Source/GRChomboCore/SetupFunctions.hpp
@@ -105,7 +105,7 @@ void setupAMRObject(GRAMR &gr_amr, AMRLevelFactory &a_factory)
     // remove restart trigger file
     if (chombo_params.allow_user_restart && UserRestart::activate())
     {
-       UserRestart::remove_trigger(chombo_params.restart_trigger_file);
+        UserRestart::remove_trigger(chombo_params.restart_trigger_file);
     }
 
     // set size of box

--- a/Source/GRChomboCore/UserRestart.cpp
+++ b/Source/GRChomboCore/UserRestart.cpp
@@ -3,7 +3,6 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-
 #include "UserRestart.hpp"
 
 // This file includes functions that enables the user to trigger a clean restart
@@ -30,10 +29,11 @@ void UserRestart::check(std::string a_restart_trigger_file)
 
 void UserRestart::remove_trigger(std::string a_restart_trigger_file)
 {
-    if (procID() == 0);
+    if (procID() == 0)
+        ;
     {
-        bool trigger_file_exists
-            = (access(a_restart_trigger_file.c_str(), F_OK) != -1);
+        bool trigger_file_exists =
+            (access(a_restart_trigger_file.c_str(), F_OK) != -1);
         if (trigger_file_exists)
         {
             std::remove(a_restart_trigger_file.c_str());
@@ -42,7 +42,4 @@ void UserRestart::remove_trigger(std::string a_restart_trigger_file)
     s_activate = false;
 }
 
-bool UserRestart::activate()
-{
-    return s_activate;
-}
+bool UserRestart::activate() { return s_activate; }

--- a/Source/GRChomboCore/UserRestart.cpp
+++ b/Source/GRChomboCore/UserRestart.cpp
@@ -1,0 +1,48 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+
+#include "UserRestart.hpp"
+
+// This file includes functions that enables the user to trigger a clean restart
+// mid evolution
+
+bool UserRestart::s_activate = false;
+
+void UserRestart::check(std::string a_restart_trigger_file)
+{
+    int restart = 0;
+    int master_rank = 0;
+
+    // check if the restart trigger file exists on rank 0
+    if (procID() == master_rank)
+    {
+        restart = static_cast<int>(
+            access(a_restart_trigger_file.c_str(), F_OK) != -1);
+    }
+
+    // broadcast check to all ranks
+    broadcast(restart, master_rank);
+    s_activate = static_cast<bool>(restart);
+}
+
+void UserRestart::remove_trigger(std::string a_restart_trigger_file)
+{
+    if (procID() == 0);
+    {
+        bool trigger_file_exists
+            = (access(a_restart_trigger_file.c_str(), F_OK) != -1);
+        if (trigger_file_exists)
+        {
+            std::remove(a_restart_trigger_file.c_str());
+        }
+    }
+    s_activate = false;
+}
+
+bool UserRestart::activate()
+{
+    return s_activate;
+}

--- a/Source/GRChomboCore/UserRestart.hpp
+++ b/Source/GRChomboCore/UserRestart.hpp
@@ -1,0 +1,30 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef USERRESTART_HPP_
+#define USERRESTART_HPP_
+
+#include <unistd.h>
+#include "SPMD.H"
+
+// This class includes functions that enables the user to trigger a clean
+// restart mid evolution
+
+class UserRestart
+{
+  public:
+    // checks whether the restart trigger file exists and updates s_activate
+    static void check(std::string a_restart_trigger_file);
+
+    // removes the restart trigger file
+    static void remove_trigger(std::string a_restart_trigger_file);
+
+    static bool activate();
+
+  private:
+    static bool s_activate;
+};
+
+#endif /* USERRESTART_HPP_ */

--- a/Source/GRChomboCore/UserRestart.hpp
+++ b/Source/GRChomboCore/UserRestart.hpp
@@ -6,8 +6,8 @@
 #ifndef USERRESTART_HPP_
 #define USERRESTART_HPP_
 
-#include <unistd.h>
 #include "SPMD.H"
+#include <unistd.h>
 
 // This class includes functions that enables the user to trigger a clean
 // restart mid evolution

--- a/Tests/BasicAMRInterpolatorTest/AMRInterpolatorTest.inputs
+++ b/Tests/BasicAMRInterpolatorTest/AMRInterpolatorTest.inputs
@@ -16,7 +16,7 @@ ref_ratio = 2 2 2 2 2 2 2 2 2
 isPeriodic = 1 1 1
 
 #Max and min box sizes
-max_grid_size = 32
-block_factor = 4
+max_box_size = 32
+min_box_size = 4
 tag_buffer_size = 3
 checkpoint_interval = 1


### PR DESCRIPTION
I have added the ability for users to completely restart the simulation without stopping the code, thus saving your space in the queue on busy clusters. This might be useful, for example, if your simulation has started after 3 days in the queue but you accidentally set a parameter slightly wrong and you're crying at the fact you need to wait another 3 days! You can probably guess why I bothered to write this...

To add this to your own examples, you need to just to add a `do... while` loop in `Main_<example>.cpp` as I have done for the provided examples. A restart is triggered at the end of a coarse time step by the existence (e.g. by `touch`ing) of a file with a parameterised file name (defaulted to `GRCHOMBO_RESTART`) that is subsequently deleted after the simulation restarts.

Since `AMR::conclude` is called, this _shouldn't_ cause excessive memory usage but I haven't tested it and wouldn't be surprised if more memory is used after a restart.

I have also taken the liberty of updating the example parameter files with some of their missing parameters (either commented out or set to default values) to make them more consistent.