### PR TITLE
Fixed to default to center for non-cubic grids

### DIFF
--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -95,7 +95,8 @@ class ChomboParameters
         pp.load("N1", N3);                                                                                                     
                                                                                                                                
         pp.load("center", center,                                                                                              
-                {0.5 * N1 * coarsest_dx, 0.5 * N2 * coarsest_dx, 0.5 * N3 * coarsest_dx}); // default to center
+                {0.5 * N1 * coarsest_dx, 0.5 * N2 * coarsest_dx, 
+                 0.5 * N3 * coarsest_dx}); // default to center
 
         pp.load("max_level", max_level, 0);
         // the reference ratio is hard coded to 2 on all levels

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -25,6 +25,25 @@ class ChomboParameters
         pp.load("tag_buffer_size", tag_buffer_size, 3);
         pp.load("dt_multiplier", dt_multiplier, 0.25);
         pp.load("fill_ratio", fill_ratio, 0.7);
+      
+        // Setup the grid size
+        ivN = IntVect::Unit;
+        int max_N = 0;
+        for (int dir = 0; dir < CH_SPACEDIM; ++dir)
+        {
+            char dir_str[20];
+            sprintf(dir_str, "N%d", dir + 1);
+            int N;
+            pp.load(dir_str, N);
+            N_vect.push_back(N);
+            ivN[dir] = N - 1;
+            max_N = max(N, max_N);
+        }
+        coarsest_dx = L / max_N;                                                                                              
+                                                                                                                               
+        pp.load("center", center,                                                                                              
+                {0.5 * N_vect[0] * coarsest_dx, 0.5 * N_vect[1] * coarsest_dx, 
+                 0.5 * N_vect[2] * coarsest_dx}); // default to center      
 
         // Periodicity and boundaries
         pp.load("isPeriodic", isPeriodic, {true, true, true});
@@ -54,6 +73,17 @@ class ChomboParameters
                 {
                     symmetric_boundaries_exist = true;
                     pp.load("vars_parity", boundary_params.vars_parity);
+                  
+                    if (boundary_params.hi_boundary[idir] ==                                                        
+                       BoundaryConditions::REFLECTIVE_BC) {                                                        
+                      center[idir] == N_vect[idir] * coarsest_dx;                                                   
+                    }                                                                                               
+                                                                                                          
+                    if (boundary_params.lo_boundary[idir] ==                                                        
+                       BoundaryConditions::REFLECTIVE_BC) {                                                        
+                      center[idir] == 0;                                                                            
+                    }                 
+                  
                 }
                 if ((boundary_params.hi_boundary[idir] ==
                      BoundaryConditions::SOMMERFELD_BC) ||
@@ -75,25 +105,6 @@ class ChomboParameters
         // Misc
         pp.load("ignore_checkpoint_name_mismatch",
                 ignore_checkpoint_name_mismatch, false);
-
-        // Setup the grid size
-        ivN = IntVect::Unit;
-        int max_N = 0;
-        for (int dir = 0; dir < CH_SPACEDIM; ++dir)
-        {
-            char dir_str[20];
-            sprintf(dir_str, "N%d", dir + 1);
-            int N;
-            pp.load(dir_str, N);
-            N_vect.push_back(N);
-            ivN[dir] = N - 1;
-            max_N = max(N, max_N);
-        }
-        coarsest_dx = L / max_N;                                                                                              
-                                                                                                                               
-        pp.load("center", center,                                                                                              
-                {0.5 * N_vect[0] * coarsest_dx, 0.5 * N_vect[1] * coarsest_dx, 
-                 0.5 * N_vect[2] * coarsest_dx}); // default to center
 
         pp.load("max_level", max_level, 0);
         // the reference ratio is hard coded to 2 on all levels

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -20,8 +20,6 @@ class ChomboParameters
         pp.load("verbosity", verbosity, 0);
         // Grid setup
         pp.load("L", L, 1.0);
-        pp.load("center", center,
-                {0.5 * L, 0.5 * L, 0.5 * L}); // default to center
         pp.load("regrid_threshold", regrid_threshold, 0.5);
         pp.load("num_ghosts", num_ghosts, 3);
         pp.load("tag_buffer_size", tag_buffer_size, 3);
@@ -91,6 +89,13 @@ class ChomboParameters
             max_N = max(N, max_N);
         }
         coarsest_dx = L / max_N;
+      
+        pp.load("N1", N1);                                                                                                     
+        pp.load("N1", N2);                                                                                                     
+        pp.load("N1", N3);                                                                                                     
+                                                                                                                               
+        pp.load("center", center,                                                                                              
+                {0.5 * N1 * coarsest_dx, 0.5 * N2 * coarsest_dx, 0.5 * N3 * coarsest_dx}); // default to center
 
         pp.load("max_level", max_level, 0);
         // the reference ratio is hard coded to 2 on all levels
@@ -134,6 +139,7 @@ class ChomboParameters
 
     // General parameters
     int verbosity;
+    int N1, N2, N3;
     double L;                               // Physical sidelength of the grid
     std::array<double, CH_SPACEDIM> center; // grid center
     IntVect ivN;                 // The number of grid cells in each dimension

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -25,7 +25,7 @@ class ChomboParameters
         pp.load("tag_buffer_size", tag_buffer_size, 3);
         pp.load("dt_multiplier", dt_multiplier, 0.25);
         pp.load("fill_ratio", fill_ratio, 0.7);
-      
+
         // Setup the grid size
         ivN = IntVect::Unit;
         int max_N = 0;
@@ -39,11 +39,11 @@ class ChomboParameters
             ivN[dir] = N - 1;
             max_N = max(N, max_N);
         }
-        coarsest_dx = L / max_N;                                                                                              
-                                                                                                                               
-        pp.load("center", center,                                                                                              
-                {0.5 * N_vect[0] * coarsest_dx, 0.5 * N_vect[1] * coarsest_dx, 
-                 0.5 * N_vect[2] * coarsest_dx}); // default to center      
+        coarsest_dx = L / max_N;
+
+        pp.load("center", center,
+                {0.5 * N_vect[0] * coarsest_dx, 0.5 * N_vect[1] * coarsest_dx,
+                 0.5 * N_vect[2] * coarsest_dx}); // default to center
 
         // Periodicity and boundaries
         pp.load("isPeriodic", isPeriodic, {true, true, true});
@@ -73,17 +73,18 @@ class ChomboParameters
                 {
                     symmetric_boundaries_exist = true;
                     pp.load("vars_parity", boundary_params.vars_parity);
-                  
-                    if (boundary_params.hi_boundary[idir] ==                                                        
-                       BoundaryConditions::REFLECTIVE_BC) {                                                        
-                      center[idir] == N_vect[idir] * coarsest_dx;                                                   
-                    }                                                                                               
-                                                                                                          
-                    if (boundary_params.lo_boundary[idir] ==                                                        
-                       BoundaryConditions::REFLECTIVE_BC) {                                                        
-                      center[idir] == 0;                                                                            
-                    }                 
-                  
+
+                    if (boundary_params.hi_boundary[idir] ==
+                        BoundaryConditions::REFLECTIVE_BC)
+                    {
+                        center[idir] == N_vect[idir] * coarsest_dx;
+                    }
+
+                    if (boundary_params.lo_boundary[idir] ==
+                        BoundaryConditions::REFLECTIVE_BC)
+                    {
+                        center[idir] == 0;
+                    }
                 }
                 if ((boundary_params.hi_boundary[idir] ==
                      BoundaryConditions::SOMMERFELD_BC) ||

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -91,8 +91,8 @@ class ChomboParameters
         coarsest_dx = L / max_N;
       
         pp.load("N1", N1);                                                                                                     
-        pp.load("N1", N2);                                                                                                     
-        pp.load("N1", N3);                                                                                                     
+        pp.load("N2", N2);                                                                                                     
+        pp.load("N3", N3);                                                                                                     
                                                                                                                                
         pp.load("center", center,                                                                                              
                 {0.5 * N1 * coarsest_dx, 0.5 * N2 * coarsest_dx, 

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -74,16 +74,20 @@ class ChomboParameters
                     symmetric_boundaries_exist = true;
                     pp.load("vars_parity", boundary_params.vars_parity);
 
-                    if (boundary_params.hi_boundary[idir] ==
-                        BoundaryConditions::REFLECTIVE_BC)
+                    if ((boundary_params.hi_boundary[idir] ==
+                         BoundaryConditions::REFLECTIVE_BC) &&
+                        (boundary_params.lo_boundary[idir] !=
+                         BoundaryConditions::REFLECTIVE_BC))
                     {
-                        center[idir] == N_vect[idir] * coarsest_dx;
+                        center[idir] = N_vect[idir] * coarsest_dx;
                     }
 
-                    if (boundary_params.lo_boundary[idir] ==
-                        BoundaryConditions::REFLECTIVE_BC)
+                    if ((boundary_params.lo_boundary[idir] ==
+                         BoundaryConditions::REFLECTIVE_BC) &&
+                        (boundary_params.hi_boundary[idir] !=
+                         BoundaryConditions::REFLECTIVE_BC))
                     {
-                        center[idir] == 0;
+                        center[idir] = 0;
                     }
                 }
                 if ((boundary_params.hi_boundary[idir] ==

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -85,18 +85,15 @@ class ChomboParameters
             sprintf(dir_str, "N%d", dir + 1);
             int N;
             pp.load(dir_str, N);
+            N_vect.push_back(N);
             ivN[dir] = N - 1;
             max_N = max(N, max_N);
         }
-        coarsest_dx = L / max_N;
-      
-        pp.load("N1", N1);                                                                                                     
-        pp.load("N2", N2);                                                                                                     
-        pp.load("N3", N3);                                                                                                     
+        coarsest_dx = L / max_N;                                                                                              
                                                                                                                                
         pp.load("center", center,                                                                                              
-                {0.5 * N1 * coarsest_dx, 0.5 * N2 * coarsest_dx, 
-                 0.5 * N3 * coarsest_dx}); // default to center
+                {0.5 * N_vect[0] * coarsest_dx, 0.5 * N_vect[1] * coarsest_dx, 
+                 0.5 * N_vect[2] * coarsest_dx}); // default to center
 
         pp.load("max_level", max_level, 0);
         // the reference ratio is hard coded to 2 on all levels
@@ -140,7 +137,7 @@ class ChomboParameters
 
     // General parameters
     int verbosity;
-    int N1, N2, N3;
+    std::vector<int> N_vect;
     double L;                               // Physical sidelength of the grid
     std::array<double, CH_SPACEDIM> center; // grid center
     IntVect ivN;                 // The number of grid cells in each dimension

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -100,6 +100,8 @@ class ChomboParameters
                 }
             }
         }
+	pout() << "Center has been set to: " << center << endl;
+	
         if (nonperiodic_boundaries_exist)
         {
             // write out boundary conditions where non periodic - useful for

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -100,8 +100,8 @@ class ChomboParameters
                 }
             }
         }
-	pout() << "Center has been set to: " << center << endl;
-	
+        pout() << "Center has been set to: " << center << endl;
+
         if (nonperiodic_boundaries_exist)
         {
             // write out boundary conditions where non periodic - useful for

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -100,7 +100,12 @@ class ChomboParameters
                 }
             }
         }
-        pout() << "Center has been set to: " << center << endl;
+        pout() << "Center has been set to: " ;
+	FOR1(idir)
+	{
+	  pout() << center[idir] << " ";	  
+	}
+	pout() << endl;
 
         if (nonperiodic_boundaries_exist)
         {

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -100,12 +100,9 @@ class ChomboParameters
                 }
             }
         }
-        pout() << "Center has been set to: " ;
-	FOR1(idir)
-	{
-	  pout() << center[idir] << " ";	  
-	}
-	pout() << endl;
+        pout() << "Center has been set to: ";
+        FOR1(idir) { pout() << center[idir] << " "; }
+        pout() << endl;
 
         if (nonperiodic_boundaries_exist)
         {


### PR DESCRIPTION
This works for 3D, does not generalise to higher dimensions