### PR TITLE
Add ADM Mass / Spin and Extrapolation to Infinity

### DIFF
--- a/Examples/KerrBH/KerrBHLevel.hpp
+++ b/Examples/KerrBH/KerrBHLevel.hpp
@@ -34,6 +34,9 @@ class KerrBHLevel : public GRAMRLevel
                                    const GRLevelData &a_rhs,
                                    Real a_dt) override;
 
+    // to do post each time step on every level
+    virtual void specificPostTimeStep() override;
+
     virtual void
     computeTaggingCriterion(FArrayBox &tagging_criterion,
                             const FArrayBox &current_state) override;

--- a/Examples/KerrBH/Main_KerrBH.cpp
+++ b/Examples/KerrBH/Main_KerrBH.cpp
@@ -30,6 +30,15 @@ int runGRChombo(int argc, char *argv[])
     DefaultLevelFactory<KerrBHLevel> kerr_bh_level_fact(gr_amr, sim_params);
     setupAMRObject(gr_amr, kerr_bh_level_fact);
 
+    // Set up interpolator:
+    // call this after amr object setup so grids known
+    // and need it to stay in scope throughout run
+    // Note: 'interpolator' needs to be in scope when gr_amr.run() is called,
+    // otherwise pointer is lost
+    AMRInterpolator<Lagrange<4>> interpolator(
+        gr_amr, sim_params.origin, sim_params.dx, sim_params.verbosity);
+    gr_amr.set_interpolator(&interpolator);
+
     double stop_time;
     pp.get("stop_time", stop_time);
     int max_steps;
@@ -38,6 +47,8 @@ int runGRChombo(int argc, char *argv[])
     gr_amr.run(stop_time, max_steps);
 
     gr_amr.conclude();
+
+    CH_TIMER_REPORT(); // Report results when running with Chombo timers.
 
     return 0;
 }

--- a/Examples/KerrBH/SimulationParameters.hpp
+++ b/Examples/KerrBH/SimulationParameters.hpp
@@ -28,10 +28,13 @@ class SimulationParameters : public SimulationParametersBase
         // Initial Kerr data
         pp.load("kerr_mass", kerr_params.mass);
         pp.load("kerr_spin", kerr_params.spin);
-        pp.load("kerr_center", kerr_params.center, {0.5 * L, 0.5 * L, 0.5 * L});
+        pp.load("kerr_center", kerr_params.center, center);
+
+        pp.load("activate_extraction", activate_extraction, false);
     }
 
     KerrBH::params_t kerr_params;
+    bool activate_extraction;
 };
 
 #endif /* SIMULATIONPARAMETERS_HPP_ */

--- a/Examples/KerrBH/UserVariables.hpp
+++ b/Examples/KerrBH/UserVariables.hpp
@@ -49,6 +49,9 @@ enum
     c_Mom2,
     c_Mom3,
 
+    c_Madm,
+    c_Jadm,
+
     NUM_VARS
 };
 
@@ -57,11 +60,11 @@ namespace UserVariables
 static constexpr char const *variable_names[NUM_VARS] = {
     "chi",
 
-    "h11",    "h12",    "h13",    "h22", "h23", "h33",
+    "h11",    "h12",    "h13",    "h22",  "h23", "h33",
 
     "K",
 
-    "A11",    "A12",    "A13",    "A22", "A23", "A33",
+    "A11",    "A12",    "A13",    "A22",  "A23", "A33",
 
     "Theta",
 
@@ -73,7 +76,9 @@ static constexpr char const *variable_names[NUM_VARS] = {
 
     "B1",     "B2",     "B3",
 
-    "Ham",    "Mom1",   "Mom2",   "Mom3"};
+    "Ham",    "Mom1",   "Mom2",   "Mom3",
+
+    "M_adm",  "J_adm"};
 }
 
 #endif /* USERVARIABLES_HPP */

--- a/Examples/KerrBH/params_cheap.txt
+++ b/Examples/KerrBH/params_cheap.txt
@@ -1,0 +1,108 @@
+#Params for runtime inputs
+
+verbosity = 0
+chk_prefix = KerrBH_
+plot_prefix = KerrBHp_
+#restart_file = KerrBH_000060.3d.hdf5
+
+# NB - the N values need to be multiples of block_factor
+N1 = 64
+N2 = 64
+N3 = 64
+L = 128
+
+# Params for Kerr BH
+kerr_mass = 1.0
+kerr_spin = 0.3
+# This is now defaulted to center of the grid so it does not need to be updated
+# when changing L (unless one wants to put the BH somewhere off center)
+#kerr_center = 64 64 64
+
+# Regridding
+# Thresholds on the change across a cell which prompts regrid
+regrid_threshold = 0.2
+
+# Level data
+# Maximum number of times you can regrid above coarsest level
+max_level = 3 #4 There are (max_level+1) grids, so min is zero
+# Frequency of regridding at each level
+# Need one for each level, ie max_level+1 items
+# Generally you do not need to regrid frequently on every level
+regrid_interval = 50 25 5 5 5 5 5
+# Max box sizes
+max_grid_size = 16
+# Min box size
+block_factor = 16
+# Determines how exactly regridding tries to fit the tagging
+fill_ratio = 0.75
+
+#boundaries and periodicity of grid
+#Periodic directions - 0 = false, 1 = true
+isPeriodic = 0 0 0
+# if not periodic, then specify the boundary type
+# 0 = static, 1 = sommerfeld, 2 = reflective
+# (see BoundaryConditions.hpp for details)
+hi_boundary = 1 1 1
+lo_boundary = 1 1 1
+
+# if reflective boundaries selected, must set
+# parity of all vars (in order given by UserVariables.hpp)
+# 0 = even
+# 1,2,3 = odd x, y, z
+# 4,5,6 = odd xy, yz, xz
+vars_parity            = 0 0 4 6 0 5 0    #chi and hij
+                         0 0 4 6 0 5 0    #K and Aij
+                         0 1 2 3          #Theta and Gamma
+                         0 1 2 3 1 2 3    #lapse shift and B
+                         0 1 2 3          #Ham and Mom
+                         0 0              #ADM M and J
+
+# if sommerfeld boundaries selected, must select 
+# asymptotic values (in order given by UserVariables.hpp)
+vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
+                         0.0 0.0 0.0 0.0 0.0 0.0 0.0 #K and Aij
+                         0.0 0.0 0.0 0.0             #Theta and Gamma
+                         1.0 0.0 0.0 0.0 0.0 0.0 0.0 #lapse shift and B
+                         0.0 0.0 0.0 0.0             #Ham and Mom
+                         0.0 0.0                     #ADM M and J (wrong for J, but not necessary)
+
+# Set up time steps
+# dt will be dx*dt_multiplier on each grid level
+# HDF5files are written every dt = L/N*dt_multiplier*checkpoint_interval
+checkpoint_interval = 50
+plot_interval = 10
+num_plot_vars = 6
+plot_vars = chi K lapse shift1 M_adm J_adm
+dt_multiplier = 0.25
+stop_time = 10.0
+max_steps = 2
+
+#Lapse evolution
+lapse_power = 1.0
+lapse_coeff = 2.0
+lapse_advec_coeff = 1 # 1 makes the lapse gauge 1+log slicing
+
+# Shift evolution coefficients
+shift_advec_coeff = 0 # Usually no advection for beta
+shift_Gamma_coeff = 0.75 # 
+eta = 1.0 # This is beta_driver, usually of order 1/M_ADM of spacetime
+
+# CCZ4 parameters
+# if using BSSN the kappa values should be zero
+formulation = 1  # 1 for BSSN, 0 for CCZ4
+kappa1 = 0
+kappa2 = 0
+kappa3 = 0
+covariantZ4 = 0 # 0: default. 1: dampk1 -> dampk1/lapse
+
+# coefficient for KO numerical dissipation
+# NB must be less than 0.5 for stability
+sigma = 0.3
+
+#extraction params
+activate_extraction = 1
+num_extraction_radii = 3
+extraction_radii = 30. 40. 50.
+extraction_levels = 1 1 0
+num_points_phi = 50
+num_points_theta = 52

--- a/Source/AMRInterpolator/SurfaceExtraction.impl.hpp
+++ b/Source/AMRInterpolator/SurfaceExtraction.impl.hpp
@@ -324,9 +324,18 @@ template <class SurfaceGeometry>
 void SurfaceExtraction<SurfaceGeometry>::write_integrals(
     const std::string &a_filename,
     const std::vector<std::vector<double>> &a_integrals,
-    const std::vector<std::string> &a_labels) const
+    const std::vector<std::string> &a_labels, int extrapolation_order) const
 {
+    std::vector<double> extrapolations;
+    if (extrapolation_order)
+    {
+        extrapolations =
+            richardson_extrapolation(a_integrals, extrapolation_order);
+    }
+
     const int num_integrals_per_surface = a_integrals.size();
+    const int total_num_surfaces =
+        m_params.num_surfaces + (extrapolation_order > 0 ? 1 : 0);
     // if labels are provided there must be the same number of labels as
     // there are integrals
     if (!a_labels.empty())
@@ -350,13 +359,14 @@ void SurfaceExtraction<SurfaceGeometry>::write_integrals(
     {
         // make header strings
         std::vector<std::string> header1_strings(num_integrals_per_surface *
-                                                 m_params.num_surfaces);
+                                                 total_num_surfaces);
         std::vector<std::string> header2_strings(num_integrals_per_surface *
-                                                 m_params.num_surfaces);
-        for (int isurface = 0; isurface < m_params.num_surfaces; ++isurface)
+                                                 total_num_surfaces);
+
+        for (int iintegral = 0; iintegral < num_integrals_per_surface;
+             ++iintegral)
         {
-            for (int iintegral = 0; iintegral < num_integrals_per_surface;
-                 ++iintegral)
+            for (int isurface = 0; isurface < m_params.num_surfaces; ++isurface)
             {
                 int idx = isurface * num_integrals_per_surface + iintegral;
                 if (a_labels.empty())
@@ -365,6 +375,13 @@ void SurfaceExtraction<SurfaceGeometry>::write_integrals(
                     header1_strings[idx] = a_labels[iintegral];
                 header2_strings[idx] =
                     std::to_string(m_params.surface_param_values[isurface]);
+            }
+            if (extrapolation_order)
+            {
+                int idx = m_params.num_surfaces * num_integrals_per_surface +
+                          iintegral;
+                header1_strings[idx] = a_labels[iintegral];
+                header2_strings[idx] = "Infinity";
             }
         }
         std::string pre_header2_string = m_geom.param_name() + " = ";
@@ -376,14 +393,20 @@ void SurfaceExtraction<SurfaceGeometry>::write_integrals(
 
     // make vector of data for writing
     std::vector<double> data_for_writing(num_integrals_per_surface *
-                                         m_params.num_surfaces);
-    for (int isurface = 0; isurface < m_params.num_surfaces; ++isurface)
+                                         total_num_surfaces);
+
+    for (int iintegral = 0; iintegral < num_integrals_per_surface; ++iintegral)
     {
-        for (int iintegral = 0; iintegral < num_integrals_per_surface;
-             ++iintegral)
+        for (int isurface = 0; isurface < m_params.num_surfaces; ++isurface)
         {
             int idx = isurface * num_integrals_per_surface + iintegral;
             data_for_writing[idx] = a_integrals[iintegral][isurface];
+        }
+        if (extrapolation_order)
+        {
+            int idx =
+                m_params.num_surfaces * num_integrals_per_surface + iintegral;
+            data_for_writing[idx] = extrapolations[iintegral];
         }
     }
 
@@ -396,16 +419,67 @@ void SurfaceExtraction<SurfaceGeometry>::write_integrals(
 template <class SurfaceGeometry>
 void SurfaceExtraction<SurfaceGeometry>::write_integral(
     const std::string &a_filename, const std::vector<double> a_integrals,
-    const std::string a_label) const
+    const std::string a_label, int extrapolation_order) const
 {
     std::vector<std::vector<double>> integrals(1, a_integrals);
     if (!a_label.empty())
     {
         std::vector<std::string> labels(1, a_label);
-        write_integrals(a_filename, integrals, labels);
+        write_integrals(a_filename, integrals, labels, extrapolation_order);
     }
     else
-        write_integrals(a_filename, integrals);
+        write_integrals(a_filename, integrals, extrapolation_order);
+}
+
+// function to apply richardson extrapolation of 1st or 2nd order to calculated
+// integrals
+template <class SurfaceGeometry>
+std::vector<double>
+SurfaceExtraction<SurfaceGeometry>::richardson_extrapolation(
+    const std::vector<std::vector<double>> &integrals,
+    int extrapolation_order) const
+{
+    CH_TIME("SurfaceExtraction::richardson_extrapolation");
+    int num_comps = integrals.size();
+    int num_surfaces = m_params.num_surfaces;
+    CH_assert(extrapolation_order <= 2 && extrapolation_order >= 0);
+
+    std::vector<double> extrapolations(num_comps);
+
+    if (num_surfaces >= 3 && extrapolation_order == 2)
+    {
+        for (int icomp = 0; icomp < num_comps; ++icomp)
+        {
+            int i1 = num_surfaces - 1;
+            int i2 = num_surfaces - 2;
+            int i3 = num_surfaces - 3;
+            double r1 = m_params.surface_param_values[i1];
+            double r2 = m_params.surface_param_values[i2];
+            double r3 = m_params.surface_param_values[i3];
+            double c2 = r2 / r1 * (1. - r3 / r1) / (1. - r3 / r2);
+            double c3 = -r3 / r1 * (1. - r2 / r1) / (r2 / r3 - 1.);
+            double comp_inf =
+                (integrals[icomp][i1] - c2 * integrals[icomp][i2] -
+                 c3 * integrals[icomp][i3]) /
+                (1. - c2 - c3);
+            extrapolations[icomp] = comp_inf;
+        }
+    }
+    else if (num_surfaces >= 2 && extrapolation_order >= 1)
+    {
+        for (int icomp = 0; icomp < num_comps; ++icomp)
+        {
+            int i1 = num_surfaces - 1;
+            int i2 = num_surfaces - 2;
+            double r1 = m_params.surface_param_values[i1];
+            double r2 = m_params.surface_param_values[i2];
+            double comp_inf =
+                (integrals[icomp][i1] - r2 / r1 * integrals[icomp][i2]) /
+                (1. - r2 / r1);
+            extrapolations[icomp] = comp_inf;
+        }
+    }
+    return extrapolations;
 }
 
 #endif /* SURFACEEXTRACTION_IMPL_HPP_ */

--- a/Source/CCZ4/ADMMass.hpp
+++ b/Source/CCZ4/ADMMass.hpp
@@ -1,0 +1,126 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef ADMMASS_HPP_
+#define ADMMASS_HPP_
+
+#include "ADMConformalVars.hpp"
+#include "CCZ4Geometry.hpp"
+#include "Cell.hpp"
+#include "Coordinates.hpp"
+#include "FourthOrderDerivatives.hpp"
+#include "GRInterval.hpp"
+#include "Tensor.hpp"
+#include "TensorAlgebra.hpp"
+#include "UserVariables.hpp" //This files needs NUM_VARS - total number of components
+#include "VarsTools.hpp"
+#include "simd.hpp"
+
+//! Calculates the ADM massa
+class ADMMass
+{
+    // Use the variable definition in ADMConformalVars - only require the key
+    // vars
+    template <class data_t> using Vars = ADMConformalVars::VarsNoGauge<data_t>;
+
+    template <class data_t>
+    using Diff1Vars = ADMConformalVars::Diff2VarsNoGauge<data_t>;
+
+  public:
+    enum DIR
+    {
+        NONE,
+        X,
+        Y,
+        Z
+    };
+
+    ADMMass(const std::array<double, CH_SPACEDIM> &a_center, double a_dx,
+            DIR spin_direction = Z, double a_G_Newton = 1.0)
+        : m_deriv(a_dx), m_center(a_center), m_G_Newton(a_G_Newton),
+          dir(spin_direction)
+    {
+    }
+
+    template <class data_t> void compute(Cell<data_t> current_cell) const
+    {
+        // copy data from chombo gridpoint into local variables, and calc 1st
+        // derivs
+        const auto vars = current_cell.template load_vars<Vars>();
+        const auto d1 = m_deriv.template diff1<Diff1Vars>(current_cell);
+
+        using namespace TensorAlgebra;
+        const auto h_UU = compute_inverse_sym(vars.h);
+
+        // Surface element for integration
+        Coordinates<data_t> coords(current_cell, m_deriv.m_dx, m_center);
+        data_t r = coords.get_radius();
+        Tensor<1, data_t> x = {coords.x, coords.y, coords.z};
+        // This is multiplied by r^2 as SphericalExtraction assumes it is
+        // normalised as such.
+        Tensor<1, data_t> dS_U = x;
+
+        data_t dS_norm = 0.;
+        FOR2(i, j) { dS_norm += vars.h[i][j] / vars.chi * dS_U[i] * dS_U[j]; }
+        dS_norm = sqrt(dS_norm);
+        FOR1(i) { dS_U[i] /= dS_norm; }
+
+        Tensor<1, data_t> dS_L;
+        FOR1(i)
+        {
+            // dS_L[i] = dS_U[i];
+            dS_L[i] = 0.;
+            FOR1(j) { dS_L[i] += vars.h[i][j] / vars.chi * dS_U[j]; }
+        }
+
+        data_t Madm = 0.0;
+        FOR4(i, j, k, l)
+        {
+            Madm += dS_L[i] / (16. * M_PI * m_G_Newton) * pow(vars.chi, -1.5) *
+                    h_UU[j][k] * h_UU[i][l] *
+                    (vars.chi * (d1.h[l][k][j] - d1.h[j][k][l]) -
+                     (vars.h[l][k] * d1.chi[j] - vars.h[j][k] * d1.chi[l]));
+        }
+
+        // assign values of ADMMass in output box
+        current_cell.store_vars(Madm, c_Madm);
+
+        if (dir == NONE)
+            return;
+
+        // spin about z axis
+        data_t Jadm = 0.0;
+
+        // note this is the levi civita symbol,
+        // not tensor (eps_tensor = eps_symbol * chi^-1.5)
+        const Tensor<3, double> epsilon = TensorAlgebra::epsilon();
+
+        FOR3(i, j, k)
+        {
+            Jadm += -dS_L[i] / (8. * M_PI * m_G_Newton) *
+                    epsilon[dir - 1][j][k] * x[j] * vars.K *
+                    TensorAlgebra::delta(i, k);
+
+            FOR2(l, m)
+            {
+                Jadm += dS_L[i] / (8. * M_PI * m_G_Newton) *
+                        epsilon[dir - 1][j][k] * x[j] * h_UU[i][l] *
+                        h_UU[k][m] * vars.chi *
+                        (vars.A[l][m] + vars.K * vars.h[l][m] / 3.);
+            }
+        }
+        current_cell.store_vars(Jadm, c_Jadm);
+    }
+
+  protected:
+    const FourthOrderDerivatives
+        m_deriv; //!< An object for calculating derivatives of the variables
+    const std::array<double, CH_SPACEDIM> &m_center;
+    const double m_G_Newton; //!< Newton's constant
+
+    DIR dir;
+};
+
+#endif /* ADMMASS_HPP_ */

--- a/Source/utils/ADMMassExtraction.hpp
+++ b/Source/utils/ADMMassExtraction.hpp
@@ -1,0 +1,77 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef ADMMASSEXTRACTION_HPP_
+#define ADMMASSEXTRACTION_HPP_
+
+#include "SphericalExtraction.hpp"
+//!  The class allows extraction of the values of the ADM mass and angular
+//!  momentum over spherical shells at specified radii, and integration over
+//!  those shells
+/*!
+   The class allows the user to extract data from the grid for the ADM mass and
+   angular momentum over spherical shells at specified radii. The values may
+   then be written to an output file, or integrated across the surfaces.
+*/
+class ADMMassExtraction : public SphericalExtraction
+{
+  public:
+    //! The constructor
+    ADMMassExtraction(SphericalExtraction::params_t &a_params, double a_dt,
+                      double a_time, bool a_first_step,
+                      double a_restart_time = 0.0, bool a_extract_J = true)
+        : SphericalExtraction(a_params, a_dt, a_time, a_first_step,
+                              a_restart_time),
+          extract_J(a_extract_J)
+    {
+        add_var(c_Madm);
+        if (extract_J)
+            add_var(c_Jadm);
+    }
+
+    //! The old constructor which assumes it is called in specificPostTimeStep
+    //! so the first time step is when m_time == m_dt
+    ADMMassExtraction(SphericalExtraction::params_t a_params, double a_dt,
+                      double a_time, double a_restart_time = 0.0,
+                      bool a_extract_J = true)
+        : ADMMassExtraction(a_params, a_dt, a_time, (a_dt == a_time),
+                            a_restart_time, a_extract_J)
+    {
+    }
+
+    //! Execute the query
+    void execute_query(AMRInterpolator<Lagrange<4>> *a_interpolator)
+    {
+        // extract the values of the Weyl scalars on the spheres
+        extract(a_interpolator);
+
+        if (m_params.write_extraction)
+        {
+            write_extraction("Weyl4ExtractionOut_");
+        }
+
+        // now calculate and write the requested spherical harmonic modes
+        std::vector<std::vector<double>> out_integrals(1 + extract_J);
+
+        add_var_integrand(0, out_integrals[0], IntegrationMethod::simpson);
+        if (extract_J)
+            add_var_integrand(1, out_integrals[1], IntegrationMethod::simpson);
+
+        // do the integration over the surface
+        integrate();
+        int extrapolation_order = 2;
+        std::vector<std::string> labels(1 + extract_J);
+        labels[0] = "M_adm";
+        if (extract_J)
+            labels[1] = "J_adm";
+        write_integrals("IntegralADMmass", out_integrals, labels,
+                        extrapolation_order);
+    }
+
+  private:
+    bool extract_J;
+};
+
+#endif /* ADMMASSEXTRACTION_HPP_ */


### PR DESCRIPTION
Addition of a class `ADMMass` that calculates the ADM mass and spin of a spacetime, together with a class `ADMMassExtraction` that extracts the corresponding variables.

This partially solves #90 , and will have to be changed once diagnostics are added. #90 also includes the Kretschmann scalar and such variables, but that's in my opinion a feature to be added separately.

This PR also includes Extrapolation to infinity of first and second order. First order is in Alcubierre. Second order I wrote some notes about it, as I didn't find it elsewhere and made the computation myself. Second order (requires 3 radii to cancel leading terms of order 1/r AND 1/r^2) greatly improves the result, so it must be correct.

I added this extraction to the Kerr example, as it's a neat place for it to be. For a Kerr BH with `Mass=1.0` and `Spin=0.3` I managed to get in my laptop a quick extraction that with 2nd order extraction to infinity results in `M=1.0000609955` and `a=0.29994697676`, which looks pretty good to me. I used `N=64`, `L=128`, extraction radii at `r = (30. 40. 50.)` at levels `(1 1 0)`. The simpson method of @mirenradia's SurfaceExtraction also greatly helps this. Other methods (except for boole rule) or first order extraction get slightly worse results, but still converge.

ADM extraction has some ambiguity in terms of what factors of chi should be added. In principle it doesn't matter. I tested that indeed it doesn't matter much, once extrapolation is done. So I added them trying to follow standard calculations, but it is open for review.