### PR TITLE
Refactor UserVariables

### DIFF
--- a/Examples/BinaryBH/UserVariables.hpp
+++ b/Examples/BinaryBH/UserVariables.hpp
@@ -6,45 +6,15 @@
 #ifndef USERVARIABLES_HPP
 #define USERVARIABLES_HPP
 
+#include "ArrayTools.hpp"
+#include "CCZ4UserVariables.hpp"
+
 /// This enum gives the index of every variable stored in the grid
 enum
 {
-    c_chi,
-
-    c_h11, // Symmetric tensor must be declared in this order TODO: make this
-           // error proof by autogeneration or a macro.
-    c_h12,
-    c_h13,
-    c_h22,
-    c_h23,
-    c_h33,
-
-    c_K,
-
-    c_A11,
-    c_A12,
-    c_A13,
-    c_A22,
-    c_A23,
-    c_A33,
-
-    c_Theta,
-
-    c_Gamma1,
-    c_Gamma2,
-    c_Gamma3,
-
-    c_lapse,
-
-    c_shift1,
-    c_shift2,
-    c_shift3,
-
-    c_B1,
-    c_B2,
-    c_B3,
-
-    c_Ham,
+    // Note that it is important that the first enum value is set to 1 more than
+    // the last CCZ4 var enum
+    c_Ham = NUM_CCZ4_VARS,
 
     c_Mom1,
     c_Mom2,
@@ -58,30 +28,17 @@ enum
 
 namespace UserVariables
 {
-static constexpr char const *variable_names[NUM_VARS] = {
-    "chi",
+static const std::array<std::string, NUM_VARS - NUM_CCZ4_VARS>
+    user_variable_names = {"Ham",
 
-    "h11",      "h12",     "h13",    "h22", "h23", "h33",
+                           "Mom1",     "Mom2",    "Mom3",
 
-    "K",
+                           "Weyl4_Re", "Weyl4_Im"};
 
-    "A11",      "A12",     "A13",    "A22", "A23", "A33",
+static const std::array<std::string, NUM_VARS> variable_names =
+    ArrayTools::concatenate(ccz4_variable_names, user_variable_names);
+} // namespace UserVariables
 
-    "Theta",
-
-    "Gamma1",   "Gamma2",  "Gamma3",
-
-    "lapse",
-
-    "shift1",   "shift2",  "shift3",
-
-    "B1",       "B2",      "B3",
-
-    "Ham",
-
-    "Mom1",     "Mom2",    "Mom3",
-
-    "Weyl4_Re", "Weyl4_Im"};
-}
+#include "UserVariables.inc.hpp"
 
 #endif /* USERVARIABLES_HPP */

--- a/Examples/KerrBH/UserVariables.hpp
+++ b/Examples/KerrBH/UserVariables.hpp
@@ -6,44 +6,15 @@
 #ifndef USERVARIABLES_HPP
 #define USERVARIABLES_HPP
 
-// Assign an enum to each variable
+#include "ArrayTools.hpp"
+#include "CCZ4UserVariables.hpp"
+
+/// This enum gives the index of every variable stored in the grid
 enum
 {
-    c_chi,
-
-    c_h11, // Symmetric tensor must be declared in this order
-    c_h12,
-    c_h13,
-    c_h22,
-    c_h23,
-    c_h33,
-
-    c_K,
-
-    c_A11,
-    c_A12,
-    c_A13,
-    c_A22,
-    c_A23,
-    c_A33,
-
-    c_Theta,
-
-    c_Gamma1,
-    c_Gamma2,
-    c_Gamma3,
-
-    c_lapse,
-
-    c_shift1,
-    c_shift2,
-    c_shift3,
-
-    c_B1,
-    c_B2,
-    c_B3,
-
-    c_Ham,
+    // Note that it is important that the first enum value is set to 1 more than
+    // the last CCZ4 var enum
+    c_Ham = NUM_CCZ4_VARS,
 
     c_Mom1,
     c_Mom2,
@@ -54,26 +25,15 @@ enum
 
 namespace UserVariables
 {
-static constexpr char const *variable_names[NUM_VARS] = {
-    "chi",
+static const std::array<std::string, NUM_VARS - NUM_CCZ4_VARS>
+    user_variable_names = {"Ham",
 
-    "h11",    "h12",    "h13",    "h22", "h23", "h33",
+                           "Mom1", "Mom2", "Mom3"};
 
-    "K",
+static const std::array<std::string, NUM_VARS> variable_names =
+    ArrayTools::concatenate(ccz4_variable_names, user_variable_names);
+} // namespace UserVariables
 
-    "A11",    "A12",    "A13",    "A22", "A23", "A33",
-
-    "Theta",
-
-    "Gamma1", "Gamma2", "Gamma3",
-
-    "lapse",
-
-    "shift1", "shift2", "shift3",
-
-    "B1",     "B2",     "B3",
-
-    "Ham",    "Mom1",   "Mom2",   "Mom3"};
-}
+#include "UserVariables.inc.hpp"
 
 #endif /* USERVARIABLES_HPP */

--- a/Examples/ScalarField/UserVariables.hpp
+++ b/Examples/ScalarField/UserVariables.hpp
@@ -6,45 +6,16 @@
 #ifndef USERVARIABLES_HPP
 #define USERVARIABLES_HPP
 
+#include "ArrayTools.hpp"
+#include "CCZ4UserVariables.hpp"
+
 // assign an enum to each variable
 enum
 {
-    c_chi,
-
-    c_h11,
-    c_h12,
-    c_h13,
-    c_h22,
-    c_h23,
-    c_h33,
-
-    c_K,
-
-    c_A11,
-    c_A12,
-    c_A13,
-    c_A22,
-    c_A23,
-    c_A33,
-
-    c_Theta,
-
-    c_Gamma1,
-    c_Gamma2,
-    c_Gamma3,
-
-    c_lapse,
-
-    c_shift1,
-    c_shift2,
-    c_shift3,
-
-    c_B1,
-    c_B2,
-    c_B3,
-
-    c_phi, // matter field added
-    c_Pi,  //(minus) conjugate momentum
+    // Note that it is important that the first enum value is set to 1 more than
+    // the last CCZ4 var enum
+    c_phi = NUM_CCZ4_VARS, // matter field added
+    c_Pi,                  //(minus) conjugate momentum
 
     c_Ham,
 
@@ -57,28 +28,15 @@ enum
 
 namespace UserVariables
 {
-static constexpr char const *variable_names[NUM_VARS] = {
-    "chi",
+static const std::array<std::string, NUM_VARS - NUM_CCZ4_VARS>
+    user_variable_names = {"phi", "Pi",
 
-    "h11",    "h12",    "h13",    "h22", "h23", "h33",
+                           "Ham", "Mom1", "Mom2", "Mom3"};
 
-    "K",
+static const std::array<std::string, NUM_VARS> variable_names =
+    ArrayTools::concatenate(ccz4_variable_names, user_variable_names);
+} // namespace UserVariables
 
-    "A11",    "A12",    "A13",    "A22", "A23", "A33",
-
-    "Theta",
-
-    "Gamma1", "Gamma2", "Gamma3",
-
-    "lapse",
-
-    "shift1", "shift2", "shift3",
-
-    "B1",     "B2",     "B3",
-
-    "phi",    "Pi",
-
-    "Ham",    "Mom1",   "Mom2",   "Mom3"};
-}
+#include "UserVariables.inc.hpp"
 
 #endif /* USERVARIABLES_HPP */

--- a/Source/CCZ4/CCZ4UserVariables.hpp
+++ b/Source/CCZ4/CCZ4UserVariables.hpp
@@ -1,0 +1,76 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef CCZ4VARIABLES_HPP
+#define CCZ4VARIABLES_HPP
+
+#include <algorithm>
+#include <array>
+#include <string>
+
+/// This enum gives the index of the CCZ4 variables on the grid
+enum
+{
+    c_chi,
+
+    c_h11,
+    c_h12,
+    c_h13,
+    c_h22,
+    c_h23,
+    c_h33,
+
+    c_K,
+
+    c_A11,
+    c_A12,
+    c_A13,
+    c_A22,
+    c_A23,
+    c_A33,
+
+    c_Theta,
+
+    c_Gamma1,
+    c_Gamma2,
+    c_Gamma3,
+
+    c_lapse,
+
+    c_shift1,
+    c_shift2,
+    c_shift3,
+
+    c_B1,
+    c_B2,
+    c_B3,
+
+    NUM_CCZ4_VARS
+};
+
+namespace UserVariables
+{
+static const std::array<std::string, NUM_CCZ4_VARS> ccz4_variable_names = {
+    "chi",
+
+    "h11",    "h12",    "h13",    "h22", "h23", "h33",
+
+    "K",
+
+    "A11",    "A12",    "A13",    "A22", "A23", "A33",
+
+    "Theta",
+
+    "Gamma1", "Gamma2", "Gamma3",
+
+    "lapse",
+
+    "shift1", "shift2", "shift3",
+
+    "B1",     "B2",     "B3",
+};
+} // namespace UserVariables
+
+#endif /* CCZ4VARIABLES_HPP */

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -143,6 +143,8 @@ class ChomboParameters
         pp.load("plot_vars", plot_var_names, num_plot_vars, plot_var_names);
         for (std::string var_name : plot_var_names)
         {
+            // TODO: replace with UserVariables::variable_name_to_enum in
+            // UserVariables.inc.hpp
             int var = variable_name_to_enum(var_name);
             if (var >= 0 && var < NUM_VARS)
             {
@@ -171,17 +173,19 @@ class ChomboParameters
         }
     }
 
+    // TODO: Remove this function
+    // (Kept here for temporary backwards compatibility)
     /// Takes a string and returns the variable enum number if the string
     /// matches one of those in UserVariables::variable_names, or returns -1
     /// otherwise
-    int variable_name_to_enum(const std::string &a_var_name)
+    static int variable_name_to_enum(const std::string &a_var_name)
     {
         using namespace UserVariables;
 
-        // std::find did not work very well with the char const* array type of
-        // UserVariables::variable_names so here convert to a
-        // std::array of std::strings first. This is quite inefficient but this
-        // function isn't used much so doesn't matter.
+        // std::find did not work very well with the old char const* array type
+        // of UserVariables::variable_names so here convert to a std::array of
+        // std::strings first. This is quite inefficient but this function isn't
+        // used much so doesn't matter.
         std::array<std::string, NUM_VARS> variable_names_array;
         for (int ivar = 0; ivar < NUM_VARS; ++ivar)
         {

--- a/Source/GRChomboCore/UserVariables.inc.hpp
+++ b/Source/GRChomboCore/UserVariables.inc.hpp
@@ -1,0 +1,43 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#if !defined(USERVARIABLES_HPP)
+#error "This file should only be included through UserVariables.hpp"
+#endif
+
+#ifndef USERVARIABLES_INC_HPP
+#define USERVARIABLES_INC_HPP
+
+#include "parstream.H"
+#include <algorithm>
+#include <array>
+#include <string>
+
+// This file must be included at the end of UserVariables.hpp
+
+namespace UserVariables
+{
+/// Takes a string and returns the variable enum number if the string
+/// matches one of those in UserVariables::variable_names, or returns -1
+/// otherwise
+static int variable_name_to_enum(const std::string &a_var_name)
+{
+    const auto var_name_it =
+        std::find(variable_names.begin(), variable_names.end(), a_var_name);
+
+    int var = std::distance(variable_names.begin(), var_name_it);
+    if (var != NUM_VARS)
+        return var;
+    else
+    {
+        pout() << "Variable with name " << a_var_name << " not found."
+               << std::endl;
+        return -1;
+    }
+}
+
+}; // namespace UserVariables
+
+#endif /* USERVARIABLES_INC_HPP_ */

--- a/Source/utils/ArrayTools.hpp
+++ b/Source/utils/ArrayTools.hpp
@@ -1,0 +1,29 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef ARRAYTOOLS_HPP
+#define ARRAYTOOLS_HPP
+
+#include <algorithm>
+#include <array>
+
+/// A place for tools that operate on std::arrays
+namespace ArrayTools
+{
+/// This just concantenates two arrays together.
+/// MR: I have no idea why this or something similar isn't in the standard
+/// library
+template <typename T, size_t N, size_t M>
+std::array<T, N + M> concatenate(const std::array<T, N> &first,
+                                 const std::array<T, M> &second)
+{
+    std::array<T, N + M> out;
+    std::copy(first.cbegin(), first.cend(), out.begin());
+    std::copy(second.cbegin(), second.cend(), out.begin() + N);
+    return out;
+}
+} // namespace ArrayTools
+
+#endif /* ARRAYTOOLS_HPP */

--- a/Tests/BasicAMRInterpolatorTest/UserVariables.hpp
+++ b/Tests/BasicAMRInterpolatorTest/UserVariables.hpp
@@ -6,6 +6,9 @@
 #ifndef USERVARIABLES_HPP
 #define USERVARIABLES_HPP
 
+#include <array>
+#include <string>
+
 // assign enum to each variable
 enum
 {
@@ -17,7 +20,9 @@ enum
 
 namespace UserVariables
 {
-static constexpr char const *variable_names[NUM_VARS] = {"chi", "phi"};
+static const std::array<std::string, NUM_VARS> variable_names = {"chi", "phi"};
 }
+
+#include "UserVariables.inc.hpp"
 
 #endif /* USERVARIABLES_HPP */

--- a/Tests/CppChFComparison/UserVariables.hpp
+++ b/Tests/CppChFComparison/UserVariables.hpp
@@ -3,74 +3,28 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-#ifndef USERVARIABLES_HPP_
-#define USERVARIABLES_HPP_
+#ifndef USERVARIABLES_HPP
+#define USERVARIABLES_HPP
+
+#include "CCZ4UserVariables.hpp"
+#include <array>
+#include <string>
 
 enum
 {
-    c_chi,
+    c_h = c_h11,
+    c_A = c_A11,
+    c_Gamma = c_Gamma1,
+    c_shift = c_shift1,
+    c_B = c_B1,
 
-    c_h,
-    c_h11 = c_h,
-    c_h12,
-    c_h13,
-    c_h22,
-    c_h23,
-    c_h33,
-
-    c_K,
-
-    c_A,
-    c_A11 = c_A,
-    c_A12,
-    c_A13,
-    c_A22,
-    c_A23,
-    c_A33,
-
-    c_Theta,
-
-    c_Gamma,
-    c_Gamma1 = c_Gamma,
-    c_Gamma2,
-    c_Gamma3,
-
-    c_lapse,
-
-    c_shift,
-    c_shift1 = c_shift,
-    c_shift2,
-    c_shift3,
-
-    c_B,
-    c_B1 = c_B,
-    c_B2,
-    c_B3,
-
-    NUM_VARS
+    NUM_VARS = NUM_CCZ4_VARS
 };
 
 namespace UserVariables
 {
-static constexpr char const *variable_names[NUM_VARS] = {
-    "chi",
-
-    "h11",    "h12",    "h13",    "h22", "h23", "h33",
-
-    "K",
-
-    "A11",    "A12",    "A13",    "A22", "A23", "A33",
-
-    "Theta",
-
-    "Gamma1", "Gamma2", "Gamma3",
-
-    "lapse",
-
-    "shift1", "shift2", "shift3",
-
-    "B1",     "B2",     "B3",
-};
+static const std::array<std::string, NUM_VARS> variable_names =
+    ccz4_variable_names;
 }
 
 #endif /* USERVARIABLES_HPP */

--- a/Tests/CppChFConstraintComparison/UserVariables.hpp
+++ b/Tests/CppChFConstraintComparison/UserVariables.hpp
@@ -3,51 +3,23 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-#ifndef USERVARIABLES_HPP_
-#define USERVARIABLES_HPP_
+#ifndef USERVARIABLES_HPP
+#define USERVARIABLES_HPP
 
+#include "ArrayTools.hpp"
+#include "CCZ4UserVariables.hpp"
+
+/// This enum gives the index of every variable stored in the grid
 enum
 {
-    c_chi,
-
-    c_h,
-    c_h11 = c_h,
-    c_h12,
-    c_h13,
-    c_h22,
-    c_h23,
-    c_h33,
-
-    c_K,
-
-    c_A,
-    c_A11 = c_A,
-    c_A12,
-    c_A13,
-    c_A22,
-    c_A23,
-    c_A33,
-
-    c_Theta,
-
-    c_Gamma,
-    c_Gamma1 = c_Gamma,
-    c_Gamma2,
-    c_Gamma3,
-
-    c_lapse,
-
-    c_shift,
-    c_shift1 = c_shift,
-    c_shift2,
-    c_shift3,
-
-    c_B,
-    c_B1 = c_B,
-    c_B2,
-    c_B3,
-
-    c_Ham,
+    c_h = c_h11,
+    c_A = c_A11,
+    c_Gamma = c_Gamma1,
+    c_shift = c_shift1,
+    c_B = c_B1,
+    // Note that it is important that the first enum value is set to 1 more than
+    // the last CCZ4 var enum
+    c_Ham = NUM_CCZ4_VARS,
 
     c_Mom,
     c_Mom1 = c_Mom,
@@ -59,26 +31,13 @@ enum
 
 namespace UserVariables
 {
-static constexpr char const *variable_names[NUM_VARS] = {
-    "chi",
+static const std::array<std::string, NUM_VARS - NUM_CCZ4_VARS>
+    user_variable_names = {"Ham",
 
-    "h11",    "h12",    "h13",    "h22", "h23", "h33",
+                           "Mom1", "Mom2", "Mom3"};
 
-    "K",
+static const std::array<std::string, NUM_VARS> variable_names =
+    ArrayTools::concatenate(ccz4_variable_names, user_variable_names);
+} // namespace UserVariables
 
-    "A11",    "A12",    "A13",    "A22", "A23", "A33",
-
-    "Theta",
-
-    "Gamma1", "Gamma2", "Gamma3",
-
-    "lapse",
-
-    "shift1", "shift2", "shift3",
-
-    "B1",     "B2",     "B3",
-
-    "Ham",    "Mom1",   "Mom2",   "Mom3"};
-}
-
-#endif /* USERVARIABLES_HPP_ */
+#endif /* USERVARIABLES_HPP */

--- a/Tests/DerivativeUnitTests/UserVariables.hpp
+++ b/Tests/DerivativeUnitTests/UserVariables.hpp
@@ -3,8 +3,11 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-#ifndef USERVARIABLES_HPP_
-#define USERVARIABLES_HPP_
+#ifndef USERVARIABLES_HPP
+#define USERVARIABLES_HPP
+
+#include <array>
+#include <string>
 
 enum
 {
@@ -19,8 +22,8 @@ enum
 
 namespace UserVariables
 {
-static constexpr char const *variable_names[NUM_VARS] = {
+static const std::array<std::string, NUM_VARS> variable_names = {
     "d1", "d2", "d2_mixed", "diss", "advec_up", "advec_down"};
 }
 
-#endif /* USERVARIABLES_HPP_ */
+#endif /* USERVARIABLES_HPP */

--- a/Tests/KclBssnTests/UserVariables.hpp
+++ b/Tests/KclBssnTests/UserVariables.hpp
@@ -6,49 +6,20 @@
 #ifndef USERVARIABLES_HPP
 #define USERVARIABLES_HPP
 
-// assign enum to each variable
+#include "ArrayTools.hpp"
+#include "CCZ4UserVariables.hpp"
+
+/// This enum gives the index of every variable stored in the grid
 enum
 {
-    c_chi,
-
-    c_h,
-    c_h11 = c_h,
-    c_h12,
-    c_h13,
-    c_h22,
-    c_h23,
-    c_h33,
-
-    c_K,
-
-    c_A,
-    c_A11 = c_A,
-    c_A12,
-    c_A13,
-    c_A22,
-    c_A23,
-    c_A33,
-
-    c_Theta,
-
-    c_Gamma,
-    c_Gamma1 = c_Gamma,
-    c_Gamma2,
-    c_Gamma3,
-
-    c_lapse,
-
-    c_shift,
-    c_shift1 = c_shift,
-    c_shift2,
-    c_shift3,
-
-    c_B,
-    c_B1 = c_B,
-    c_B2,
-    c_B3,
-
-    c_phi,
+    c_h = c_h11,
+    c_A = c_A11,
+    c_Gamma = c_Gamma1,
+    c_shift = c_shift1,
+    c_B = c_B1,
+    // Note that it is important that the first enum value is set to 1 more than
+    // the last CCZ4 var enum
+    c_phi = NUM_CCZ4_VARS,
     c_Pi,
 
     c_chi2,
@@ -65,32 +36,17 @@ enum
 
 namespace UserVariables
 {
-static constexpr char const *variable_names[NUM_VARS] = {
-    "chi",
+static const std::array<std::string, NUM_VARS - NUM_CCZ4_VARS>
+    user_variable_names = {"phi",  "Pi",
 
-    "h11",    "h12",    "h13",    "h22", "h23", "h33",
+                           "chi2",
 
-    "K",
+                           "Ham",
 
-    "A11",    "A12",    "A13",    "A22", "A23", "A33",
+                           "Mom1", "Mom2", "Mom3"};
 
-    "Theta",
-
-    "Gamma1", "Gamma2", "Gamma3",
-
-    "lapse",
-
-    "shift1", "shift2", "shift3",
-
-    "B1",     "B2",     "B3",
-
-    "phi",    "Pi",
-
-    "chi2",
-
-    "Ham",
-
-    "Mom1",   "Mom2",   "Mom3"};
-}
+static const std::array<std::string, NUM_VARS> variable_names =
+    ArrayTools::concatenate(ccz4_variable_names, user_variable_names);
+} // namespace UserVariables
 
 #endif /* USERVARIABLES_HPP */

--- a/Tests/KclWeyl4Test/UserVariables.hpp
+++ b/Tests/KclWeyl4Test/UserVariables.hpp
@@ -1,98 +1,48 @@
 #ifndef USERVARIABLES_HPP
 #define USERVARIABLES_HPP
 
+#include "ArrayTools.hpp"
+#include "CCZ4UserVariables.hpp"
+
 // TODO: This file can be auto-generated from a list of variable names
 // Also, we should probably scope this enum too...
 //
 enum
 {
+    c_h = c_h11,
+    c_A = c_A11,
+    c_Gamma = c_Gamma1,
+    c_shift = c_shift1,
+    c_B = c_B1,
 
-    c_Weyl4_Re,
-    c_Weyl4_Im,
-
-    c_chi,
-
-    c_h,
-    c_h11 = c_h,
-    c_h12,
-    c_h13,
-    c_h22,
-    c_h23,
-    c_h33,
-
-    c_K,
-
-    c_A,
-    c_A11 = c_A,
-    c_A12,
-    c_A13,
-    c_A22,
-    c_A23,
-    c_A33,
-
-    c_Theta,
-
-    c_Gamma,
-    c_Gamma1 = c_Gamma,
-    c_Gamma2,
-    c_Gamma3,
-
-    c_lapse,
-
-    c_shift,
-    c_shift1 = c_shift,
-    c_shift2,
-    c_shift3,
-
-    c_B,
-    c_B1 = c_B,
-    c_B2,
-    c_B3,
-
-    c_phi,
+    c_phi = NUM_CCZ4_VARS,
     c_Pi,
 
     c_Rho,
 
     c_chi2,
 
+    c_Weyl4_Re,
+    c_Weyl4_Im,
+
     NUM_VARS
 };
 
 namespace UserVariables
 {
-static constexpr char const *variable_names[NUM_VARS] = {
-    "ReWeyl4", "ImWeyl4",
+static const std::array<std::string, NUM_VARS - NUM_CCZ4_VARS>
+    user_variable_names = {
 
-    "chi",
+        "phi",      "Pi",
 
-    "h11",     "h12",     "h13",    "h22", "h23", "h33",
+        "rho",
 
-    "K",
+        "chi2",
 
-    "A11",     "A12",     "A13",    "A22", "A23", "A33",
+        "Weyl4_Re", "Weyl4_Im"};
 
-    "Theta",
-
-    "Gamma1",  "Gamma2",  "Gamma3",
-
-    "lapse",
-
-    "shift1",  "shift2",  "shift3",
-
-    "B1",      "B2",      "B3",
-
-    "phi",     "Pi",
-
-    "rho",
-
-    "chi2"
-
-    //        "Ham",
-    //        "Mom1",
-    //        "Mom2",
-    //        "Mom3"
-};
-}
+static const std::array<std::string, NUM_VARS> variable_names =
+    ArrayTools::concatenate(ccz4_variable_names, user_variable_names);
+} // namespace UserVariables
 
 #endif /* USERVARIABLES_HPP */

--- a/Tests/PositiveChiAndAlphaUnitTest/UserVariables.hpp
+++ b/Tests/PositiveChiAndAlphaUnitTest/UserVariables.hpp
@@ -3,8 +3,11 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-#ifndef USERVARIABLES_HPP_
-#define USERVARIABLES_HPP_
+#ifndef USERVARIABLES_HPP
+#define USERVARIABLES_HPP
+
+#include <array>
+#include <string>
 
 enum
 {
@@ -15,10 +18,10 @@ enum
 
 namespace UserVariables
 {
-static constexpr char const *variable_names[NUM_VARS] = {
+static const std::array<std::string, NUM_VARS> variable_names = {
     "chi",
     "lapse",
 };
 }
 
-#endif /* USERVARIABLES_HPP_ */
+#endif /* USERVARIABLES_HPP */

--- a/Tests/SetValueUnitTest/GNUmakefile
+++ b/Tests/SetValueUnitTest/GNUmakefile
@@ -14,6 +14,7 @@ LibNames := BoxTools
 
 src_dirs := $(GRCHOMBO_SOURCE)/utils \
             $(GRCHOMBO_SOURCE)/simd \
-		   	$(GRCHOMBO_SOURCE)/BoxUtils
+            $(GRCHOMBO_SOURCE)/BoxUtils \
+            $(GRCHOMBO_SOURCE)/CCZ4
 
 include $(CHOMBO_HOME)/mk/Make.test

--- a/Tests/SetValueUnitTest/UserVariables.hpp
+++ b/Tests/SetValueUnitTest/UserVariables.hpp
@@ -6,44 +6,15 @@
 #ifndef USERVARIABLES_HPP
 #define USERVARIABLES_HPP
 
-// assign number to variables
+#include "ArrayTools.hpp"
+#include "CCZ4UserVariables.hpp"
+
+/// This enum gives the index of every variable stored in the grid
 enum
 {
-    c_chi,
-
-    c_h11, // Symmetric tensor must be declared in this order
-    c_h12,
-    c_h13,
-    c_h22,
-    c_h23,
-    c_h33,
-
-    c_K,
-
-    c_A11,
-    c_A12,
-    c_A13,
-    c_A22,
-    c_A23,
-    c_A33,
-
-    c_Theta,
-
-    c_Gamma1,
-    c_Gamma2,
-    c_Gamma3,
-
-    c_lapse,
-
-    c_shift1,
-    c_shift2,
-    c_shift3,
-
-    c_B1,
-    c_B2,
-    c_B3,
-
-    c_Ham,
+    // Note that it is important that the first enum value is set to 1 more than
+    // the last CCZ4 var enum
+    c_Ham = NUM_CCZ4_VARS,
 
     c_Mom1,
     c_Mom2,
@@ -54,26 +25,13 @@ enum
 
 namespace UserVariables
 {
-static constexpr char const *variable_names[NUM_VARS] = {
-    "chi",
+static const std::array<std::string, NUM_VARS - NUM_CCZ4_VARS>
+    user_variable_names = {"Ham",
 
-    "h11",    "h12",    "h13",    "h22", "h23", "h33",
+                           "Mom1", "Mom2", "Mom3"};
 
-    "K",
-
-    "A11",    "A12",    "A13",    "A22", "A23", "A33",
-
-    "Theta",
-
-    "Gamma1", "Gamma2", "Gamma3",
-
-    "lapse",
-
-    "shift1", "shift2", "shift3",
-
-    "B1",     "B2",     "B3",
-
-    "Ham",    "Mom1",   "Mom2",   "Mom3"};
-}
+static const std::array<std::string, NUM_VARS> variable_names =
+    ArrayTools::concatenate(ccz4_variable_names, user_variable_names);
+} // namespace UserVariables
 
 #endif /* USERVARIABLES_HPP */

--- a/Tests/SphericalExtractionTest/UserVariables.hpp
+++ b/Tests/SphericalExtractionTest/UserVariables.hpp
@@ -6,6 +6,9 @@
 #ifndef USERVARIABLES_HPP
 #define USERVARIABLES_HPP
 
+#include <array>
+#include <string>
+
 // assign enum to each variable
 enum
 {
@@ -17,7 +20,10 @@ enum
 
 namespace UserVariables
 {
-static constexpr char const *variable_names[NUM_VARS] = {"phi_Re", "phi_Im"};
+static const std::array<std::string, NUM_VARS> variable_names = {"phi_Re",
+                                                                 "phi_Im"};
 }
+
+#include "UserVariables.inc.hpp"
 
 #endif /* USERVARIABLES_HPP */

--- a/Tests/SphericalHarmonicTest/UserVariables.hpp
+++ b/Tests/SphericalHarmonicTest/UserVariables.hpp
@@ -3,8 +3,11 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-#ifndef USERVARIABLES_HPP_
-#define USERVARIABLES_HPP_
+#ifndef USERVARIABLES_HPP
+#define USERVARIABLES_HPP
+
+#include <array>
+#include <string>
 
 // assigns number to each variable
 enum
@@ -16,7 +19,7 @@ enum
 
 namespace UserVariables
 {
-static constexpr char const *variable_names[NUM_VARS] = {"phi"};
+static const std::array<std::string, NUM_VARS> variable_names = {"phi"};
 }
 
-#endif /* USERVARIABLES_HPP_ */
+#endif /* USERVARIABLES_HPP */

--- a/Tests/VariableStoreTest/UserVariables.hpp
+++ b/Tests/VariableStoreTest/UserVariables.hpp
@@ -3,8 +3,11 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-#ifndef USERVARIABLES_HPP_
-#define USERVARIABLES_HPP_
+#ifndef USERVARIABLES_HPP
+#define USERVARIABLES_HPP
+
+#include <array>
+#include <string>
 
 enum
 {
@@ -15,10 +18,10 @@ enum
 
 namespace UserVariables
 {
-static constexpr char const *variable_names[NUM_VARS] = {
+static const std::array<std::string, NUM_VARS> variable_names = {
     "var",
     "sym_var",
 };
 }
 
-#endif /* USERVARIABLES_HPP_ */
+#endif /* USERVARIABLES_HPP */


### PR DESCRIPTION
This resolves #118.
* The enum and name definitions of the common CCZ4 variables in the provided examples have been moved into a common CCZ4Variables.hpp file.
* The type of `UserVariables::variable_names` has been changed to a more modern C++ type of `std::array<std::string, NUM_VARS>`. Note that this is now `const` rather than `constexpr` but I don't think this is an issue.
* `ChomboParameters::variable_name_to_enum` has been moved to the `UserVariables` namespace in a new UserVariables.inc.hpp file which must be included at the end of UserVariables.hpp. This will therefore break users' other examples which don't include this file yet and haven't made the change above.
* A new template function to concatenate `std::array`s is defined in a new `MiscTools` namespace (this really ought to be in the standard library) which is used to concatenate the CCZ4 variable names array with the user one.