### PR TITLE
Add variable_name_to_enum function

### DIFF
--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -185,12 +185,3 @@ void BinaryBHLevel::prePlotLevel()
                        m_state_new, m_state_new, EXCLUDE_GHOST_CELLS);
     }
 }
-
-// Specify if you want any plot files to be written, with which vars
-void BinaryBHLevel::specificWritePlotHeader(std::vector<int> &plot_states) const
-{
-    if (m_p.num_plot_vars > 0)
-        plot_states = m_p.plot_vars;
-    else
-        plot_states = {c_chi, c_Weyl4_Re, c_Weyl4_Im};
-}

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -189,5 +189,8 @@ void BinaryBHLevel::prePlotLevel()
 // Specify if you want any plot files to be written, with which vars
 void BinaryBHLevel::specificWritePlotHeader(std::vector<int> &plot_states) const
 {
-    plot_states = {c_chi, c_Weyl4_Re, c_Weyl4_Im};
+    if (m_p.num_plot_vars > 0)
+        plot_states = m_p.plot_vars;
+    else
+        plot_states = {c_chi, c_Weyl4_Re, c_Weyl4_Im};
 }

--- a/Examples/BinaryBH/BinaryBHLevel.hpp
+++ b/Examples/BinaryBH/BinaryBHLevel.hpp
@@ -50,9 +50,6 @@ class BinaryBHLevel : public GRAMRLevel
 
     /// Any actions that should happen just before plot files output
     virtual void prePlotLevel() override;
-
-    //! Specify which variables to write at plot intervals
-    virtual void specificWritePlotHeader(std::vector<int> &plot_states) const;
 };
 
 #endif /* BINARYBHLEVEL_HPP_ */

--- a/Examples/BinaryBH/params.txt
+++ b/Examples/BinaryBH/params.txt
@@ -50,6 +50,8 @@ block_factor = 16
 checkpoint_interval = 100
 # set to zero to turn off plot files, comps defined in BinaryBHLevel.cpp
 plot_interval = 10
+num_plot_vars = 3
+plot_vars = chi Weyl4_Re Weyl4_Im
 dt_multiplier = 0.25
 stop_time = 2200.0
 

--- a/Examples/BinaryBH/params_expensive.txt
+++ b/Examples/BinaryBH/params_expensive.txt
@@ -37,6 +37,8 @@ tag_buffer_size = 3
 checkpoint_interval = 4
 # set to zero to turn off plot files
 plot_interval = 0
+num_plot_vars = 3
+plot_vars = chi Weyl4_Re Weyl4_Im
 dt_multiplier = 0.25
 stop_time = 1.0
 max_steps = 2

--- a/Examples/BinaryBH/params_very_cheap.txt
+++ b/Examples/BinaryBH/params_very_cheap.txt
@@ -36,6 +36,8 @@ tag_buffer_size = 3
 checkpoint_interval = 1
 # set to zero to turn off plot files
 plot_interval = 0
+num_plot_vars = 3
+plot_vars = chi Weyl4_Re Weyl4_Im
 dt_multiplier = 0.25
 stop_time = 10.0
 
@@ -55,7 +57,7 @@ eta = 1.82
 kappa1 = 0.1
 kappa2 = 0
 kappa3 = 1.
-covariantZ4 = 1 # 0: default. 1: dampk1 -> dampk1/lapse  
+covariantZ4 = 1 # 0: default. 1: dampk1 -> dampk1/lapse
 
 #coefficient for KO numerical dissipation
 sigma = 0.3

--- a/Examples/KerrBH/KerrBHLevel.cpp
+++ b/Examples/KerrBH/KerrBHLevel.cpp
@@ -79,13 +79,6 @@ void KerrBHLevel::specificUpdateODE(GRLevelData &a_soln,
     BoxLoops::loop(TraceARemoval(), a_soln, a_soln, INCLUDE_GHOST_CELLS);
 }
 
-// Specify which variables to write at plot intervals
-void KerrBHLevel::specificWritePlotHeader(std::vector<int> &plot_states) const
-{
-    // Specify the variables we want to output as plot
-    plot_states = {c_chi, c_K, c_lapse, c_shift1};
-}
-
 void KerrBHLevel::computeTaggingCriterion(FArrayBox &tagging_criterion,
                                           const FArrayBox &current_state)
 {

--- a/Examples/KerrBH/KerrBHLevel.hpp
+++ b/Examples/KerrBH/KerrBHLevel.hpp
@@ -34,10 +34,6 @@ class KerrBHLevel : public GRAMRLevel
                                    const GRLevelData &a_rhs,
                                    Real a_dt) override;
 
-    /// Specify which variables to write at plot intervals
-    virtual void
-    specificWritePlotHeader(std::vector<int> &plot_states) const override;
-
     virtual void
     computeTaggingCriterion(FArrayBox &tagging_criterion,
                             const FArrayBox &current_state) override;

--- a/Examples/KerrBH/params.txt
+++ b/Examples/KerrBH/params.txt
@@ -47,6 +47,8 @@ fill_ratio = 0.75
 # HDF5files are written every dt = L/N*dt_multiplier*checkpoint_interval
 checkpoint_interval = 50
 plot_interval = 10
+num_plot_vars = 4
+plot_vars = chi K lapse shift1
 dt_multiplier = 0.25
 stop_time = 20.0
 max_steps = 10000000
@@ -58,7 +60,7 @@ lapse_advec_coeff = 1 # 1 makes the lapse gauge 1+log slicing
 
 # Shift evolution coefficients
 shift_advec_coeff = 0 # Usually no advection for beta
-shift_Gamma_coeff = 0.75 # 
+shift_Gamma_coeff = 0.75 #
 eta = 1.0 # This is beta_driver, usually of order 1/M_ADM of spacetime
 
 # CCZ4 parameters

--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -122,13 +122,6 @@ void ScalarFieldLevel::specificUpdateODE(GRLevelData &a_soln,
     BoxLoops::loop(TraceARemoval(), a_soln, a_soln, INCLUDE_GHOST_CELLS);
 }
 
-// Specify if you want any plot files to be written, with which vars
-void ScalarFieldLevel::specificWritePlotHeader(
-    std::vector<int> &plot_states) const
-{
-    plot_states = {c_phi, c_chi};
-}
-
 void ScalarFieldLevel::computeTaggingCriterion(FArrayBox &tagging_criterion,
                                                const FArrayBox &current_state)
 {

--- a/Examples/ScalarField/ScalarFieldLevel.hpp
+++ b/Examples/ScalarField/ScalarFieldLevel.hpp
@@ -47,9 +47,6 @@ class ScalarFieldLevel : public GRAMRLevel
     virtual void specificUpdateODE(GRLevelData &a_soln,
                                    const GRLevelData &a_rhs, Real a_dt);
 
-    //! Specify which variables to write at plot intervals
-    virtual void specificWritePlotHeader(std::vector<int> &plot_states) const;
-
     //! Tell Chombo how to tag cells for regridding
     virtual void computeTaggingCriterion(FArrayBox &tagging_criterion,
                                          const FArrayBox &current_state);

--- a/Examples/ScalarField/params.txt
+++ b/Examples/ScalarField/params.txt
@@ -53,7 +53,7 @@ vars_parity            = 0 0 4 6 0 5 0    #chi and hij
                          0 0              #phi and Pi
                          0 1 2 3          #Ham and Mom
 
-# if sommerfeld boundaries selected, must select 
+# if sommerfeld boundaries selected, must select
 # asymptotic values (in order given by UserVariables.hpp)
 vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
                          0.0 0.0 0.0 0.0 0.0 0.0 0.0 #K and Aij
@@ -67,6 +67,8 @@ vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
 # HDF5files are written every dt = L/N*dt_multiplier*checkpoint_interval
 checkpoint_interval = 100
 plot_interval = 10
+num_plot_vars = 2
+plot_vars = chi phi
 dt_multiplier = 0.25
 stop_time = 10.0
 
@@ -77,7 +79,7 @@ lapse_advec_coeff = 1 # 1 makes the lapse gauge 1+log slicing
 
 # Shift evolution coefficients
 shift_advec_coeff = 0 # Usually no advection for beta
-shift_Gamma_coeff = 0.75 # 
+shift_Gamma_coeff = 0.75 #
 eta = 1.0 # This is beta_driver, usually of order 1/M_ADM of spacetime
 
 # CCZ4 parameters

--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -676,9 +676,10 @@ void GRAMRLevel::writePlotLevel(HDF5Handle &a_handle) const
     if (m_verbosity)
         pout() << "GRAMRLevel::writePlotLevel" << endl;
 
-    // number and index of states to print
-    std::vector<int> plot_states;
-    // to be specified in specific Level class
+    // number and index of states to print. first default to parameter
+    std::vector<int> plot_states = m_p.plot_vars;
+    // but call this which may defined in specific Level class for backwards
+    // compatibility
     specificWritePlotHeader(plot_states);
     int num_states = plot_states.size();
 
@@ -748,9 +749,10 @@ void GRAMRLevel::writePlotHeader(HDF5Handle &a_handle) const
     if (m_verbosity)
         pout() << "GRAMRLevel::writePlotHeader" << endl;
 
-    // number and index of states to print
-    std::vector<int> plot_states;
-    // to be specified in specific Level class
+    // number and index of states to print. first default to parameter
+    std::vector<int> plot_states = m_p.plot_vars;
+    // but call this which may defined in specific Level class for backwards
+    // compatibility
     specificWritePlotHeader(plot_states);
     int num_states = plot_states.size();
 
@@ -781,11 +783,6 @@ void GRAMRLevel::writePlotHeader(HDF5Handle &a_handle) const
                         "provided but no components are selected for plotting. "
                         "Plot files will be empty.");
     }
-}
-
-void GRAMRLevel::specificWritePlotHeader(std::vector<int> &plot_states) const
-{
-    plot_states = m_p.plot_vars;
 }
 #endif /*ifdef CH_USE_HDF5*/
 

--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -782,6 +782,11 @@ void GRAMRLevel::writePlotHeader(HDF5Handle &a_handle) const
                         "Plot files will be empty.");
     }
 }
+
+void GRAMRLevel::specificWritePlotHeader(std::vector<int> &plot_states) const
+{
+    plot_states = m_p.plot_vars;
+}
 #endif /*ifdef CH_USE_HDF5*/
 
 void GRAMRLevel::evalRHS(GRLevelData &rhs, GRLevelData &soln,

--- a/Source/GRChomboCore/GRAMRLevel.hpp
+++ b/Source/GRChomboCore/GRAMRLevel.hpp
@@ -141,7 +141,7 @@ class GRAMRLevel : public AMRLevel, public InterpSource
     virtual void prePlotLevel() {}
 
     /// Specify which variables to write at plot intervals
-    virtual void specificWritePlotHeader(std::vector<int> &plot_states) const;
+    virtual void specificWritePlotHeader(std::vector<int> &plot_states) const {}
 
     /// Things to do immediately after restart from checkpoint
     virtual void postRestart() {}

--- a/Source/GRChomboCore/GRAMRLevel.hpp
+++ b/Source/GRChomboCore/GRAMRLevel.hpp
@@ -141,8 +141,7 @@ class GRAMRLevel : public AMRLevel, public InterpSource
     virtual void prePlotLevel() {}
 
     /// Specify which variables to write at plot intervals
-    virtual void
-    specificWritePlotHeader(std::vector<int> &plot_states) const {};
+    virtual void specificWritePlotHeader(std::vector<int> &plot_states) const;
 
     /// Things to do immediately after restart from checkpoint
     virtual void postRestart() {}


### PR DESCRIPTION
This allows loading of strings of variable names from the parameter file
to the correct var enum number. As an example, parameters to choose the
variables in plot files have been added. This resolves #104.