### PR TITLE
Bugfix/127

### DIFF
--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -296,6 +296,13 @@ void GRAMRLevel::regrid(const Vector<Box> &a_new_grids)
         m_patcher.define(level_domain, coarser_gr_amr_level_ptr->m_grids,
                          NUM_VARS, coarser_gr_amr_level_ptr->problemDomain(),
                          m_ref_ratio, m_num_ghosts);
+        if (NUM_DIAGNOSTIC_VARS > 0)
+        {
+            m_patcher_diagnostics.define(
+                level_domain, coarser_gr_amr_level_ptr->m_grids,
+                NUM_DIAGNOSTIC_VARS, coarser_gr_amr_level_ptr->problemDomain(),
+                m_ref_ratio, m_num_ghosts);
+        }
 
         // interpolate from coarser level
         m_fine_interp.interpToFine(m_state_new,
@@ -372,6 +379,13 @@ void GRAMRLevel::initialGrid(const Vector<Box> &a_new_grids)
         m_patcher.define(level_domain, coarser_gr_amr_level_ptr->m_grids,
                          NUM_VARS, coarser_gr_amr_level_ptr->problemDomain(),
                          m_ref_ratio, m_num_ghosts);
+        if (NUM_DIAGNOSTIC_VARS > 0)
+        {
+            m_patcher_diagnostics.define(
+                level_domain, coarser_gr_amr_level_ptr->m_grids,
+                NUM_DIAGNOSTIC_VARS, coarser_gr_amr_level_ptr->problemDomain(),
+                m_ref_ratio, m_num_ghosts);
+        }
     }
 }
 
@@ -670,6 +684,13 @@ void GRAMRLevel::readCheckpointLevel(HDF5Handle &a_handle)
         m_patcher.define(level_domain, coarser_gr_amr_level_ptr->m_grids,
                          NUM_VARS, coarser_gr_amr_level_ptr->problemDomain(),
                          m_ref_ratio, m_num_ghosts);
+        if (NUM_DIAGNOSTIC_VARS > 0)
+        {
+            m_patcher_diagnostics.define(
+                level_domain, coarser_gr_amr_level_ptr->m_grids,
+                NUM_DIAGNOSTIC_VARS, coarser_gr_amr_level_ptr->problemDomain(),
+                m_ref_ratio, m_num_ghosts);
+        }
     }
 
     // reshape state with new grids
@@ -980,9 +1001,9 @@ void GRAMRLevel::fillAllDiagnosticsGhosts()
     if (m_coarser_level_ptr != nullptr)
     {
         GRAMRLevel *coarser_gr_amr_level_ptr = gr_cast(m_coarser_level_ptr);
-        m_patcher.fillInterp(m_state_diagnostics,
-                             coarser_gr_amr_level_ptr->m_state_diagnostics, 0,
-                             0, NUM_DIAGNOSTIC_VARS);
+        m_patcher_diagnostics.fillInterp(
+            m_state_diagnostics, coarser_gr_amr_level_ptr->m_state_diagnostics,
+            0, 0, NUM_DIAGNOSTIC_VARS);
     }
     m_state_diagnostics.exchange(m_exchange_copier);
 }

--- a/Source/GRChomboCore/GRAMRLevel.hpp
+++ b/Source/GRChomboCore/GRAMRLevel.hpp
@@ -199,6 +199,9 @@ class GRAMRLevel : public AMRLevel, public InterpSource
 
     FourthOrderFillPatch m_patcher; //!< Organises interpolation from coarse to
                                     //!< fine levels of ghosts
+    FourthOrderFillPatch
+        m_patcher_diagnostics; //!< Organises interpolation from coarse to
+                               //!< fine levels of ghosts for diagnostics
     FourthOrderFineInterp m_fine_interp; //!< executes the interpolation from
                                          //!< coarse to fine when regridding
 

--- a/Tests/SphericalExtractionTest/SphericalExtractionTest.inputs
+++ b/Tests/SphericalExtractionTest/SphericalExtractionTest.inputs
@@ -24,8 +24,8 @@ checkpoint_interval = 1
 # extraction params
 num_extraction_radii = 2
 extraction_radii = 4. 6.
-num_points_phi_lo = 16
-num_points_theta_lo = 17
+num_points_phi_lo = 12
+num_points_theta_lo = 13
 
 # Spherical Harmonic to set and extract
 es = 0


### PR DESCRIPTION
As in issue #127, the reuse of m_patcher only works if NUM_DIAGNOSTIC_VARS < NUM_VARS which is usually, but not always, the case. 

This fixes it by creating a specific patcher for the diagnostics. 

Side note: As in the testing done by @amelialdrew, it seems that the speed up one gets from separating out diagnostics is roughly proportional to the percentage of vars which are moved out of evolution vars. So if the numbers of evolution and diagnostics vars are equal one gets a roughly 50% speed up. Nice :-) 