### PR TITLE
Add AMRReductions class

### DIFF
--- a/Examples/BinaryBH/SimulationParameters.hpp
+++ b/Examples/BinaryBH/SimulationParameters.hpp
@@ -45,10 +45,13 @@ class SimulationParameters : public SimulationParametersBase
             bh2_params.center[idir] = centerB[idir] + offsetB[idir];
         }
 
-        // Do we want Weyl extraction and puncture tracking?
+        // Do we want Weyl extraction, puncture tracking and constraint norm
+        // calculation?
         pp.load("activate_extraction", activate_extraction, false);
         pp.load("track_punctures", track_punctures, false);
         pp.load("puncture_tracking_level", puncture_tracking_level, max_level);
+        pp.load("calculate_constraint_norms", calculate_constraint_norms,
+                false);
 
         // hard code num punctures to 2 for now
         int num_punctures = 2;
@@ -58,7 +61,7 @@ class SimulationParameters : public SimulationParametersBase
     }
 
     // Initial data
-    bool activate_extraction, track_punctures;
+    bool activate_extraction, track_punctures, calculate_constraint_norms;
     int puncture_tracking_level;
     std::vector<std::array<double, CH_SPACEDIM>> initial_puncture_coords;
     // Collection of parameters necessary for initial conditions

--- a/Examples/ScalarField/DiagnosticVariables.hpp
+++ b/Examples/ScalarField/DiagnosticVariables.hpp
@@ -11,9 +11,7 @@ enum
 {
     c_Ham,
 
-    c_Mom1,
-    c_Mom2,
-    c_Mom3,
+    c_Mom,
 
     NUM_DIAGNOSTIC_VARS
 };
@@ -23,7 +21,7 @@ namespace DiagnosticVariables
 static const std::array<std::string, NUM_DIAGNOSTIC_VARS> variable_names = {
     "Ham",
 
-    "Mom1", "Mom2", "Mom3"};
+    "Mom"};
 }
 
 #endif /* DIAGNOSTICVARIABLES_HPP */

--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -14,7 +14,7 @@
 #include "MatterCCZ4.hpp"
 
 // For constraints calculation
-#include "MatterConstraints.hpp"
+#include "NewMatterConstraints.hpp"
 
 // For tag cells
 #include "ChiAndPhiTaggingCriterion.hpp"
@@ -63,7 +63,8 @@ void ScalarFieldLevel::prePlotLevel()
     Potential potential(m_p.potential_params);
     ScalarFieldWithPotential scalar_field(potential);
     BoxLoops::loop(MatterConstraints<ScalarFieldWithPotential>(
-                       scalar_field, m_dx, m_p.G_Newton),
+                       scalar_field, m_dx, c_Ham, Interval(c_Mom, c_Mom), -1,
+                       Interval(), m_p.G_Newton),
                    m_state_new, m_state_diagnostics, EXCLUDE_GHOST_CELLS);
 }
 

--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -62,10 +62,10 @@ void ScalarFieldLevel::prePlotLevel()
     fillAllGhosts();
     Potential potential(m_p.potential_params);
     ScalarFieldWithPotential scalar_field(potential);
-    BoxLoops::loop(MatterConstraints<ScalarFieldWithPotential>(
-                       scalar_field, m_dx, c_Ham, Interval(c_Mom, c_Mom), -1,
-                       Interval(), m_p.G_Newton),
-                   m_state_new, m_state_diagnostics, EXCLUDE_GHOST_CELLS);
+    BoxLoops::loop(
+        MatterConstraints<ScalarFieldWithPotential>(
+            scalar_field, m_dx, m_p.G_Newton, c_Ham, Interval(c_Mom, c_Mom)),
+        m_state_new, m_state_diagnostics, EXCLUDE_GHOST_CELLS);
 }
 
 // Things to do in RHS update, at each RK4 step

--- a/Source/AMRInterpolator/AMRInterpolator.impl.hpp
+++ b/Source/AMRInterpolator/AMRInterpolator.impl.hpp
@@ -37,9 +37,9 @@ template <typename InterpAlgo> void AMRInterpolator<InterpAlgo>::refresh()
     {
         AMRLevel &level = *levels[level_idx];
         InterpSource &interp_source = dynamic_cast<InterpSource &>(level);
-        interp_source.fillAllGhosts();
+        interp_source.fillAllGhosts(VariableType::evolution);
         if (NUM_DIAGNOSTIC_VARS > 0)
-            interp_source.fillAllDiagnosticsGhosts();
+            interp_source.fillAllGhosts(VariableType::diagnostic);
     }
 }
 
@@ -326,7 +326,8 @@ AMRInterpolator<InterpAlgo>::findBoxes(InterpolationQuery &query)
         const AMRLevel &level = *levels[level_idx];
 
         const LevelData<FArrayBox> &level_data =
-            dynamic_cast<const InterpSource &>(level).getLevelData();
+            dynamic_cast<const InterpSource &>(level).getLevelData(
+                VariableType::evolution);
         const DisjointBoxLayout &box_layout = level_data.disjointBoxLayout();
         const Box &domain_box = level.problemDomain().domainBox();
 
@@ -575,11 +576,12 @@ void AMRInterpolator<InterpAlgo>::calculateAnswers(InterpolationQuery &query)
         const AMRLevel &level = *levels[level_idx];
         const InterpSource &source = dynamic_cast<const InterpSource &>(level);
         const LevelData<FArrayBox> *const evolution_level_data_ptr =
-            &source.getLevelData();
+            &source.getLevelData(VariableType::evolution);
         const LevelData<FArrayBox> *diagnostics_level_data_ptr;
         if (NUM_DIAGNOSTIC_VARS > 0)
         {
-            diagnostics_level_data_ptr = &source.getDiagnosticsLevelData();
+            diagnostics_level_data_ptr =
+                &source.getLevelData(VariableType::diagnostic);
         }
         const DisjointBoxLayout *const evolution_box_layout_ptr =
             &evolution_level_data_ptr->disjointBoxLayout();

--- a/Source/AMRInterpolator/InterpSource.hpp
+++ b/Source/AMRInterpolator/InterpSource.hpp
@@ -7,18 +7,19 @@
 #define INTERPSOURCE_H_
 
 #include "LevelData.H"
+#include "VariableType.hpp"
 #include <array>
 
 // Abstrace base class to get the FABs out of an AMRLevel
 class InterpSource
 {
   public:
-    virtual const LevelData<FArrayBox> &getLevelData() const = 0;
-    virtual const LevelData<FArrayBox> &getDiagnosticsLevelData() const = 0;
+    virtual const LevelData<FArrayBox> &getLevelData(
+        const VariableType var_type = VariableType::evolution) const = 0;
     virtual bool
     contains(const std::array<double, CH_SPACEDIM> &point) const = 0;
-    virtual void fillAllGhosts() = 0;
-    virtual void fillAllDiagnosticsGhosts() = 0;
+    virtual void
+    fillAllGhosts(const VariableType var_type = VariableType::evolution) = 0;
 };
 
 #endif /* INTERPSOURCE_H_ */

--- a/Source/BoxUtils/AMRReductions.hpp
+++ b/Source/BoxUtils/AMRReductions.hpp
@@ -22,6 +22,7 @@ template <VariableType var_t> class AMRReductions
             : static_cast<int>(NUM_DIAGNOSTIC_VARS);
     const int m_base_level;
     const double m_coarsest_dx;
+    double m_domain_volume;
     Vector<LevelData<FArrayBox> *> m_level_data_ptrs;
     Vector<int> m_ref_ratios;
 
@@ -30,6 +31,10 @@ template <VariableType var_t> class AMRReductions
 
     //! gets the vector of refinement ratios and stores them
     void set_ref_ratios_vect(const GRAMR &a_gramr);
+
+    //! Sets m_domain_volume which is used in norm() if a_normalize_by_volume
+    //! is true. Must be called after set_level_data_vect
+    void set_domain_volume();
 
   public:
     //! Constructor
@@ -49,17 +54,22 @@ template <VariableType var_t> class AMRReductions
 
     //! returns the volume-weighted p-norm of an interval of variables
     //! p = a_norm_exponent
-    Real norm(const Interval &a_vars, const int a_norm_exponent = 2) const;
+    Real norm(const Interval &a_vars, const int a_norm_exponent = 2,
+              const bool a_normalize_by_volume = false) const;
 
     //! returns the volume weighted p-norm of a single variable
     //! p = a_norm_exponent
-    Real norm(const int a_var, const int a_norm_exponent = 2) const;
+    Real norm(const int a_var, const int a_norm_exponent = 2,
+              const bool a_normalize_by_volume = false) const;
 
     //! returns the volume-weighted sum (integral) of an interval of variables
     Real sum(const Interval &a_vars) const;
 
     //! returns the volume-weighted sum (integral of a single variable);
     Real sum(const int a_var) const;
+
+    //! returns the m_domain_volume member
+    Real get_domain_volume() const;
 };
 
 #include "AMRReductions.impl.hpp"

--- a/Source/BoxUtils/AMRReductions.hpp
+++ b/Source/BoxUtils/AMRReductions.hpp
@@ -1,0 +1,67 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef AMRREDUCTIONS_HPP
+#define AMRREDUCTIONS_HPP
+
+#include "GRAMR.hpp"
+#include "GRAMRLevel.hpp"
+#include "UserVariables.hpp"
+#include "VariableType.hpp"
+
+//! A class that provides a user-friendly interface to Chombo's
+//! computeSum and computeNorm functions
+template <VariableType var_t> class AMRReductions
+{
+  private:
+    static constexpr int m_num_vars =
+        (var_t == VariableType::evolution)
+            ? static_cast<int>(NUM_VARS)
+            : static_cast<int>(NUM_DIAGNOSTIC_VARS);
+    const int m_base_level;
+    const double m_coarsest_dx;
+    Vector<LevelData<FArrayBox> *> m_level_data_ptrs;
+    Vector<int> m_ref_ratios;
+
+    //! constructs a Vector of LevelData<FArrayBox> pointers and stores them
+    void set_level_data_vect(const GRAMR &a_gramr);
+
+    //! gets the vector of refinement ratios and stores them
+    void set_ref_ratios_vect(const GRAMR &a_gramr);
+
+  public:
+    //! Constructor
+    AMRReductions(const GRAMR &a_gramr, const int a_base_level = 0);
+
+    //! returns the minimum of an interval of variables
+    Real min(const Interval &a_vars) const;
+
+    //! returns the minimum of a single variable
+    Real min(const int a_var) const;
+
+    //! returns the maximum of an interval of variables
+    Real max(const Interval &a_vars) const;
+
+    //! returns the minimum of a single variables
+    Real max(const int a_var) const;
+
+    //! returns the volume-weighted p-norm of an interval of variables
+    //! p = a_norm_exponent
+    Real norm(const Interval &a_vars, const int a_norm_exponent = 2) const;
+
+    //! returns the volume weighted p-norm of a single variable
+    //! p = a_norm_exponent
+    Real norm(const int a_var, const int a_norm_exponent = 2) const;
+
+    //! returns the volume-weighted sum (integral) of an interval of variables
+    Real sum(const Interval &a_vars) const;
+
+    //! returns the volume-weighted sum (integral of a single variable);
+    Real sum(const int a_var) const;
+};
+
+#include "AMRReductions.impl.hpp"
+
+#endif /* AMRREDUCTIONS_HPP */

--- a/Source/BoxUtils/AMRReductions.impl.hpp
+++ b/Source/BoxUtils/AMRReductions.impl.hpp
@@ -1,0 +1,115 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#if !defined(AMRREDUCTIONS_HPP)
+#error "This file should only be included through AMRReductions.hpp"
+#endif
+
+#ifndef AMRREDUCTIONS_IMPL_HPP
+#define AMRREDUCTIONS_IMPL_HPP
+
+#include "computeNorm.H"
+#include "computeSum.H"
+
+template <VariableType var_t>
+AMRReductions<var_t>::AMRReductions(const GRAMR &a_gramr,
+                                    const int a_base_level)
+    : m_base_level(a_base_level),
+      m_coarsest_dx(a_gramr.get_gramrlevels()[0]->get_dx())
+{
+    set_level_data_vect(a_gramr);
+    set_ref_ratios_vect(a_gramr);
+}
+
+template <VariableType var_t>
+void AMRReductions<var_t>::set_level_data_vect(const GRAMR &a_gramr)
+{
+    // this function already checks if the level pointers are null
+    const auto gramrlevel_ptrs = a_gramr.get_gramrlevels();
+    int num_levels = gramrlevel_ptrs.size();
+    m_level_data_ptrs.resize(num_levels);
+
+    for (int ilev = 0; ilev < num_levels; ++ilev)
+    {
+        m_level_data_ptrs[ilev] = const_cast<GRLevelData *>(
+            &gramrlevel_ptrs[ilev]->getLevelData(var_t));
+    }
+}
+
+template <VariableType var_t>
+void AMRReductions<var_t>::set_ref_ratios_vect(const GRAMR &a_gramr)
+{
+    // this function already checks if the level pointers are null
+    const auto gramrlevel_ptrs = a_gramr.get_gramrlevels();
+    int num_levels = gramrlevel_ptrs.size();
+    m_ref_ratios.resize(num_levels);
+
+    for (int ilev = 0; ilev < num_levels; ++ilev)
+    {
+        m_ref_ratios[ilev] = gramrlevel_ptrs[ilev]->refRatio();
+    }
+}
+
+template <VariableType var_t>
+Real AMRReductions<var_t>::min(const Interval &a_vars) const
+{
+    CH_assert(a_vars.begin() >= 0 && a_vars.end() < m_num_vars);
+    CH_TIME("AMRReductions::min");
+    return computeMin(m_level_data_ptrs, m_ref_ratios, a_vars, m_base_level);
+}
+
+template <VariableType var_t>
+Real AMRReductions<var_t>::min(const int a_var) const
+{
+    return min(Interval(a_var, a_var));
+}
+
+template <VariableType var_t>
+Real AMRReductions<var_t>::max(const Interval &a_vars) const
+{
+    CH_assert(a_vars.begin() >= 0 && a_vars.end() < m_num_vars);
+    CH_TIME("AMRReductions::max");
+    return computeMax(m_level_data_ptrs, m_ref_ratios, a_vars, m_base_level);
+}
+
+template <VariableType var_t>
+Real AMRReductions<var_t>::max(const int a_var) const
+{
+    return max(Interval(a_var, a_var));
+}
+
+template <VariableType var_t>
+Real AMRReductions<var_t>::norm(const Interval &a_vars,
+                                const int a_norm_exponent) const
+{
+    CH_assert(a_vars.begin() >= 0 && a_vars.end() < m_num_vars);
+    CH_TIME("AMRReductions::norm");
+    return computeNorm(m_level_data_ptrs, m_ref_ratios, m_coarsest_dx, a_vars,
+                       a_norm_exponent, m_base_level);
+}
+
+template <VariableType var_t>
+Real AMRReductions<var_t>::norm(const int a_var,
+                                const int a_norm_exponent) const
+{
+    return norm(Interval(a_var, a_var), a_norm_exponent);
+}
+
+template <VariableType var_t>
+Real AMRReductions<var_t>::sum(const Interval &a_vars) const
+{
+    CH_assert(a_vars.begin() >= 0 && a_vars.end() < m_num_vars);
+    CH_TIME("AMRReductions::sum");
+    return computeSum(m_level_data_ptrs, m_ref_ratios, m_coarsest_dx, a_vars,
+                      m_base_level);
+}
+
+template <VariableType var_t>
+Real AMRReductions<var_t>::sum(const int a_var) const
+{
+    return sum(Interval(a_var, a_var));
+}
+
+#endif

--- a/Source/BoxUtils/AMRReductions.impl.hpp
+++ b/Source/BoxUtils/AMRReductions.impl.hpp
@@ -21,6 +21,7 @@ AMRReductions<var_t>::AMRReductions(const GRAMR &a_gramr,
 {
     set_level_data_vect(a_gramr);
     set_ref_ratios_vect(a_gramr);
+    set_domain_volume();
 }
 
 template <VariableType var_t>
@@ -50,6 +51,22 @@ void AMRReductions<var_t>::set_ref_ratios_vect(const GRAMR &a_gramr)
     {
         m_ref_ratios[ilev] = gramrlevel_ptrs[ilev]->refRatio();
     }
+}
+
+template <VariableType var_t> void AMRReductions<var_t>::set_domain_volume()
+{
+    // first check if m_level_data_ptrs has been set
+    CH_assert((m_level_data_ptrs.size() > 0) &&
+              (m_level_data_ptrs[0] != nullptr));
+
+    // first calculate the volume assuming each cell on the coarsest level has
+    // unit length
+    int cell_volume =
+        m_level_data_ptrs[0]->disjointBoxLayout().physDomain().size().product();
+
+    // multiply by dx_coarsest to get real volume
+    m_domain_volume =
+        pow(m_coarsest_dx, CH_SPACEDIM) * static_cast<double>(cell_volume);
 }
 
 template <VariableType var_t>
@@ -82,19 +99,27 @@ Real AMRReductions<var_t>::max(const int a_var) const
 
 template <VariableType var_t>
 Real AMRReductions<var_t>::norm(const Interval &a_vars,
-                                const int a_norm_exponent) const
+                                const int a_norm_exponent,
+                                const bool a_normalize_by_volume) const
 {
     CH_assert(a_vars.begin() >= 0 && a_vars.end() < m_num_vars);
     CH_TIME("AMRReductions::norm");
-    return computeNorm(m_level_data_ptrs, m_ref_ratios, m_coarsest_dx, a_vars,
-                       a_norm_exponent, m_base_level);
+    Real norm = computeNorm(m_level_data_ptrs, m_ref_ratios, m_coarsest_dx,
+                            a_vars, a_norm_exponent, m_base_level);
+    if (a_normalize_by_volume)
+    {
+        norm /=
+            pow(m_domain_volume, 1.0 / static_cast<double>(a_norm_exponent));
+    }
+
+    return norm;
 }
 
 template <VariableType var_t>
-Real AMRReductions<var_t>::norm(const int a_var,
-                                const int a_norm_exponent) const
+Real AMRReductions<var_t>::norm(const int a_var, const int a_norm_exponent,
+                                const bool a_normalize_by_volume) const
 {
-    return norm(Interval(a_var, a_var), a_norm_exponent);
+    return norm(Interval(a_var, a_var), a_norm_exponent, a_normalize_by_volume);
 }
 
 template <VariableType var_t>
@@ -110,6 +135,12 @@ template <VariableType var_t>
 Real AMRReductions<var_t>::sum(const int a_var) const
 {
     return sum(Interval(a_var, a_var));
+}
+
+template <VariableType var_t>
+Real AMRReductions<var_t>::get_domain_volume() const
+{
+    return m_domain_volume;
 }
 
 #endif

--- a/Source/CCZ4/NewConstraints.hpp
+++ b/Source/CCZ4/NewConstraints.hpp
@@ -62,10 +62,11 @@ class Constraints
 
     template <class data_t, template <typename> class vars_t,
               template <typename> class diff2_vars_t>
-    Vars<data_t>
-    constraint_equations(const vars_t<data_t> &vars,
-                         const vars_t<Tensor<1, data_t>> &d1,
-                         const diff2_vars_t<Tensor<2, data_t>> &d2) const;
+    Vars<data_t> constraint_equations(const vars_t<data_t> &vars,
+                                      const vars_t<Tensor<1, data_t>> &d1,
+                                      const diff2_vars_t<Tensor<2, data_t>> &d2,
+                                      const Tensor<2, data_t> &h_UU,
+                                      const chris_t<data_t> &chris) const;
 
     template <class data_t>
     void store_vars(Vars<data_t> &out, Cell<data_t> &current_cell) const;

--- a/Source/CCZ4/NewConstraints.hpp
+++ b/Source/CCZ4/NewConstraints.hpp
@@ -1,0 +1,76 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+// This compute class calculates Hamiltonian and Momentum constraints
+
+#ifndef NEWCONSTRAINTS_HPP_
+#define NEWCONSTRAINTS_HPP_
+
+#include "BSSNVars.hpp"
+#include "Cell.hpp"
+#include "FArrayBox.H"
+#include "FourthOrderDerivatives.hpp"
+#include "Tensor.hpp"
+#include "simd.hpp"
+
+#include "CCZ4Geometry.hpp"
+
+#include <array>
+
+class Constraints
+{
+  public:
+    /// CCZ4 variables
+    template <class data_t> using MetricVars = BSSNVars::VarsNoGauge<data_t>;
+
+    /// CCZ4 variables
+    template <class data_t>
+    using Diff2Vars = BSSNVars::Diff2VarsNoGauge<data_t>;
+
+    /// Vars object for Constraints
+    template <class data_t> struct Vars
+    {
+        data_t Ham;
+        data_t Ham_abs_terms;
+        Tensor<1, data_t> Mom;
+        Tensor<1, data_t> Mom_abs_terms;
+    };
+
+    // Constructor which allows specifying Ham and Mom vars
+    // if the interval of a_c_Moms is of size 1, then
+    // sqrt(Mom1^2 + Mom2^2 + Mom3^2) is stored in that variable
+    // ...abs_terms stores the absolute value of the individual terms in the
+    // conformally decomposed expressions which can be used in to normalize
+    // the constraint violations
+    // Any zero-length Interval or negative var is not calculated
+    Constraints(double dx, int a_c_Ham, const Interval &a_c_Moms,
+                int a_c_Ham_abs_terms = -1,
+                const Interval &a_c_Moms_abs_terms = Interval(),
+                double cosmological_constant = 0.0);
+
+    template <class data_t> void compute(Cell<data_t> current_cell) const;
+
+  protected:
+    const FourthOrderDerivatives m_deriv;
+    const int m_c_Ham;
+    const Interval m_c_Moms;
+    const int m_c_Ham_abs_terms = -1;
+    const Interval m_c_Moms_abs_terms;
+    double m_cosmological_constant;
+
+    template <class data_t, template <typename> class vars_t,
+              template <typename> class diff2_vars_t>
+    Vars<data_t>
+    constraint_equations(const vars_t<data_t> &vars,
+                         const vars_t<Tensor<1, data_t>> &d1,
+                         const diff2_vars_t<Tensor<2, data_t>> &d2) const;
+
+    template <class data_t>
+    void store_vars(Vars<data_t> &out, Cell<data_t> &current_cell) const;
+};
+
+#include "NewConstraints.impl.hpp"
+
+#endif /* NEWCONSTRAINTS_HPP_ */

--- a/Source/CCZ4/NewConstraints.impl.hpp
+++ b/Source/CCZ4/NewConstraints.impl.hpp
@@ -33,7 +33,10 @@ void Constraints::compute(Cell<data_t> current_cell) const
     const auto d1 = m_deriv.template diff1<MetricVars>(current_cell);
     const auto d2 = m_deriv.template diff2<Diff2Vars>(current_cell);
 
-    Vars<data_t> out = constraint_equations(vars, d1, d2);
+    const auto h_UU = TensorAlgebra::compute_inverse_sym(vars.h);
+    const auto chris = TensorAlgebra::compute_christoffel(d1.h, h_UU);
+
+    Vars<data_t> out = constraint_equations(vars, d1, d2, h_UU, chris);
 
     store_vars(out, current_cell);
 }
@@ -42,12 +45,10 @@ template <class data_t, template <typename> class vars_t,
           template <typename> class diff2_vars_t>
 Constraints::Vars<data_t> Constraints::constraint_equations(
     const vars_t<data_t> &vars, const vars_t<Tensor<1, data_t>> &d1,
-    const diff2_vars_t<Tensor<2, data_t>> &d2) const
+    const diff2_vars_t<Tensor<2, data_t>> &d2, const Tensor<2, data_t> &h_UU,
+    const chris_t<data_t> &chris) const
 {
     Vars<data_t> out;
-
-    auto h_UU = TensorAlgebra::compute_inverse_sym(vars.h);
-    auto chris = TensorAlgebra::compute_christoffel(d1.h, h_UU);
 
     if (m_c_Ham >= 0 || m_c_Ham_abs_terms >= 0)
     {

--- a/Source/CCZ4/NewConstraints.impl.hpp
+++ b/Source/CCZ4/NewConstraints.impl.hpp
@@ -1,0 +1,147 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#if !defined(NEWCONSTRAINTS_HPP_)
+#error "This file should only be included through NewConstraints.hpp"
+#endif
+
+#ifndef NEWCONSTRAINTS_IMPL_HPP_
+#define NEWCONSTRAINTS_IMPL_HPP_
+
+#include "DimensionDefinitions.hpp"
+#include "GRInterval.hpp"
+#include "VarsTools.hpp"
+
+inline Constraints::Constraints(
+    double dx, int a_c_Ham, const Interval &a_c_Moms,
+    int a_c_Ham_abs_terms /*defaulted*/,
+    const Interval &a_c_Moms_abs_terms /*defaulted*/,
+    double cosmological_constant /*defaulted*/)
+    : m_deriv(dx), m_c_Ham(a_c_Ham), m_c_Moms(a_c_Moms),
+      m_c_Ham_abs_terms(a_c_Ham_abs_terms),
+      m_c_Moms_abs_terms(a_c_Moms_abs_terms),
+      m_cosmological_constant(cosmological_constant)
+{
+}
+
+template <class data_t>
+void Constraints::compute(Cell<data_t> current_cell) const
+{
+    const auto vars = current_cell.template load_vars<MetricVars>();
+    const auto d1 = m_deriv.template diff1<MetricVars>(current_cell);
+    const auto d2 = m_deriv.template diff2<Diff2Vars>(current_cell);
+
+    Vars<data_t> out = constraint_equations(vars, d1, d2);
+
+    store_vars(out, current_cell);
+}
+
+template <class data_t, template <typename> class vars_t,
+          template <typename> class diff2_vars_t>
+Constraints::Vars<data_t> Constraints::constraint_equations(
+    const vars_t<data_t> &vars, const vars_t<Tensor<1, data_t>> &d1,
+    const diff2_vars_t<Tensor<2, data_t>> &d2) const
+{
+    Vars<data_t> out;
+
+    auto h_UU = TensorAlgebra::compute_inverse_sym(vars.h);
+    auto chris = TensorAlgebra::compute_christoffel(d1.h, h_UU);
+
+    if (m_c_Ham >= 0 || m_c_Ham_abs_terms >= 0)
+    {
+        auto ricci = CCZ4Geometry::compute_ricci(vars, d1, d2, h_UU, chris);
+
+        auto A_UU = TensorAlgebra::raise_all(vars.A, h_UU);
+        data_t tr_A2 = TensorAlgebra::compute_trace(vars.A, A_UU);
+
+        out.Ham = ricci.scalar +
+                  (GR_SPACEDIM - 1.) * vars.K * vars.K / GR_SPACEDIM - tr_A2;
+        out.Ham -= 2 * m_cosmological_constant;
+
+        out.Ham_abs_terms =
+            abs(ricci.scalar) + abs(tr_A2) +
+            abs((GR_SPACEDIM - 1.) * vars.K * vars.K / GR_SPACEDIM);
+        out.Ham_abs_terms += 2.0 * abs(m_cosmological_constant);
+    }
+
+    if (m_c_Moms.size() > 0 || m_c_Moms_abs_terms.size() > 0)
+    {
+        Tensor<2, data_t> covd_A[CH_SPACEDIM];
+        FOR3(i, j, k)
+        {
+            covd_A[i][j][k] = d1.A[j][k][i];
+            FOR1(l)
+            {
+                covd_A[i][j][k] += -chris.ULL[l][i][j] * vars.A[l][k] -
+                                   chris.ULL[l][i][k] * vars.A[l][j];
+            }
+        }
+        FOR1(i)
+        {
+            out.Mom[i] = -(GR_SPACEDIM - 1.) * d1.K[i] / GR_SPACEDIM;
+            out.Mom_abs_terms[i] = abs(out.Mom[i]);
+        }
+        Tensor<1, data_t> covd_A_term = 0.0;
+        Tensor<1, data_t> d1_chi_term = 0.0;
+        const data_t chi_regularised = simd_max(1e-6, vars.chi);
+        FOR3(i, j, k)
+        {
+            covd_A_term[i] += h_UU[j][k] * covd_A[k][j][i];
+            d1_chi_term[i] += -GR_SPACEDIM * h_UU[j][k] * vars.A[i][j] *
+                              d1.chi[k] / (2 * chi_regularised);
+        }
+        FOR1(i)
+        {
+            out.Mom[i] += covd_A_term[i] + d1_chi_term[i];
+            out.Mom_abs_terms[i] += abs(covd_A_term[i]) + abs(d1_chi_term[i]);
+        }
+    }
+    return out;
+}
+
+template <class data_t>
+void Constraints::store_vars(Vars<data_t> &out,
+                             Cell<data_t> &current_cell) const
+{
+    if (m_c_Ham >= 0)
+        current_cell.store_vars(out.Ham, m_c_Ham);
+    if (m_c_Ham_abs_terms >= 0)
+        current_cell.store_vars(out.Ham_abs_terms, m_c_Ham_abs_terms);
+    if (m_c_Moms.size() == GR_SPACEDIM)
+    {
+        FOR1(i)
+        {
+            int ivar = m_c_Moms.begin() + i;
+            current_cell.store_vars(out.Mom[i], ivar);
+        }
+    }
+    else if (m_c_Moms.size() == 1)
+    {
+        data_t Mom_sq = 0.0;
+        FOR1(i) { Mom_sq += out.Mom[i] * out.Mom[i]; }
+        data_t Mom = sqrt(Mom_sq);
+        current_cell.store_vars(Mom, m_c_Moms.begin());
+    }
+    if (m_c_Moms_abs_terms.size() == GR_SPACEDIM)
+    {
+        FOR1(i)
+        {
+            int ivar = m_c_Moms_abs_terms.begin() + i;
+            current_cell.store_vars(out.Mom_abs_terms[i], ivar);
+        }
+    }
+    else if (m_c_Moms_abs_terms.size() == 1)
+    {
+        data_t Mom_abs_terms_sq = 0.0;
+        FOR1(i)
+        {
+            Mom_abs_terms_sq += out.Mom_abs_terms[i] * out.Mom_abs_terms[i];
+        }
+        data_t Mom_abs_terms = sqrt(Mom_abs_terms_sq);
+        current_cell.store_vars(Mom_abs_terms, m_c_Moms_abs_terms.begin());
+    }
+}
+
+#endif /* NEWCONSTRAINTS_IMPL_HPP_ */

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -155,7 +155,7 @@ class ChomboParameters
                 {
                     // it's neither :(
                     pout() << "Variable with name " << var_name
-                           << " not found.";
+                           << " not found.\n";
                 }
                 else
                 {

--- a/Source/GRChomboCore/GRAMR.cpp
+++ b/Source/GRChomboCore/GRAMR.cpp
@@ -1,0 +1,41 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#include "GRAMR.hpp"
+#include "GRAMRLevel.hpp"
+
+GRAMR::GRAMR() : m_interpolator(nullptr) {}
+
+// Called after AMR object set up
+void GRAMR::set_interpolator(AMRInterpolator<Lagrange<4>> *a_interpolator)
+{
+    m_interpolator = a_interpolator;
+}
+
+// returs a std::vector of GRAMRLevel pointers
+// similar to AMR::getAMRLevels()
+std::vector<GRAMRLevel *> GRAMR::get_gramrlevels()
+{
+    std::vector<GRAMRLevel *> out(m_amrlevels.size());
+    std::transform(m_amrlevels.stdVector().cbegin(),
+                   m_amrlevels.stdVector().cend(), out.begin(),
+                   [](AMRLevel *amrlevel_ptr) {
+                       return GRAMRLevel::gr_cast(amrlevel_ptr);
+                   });
+    return out;
+}
+
+// const version of above
+std::vector<const GRAMRLevel *> GRAMR::get_gramrlevels() const
+{
+    std::vector<const GRAMRLevel *> out(m_amrlevels.size());
+    std::transform(m_amrlevels.constStdVector().cbegin(),
+                   m_amrlevels.constStdVector().cend(), out.begin(),
+                   [](const AMRLevel *amrlevel_ptr) {
+                       return GRAMRLevel::gr_cast(amrlevel_ptr);
+                   });
+
+    return out;
+}

--- a/Source/GRChomboCore/GRAMR.hpp
+++ b/Source/GRChomboCore/GRAMR.hpp
@@ -9,8 +9,10 @@
 #include "AMR.H"
 #include "AMRInterpolator.hpp"
 #include "Lagrange.hpp"
+#include <algorithm>
 #include <chrono>
 #include <ratio>
+#include <vector>
 
 /// A child of Chombo's AMR class to interface with tools which require
 /// access to the whole AMR hierarchy (such as the AMRInterpolator)
@@ -18,6 +20,10 @@
  *It is necessary for many experimental features and allows us to
  *add said features later without breaking any user code.
  */
+
+// Forward declaration for get_gramrlevels function declarations
+class GRAMRLevel;
+
 class GRAMR : public AMR
 {
   private:
@@ -28,8 +34,9 @@ class GRAMR : public AMR
   public:
     AMRInterpolator<Lagrange<4>> *m_interpolator; //!< The interpolator pointer
 
-    GRAMR() { m_interpolator = nullptr; }
+    GRAMR();
 
+    // defined here due to auto return type
     auto get_walltime()
     {
         auto now = Clock::now();
@@ -39,10 +46,14 @@ class GRAMR : public AMR
     }
 
     // Called after AMR object set up
-    void set_interpolator(AMRInterpolator<Lagrange<4>> *a_interpolator)
-    {
-        m_interpolator = a_interpolator;
-    }
+    void set_interpolator(AMRInterpolator<Lagrange<4>> *a_interpolator);
+
+    // returs a std::vector of GRAMRLevel pointers
+    // similar to AMR::getAMRLevels()
+    std::vector<GRAMRLevel *> get_gramrlevels();
+
+    // const version of above
+    std::vector<const GRAMRLevel *> get_gramrlevels() const;
 };
 
 #endif /* GRAMR_HPP_ */

--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -73,11 +73,12 @@ GRAMRLevel *GRAMRLevel::gr_cast(AMRLevel *const amr_level_ptr)
         gr_cast(static_cast<const AMRLevel *const>(amr_level_ptr)));
 }
 
-const GRLevelData &GRAMRLevel::getLevelData() const { return m_state_new; }
-
-const GRLevelData &GRAMRLevel::getDiagnosticsLevelData() const
+const GRLevelData &GRAMRLevel::getLevelData(VariableType var_type) const
 {
-    return m_state_diagnostics;
+    if (var_type == VariableType::evolution)
+        return m_state_new;
+    else
+        return m_state_diagnostics;
 }
 
 bool GRAMRLevel::contains(const std::array<double, CH_SPACEDIM> &point) const
@@ -197,7 +198,8 @@ void GRAMRLevel::tagCells(IntVectSet &a_tags)
     if (m_verbosity)
         pout() << "GRAMRLevel::tagCells " << m_level << endl;
 
-    fillAllGhosts(); // We need filled ghost cells to calculate gradients etc
+    fillAllEvolutionGhosts(); // We need filled ghost cells to calculate
+                              // gradients etc
 
     // Create tags based on undivided gradient of phi
     IntVectSet local_tags;
@@ -975,11 +977,19 @@ void GRAMRLevel::copySolnData(GRLevelData &dest, const GRLevelData &src)
 
 double GRAMRLevel::get_dx() const { return m_dx; }
 
-void GRAMRLevel::fillAllGhosts()
+void GRAMRLevel::fillAllGhosts(const VariableType var_type)
 {
-    CH_TIME("GRAMRLevel::fillAllGhosts()");
+    if (var_type == VariableType::evolution)
+        fillAllEvolutionGhosts();
+    else if (var_type == VariableType::diagnostic)
+        fillAllDiagnosticsGhosts();
+}
+
+void GRAMRLevel::fillAllEvolutionGhosts()
+{
+    CH_TIME("GRAMRLevel::fillAllEvolutionGhosts()");
     if (m_verbosity)
-        pout() << "GRAMRLevel::fillAllGhosts" << endl;
+        pout() << "GRAMRLevel::fillAllEvolutionGhosts" << endl;
 
     // If there is a coarser level then interpolate undefined ghost cells
     if (m_coarser_level_ptr != nullptr)

--- a/Source/GRChomboCore/GRAMRLevel.hpp
+++ b/Source/GRChomboCore/GRAMRLevel.hpp
@@ -32,8 +32,8 @@ class GRAMRLevel : public AMRLevel, public InterpSource
     static const GRAMRLevel *gr_cast(const AMRLevel *const amr_level_ptr);
     static GRAMRLevel *gr_cast(AMRLevel *const amr_level_ptr);
 
-    const GRLevelData &getLevelData() const;
-    const GRLevelData &getDiagnosticsLevelData() const;
+    const GRLevelData &
+    getLevelData(const VariableType var_type = VariableType::evolution) const;
 
     bool contains(const std::array<double, CH_SPACEDIM> &point) const;
 
@@ -156,13 +156,17 @@ class GRAMRLevel : public AMRLevel, public InterpSource
 
     double get_dx() const;
 
-    /// Fill all ghosts cells
-    virtual void fillAllGhosts();
-
-    /// Fill all diagnostics ghost cells
-    virtual void fillAllDiagnosticsGhosts();
+    /// Fill all [either] evolution or diagnostic ghost cells
+    virtual void
+    fillAllGhosts(const VariableType var_type = VariableType::evolution);
 
   protected:
+    /// Fill all evolution ghosts cells (i.e. those in m_state_new)
+    virtual void fillAllEvolutionGhosts();
+
+    /// Fill all diagnostics ghost cells (i.e. those in m_state_diagnostics)
+    virtual void fillAllDiagnosticsGhosts();
+
     /// Fill ghosts cells from boxes on this level only. Do not interpolate
     /// between levels.
     virtual void fillIntralevelGhosts();

--- a/Source/Matter/MatterConstraints.hpp
+++ b/Source/Matter/MatterConstraints.hpp
@@ -15,7 +15,7 @@
 #include "simd.hpp"
 #include <array>
 
-//!  Calculates the Hamiltonain and Momentum constraints with matter fields
+//!  Calculates the Hamiltonian and Momentum constraints with matter fields
 /*!
      The class calculates the Hamiltonian and Momentum constraints at each point
    in a box. It inherits from the Constraints class which calculates the

--- a/Source/Matter/MatterConstraints.impl.hpp
+++ b/Source/Matter/MatterConstraints.impl.hpp
@@ -38,7 +38,7 @@ void MatterConstraints<matter_t>::compute(Cell<data_t> current_cell) const
     // Energy Momentum Tensor
     const auto emtensor = my_matter.compute_emtensor(vars, d1, h_UU, chris.ULL);
 
-    // Hamiltonain constraint
+    // Hamiltonian constraint
     out.Ham += -16.0 * M_PI * m_G_Newton * emtensor.rho;
 
     // Momentum constraints

--- a/Source/Matter/NewMatterConstraints.hpp
+++ b/Source/Matter/NewMatterConstraints.hpp
@@ -1,0 +1,69 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef NEWMATTERCONSTRAINTS_HPP_
+#define NEWMATTERCONSTRAINTS_HPP_
+
+#include "CCZ4Geometry.hpp"
+#include "Cell.hpp"
+#include "FourthOrderDerivatives.hpp"
+#include "GRInterval.hpp"
+#include "NewConstraints.hpp"
+#include "Tensor.hpp"
+#include "simd.hpp"
+#include <array>
+
+//!  Calculates the Hamiltonain and Momentum constraints with matter fields
+/*!
+     The class calculates the Hamiltonian and Momentum constraints at each point
+   in a box. It inherits from the Constraints class which calculates the
+   constraints without the matter terms. It adds in the matter terms for a given
+   matter class matter_t, which must provide it with the Energy Momentum Tensor.
+   For an example of a matter_t class see ScalarField. \sa Constraints(),
+   ScalarField()
+*/
+template <class matter_t> class MatterConstraints : public Constraints
+{
+  public:
+    template <class data_t>
+    using MatterVars = typename matter_t::template Vars<data_t>;
+
+    // Inherit the variable definitions from CCZ4 + matter_t
+    template <class data_t>
+    struct BSSNMatterVars : public Constraints::MetricVars<data_t>,
+                            public MatterVars<data_t>
+    {
+        /// Defines the mapping between members of Vars and Chombo grid
+        /// variables (enum in User_Variables)
+        template <typename mapping_function_t>
+        void enum_mapping(mapping_function_t mapping_function)
+        {
+            Constraints::MetricVars<data_t>::enum_mapping(mapping_function);
+            MatterVars<data_t>::enum_mapping(mapping_function);
+        }
+    };
+
+    //! Constructor of class MatterConstraints
+    /*!
+        Can specify the vars of the constraint vars instead of using the
+        hardcoded ones.
+    */
+    MatterConstraints(const matter_t a_matter, double dx, int a_c_Ham,
+                      const Interval &a_c_Moms, int a_c_Ham_abs_terms = -1,
+                      const Interval &a_c_Moms_abs_terms = Interval(),
+                      double G_Newton = 1.0);
+
+    //! The compute member which calculates the constraints at each point in the
+    //! box
+    template <class data_t> void compute(Cell<data_t> current_cell) const;
+
+  protected:
+    matter_t my_matter; //!< The matter object, e.g. a scalar field
+    double m_G_Newton;  //!< Newton's constant, set to one by default.
+};
+
+#include "NewMatterConstraints.impl.hpp"
+
+#endif /* NEWMATTERCONSTRAINTS_HPP_ */

--- a/Source/Matter/NewMatterConstraints.hpp
+++ b/Source/Matter/NewMatterConstraints.hpp
@@ -15,7 +15,7 @@
 #include "simd.hpp"
 #include <array>
 
-//!  Calculates the Hamiltonain and Momentum constraints with matter fields
+//!  Calculates the Hamiltonian and Momentum constraints with matter fields
 /*!
      The class calculates the Hamiltonian and Momentum constraints at each point
    in a box. It inherits from the Constraints class which calculates the
@@ -50,10 +50,10 @@ template <class matter_t> class MatterConstraints : public Constraints
         Can specify the vars of the constraint vars instead of using the
         hardcoded ones.
     */
-    MatterConstraints(const matter_t a_matter, double dx, int a_c_Ham,
-                      const Interval &a_c_Moms, int a_c_Ham_abs_terms = -1,
-                      const Interval &a_c_Moms_abs_terms = Interval(),
-                      double G_Newton = 1.0);
+    MatterConstraints(const matter_t a_matter, double dx, double G_Newton,
+                      int a_c_Ham, const Interval &a_c_Moms,
+                      int a_c_Ham_abs_terms = -1,
+                      const Interval &a_c_Moms_abs_terms = Interval());
 
     //! The compute member which calculates the constraints at each point in the
     //! box

--- a/Source/Matter/NewMatterConstraints.impl.hpp
+++ b/Source/Matter/NewMatterConstraints.impl.hpp
@@ -1,0 +1,66 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#if !defined(NEWMATTERCONSTRAINTS_HPP_)
+#error "This file should only be included through NewMatterConstraints.hpp"
+#endif
+
+#ifndef NEWMATTERCONSTRAINTS_IMPL_HPP_
+#define NEWMATTERCONSTRAINTS_IMPL_HPP_
+#include "DimensionDefinitions.hpp"
+
+template <class matter_t>
+MatterConstraints<matter_t>::MatterConstraints(
+    const matter_t a_matter, double dx, int a_c_Ham, const Interval &a_c_Moms,
+    int a_c_Ham_abs_terms /* defaulted*/,
+    const Interval &a_c_Moms_abs_terms /*defaulted*/,
+    double G_Newton /*defaulted*/)
+    : Constraints(dx, a_c_Ham, a_c_Moms, a_c_Ham_abs_terms, a_c_Moms_abs_terms,
+                  0.0 /*No cosmological constant*/),
+      my_matter(a_matter), m_G_Newton(G_Newton)
+{
+}
+
+template <class matter_t>
+template <class data_t>
+void MatterConstraints<matter_t>::compute(Cell<data_t> current_cell) const
+{
+    // Load local vars and calculate derivs
+    const auto vars = current_cell.template load_vars<BSSNMatterVars>();
+    const auto d1 = m_deriv.template diff1<BSSNMatterVars>(current_cell);
+    const auto d2 = m_deriv.template diff2<BSSNMatterVars>(current_cell);
+
+    // Get the non matter terms for the constraints
+    Vars<data_t> out = constraint_equations(vars, d1, d2);
+
+    // Inverse metric and Christoffel symbol
+    const auto h_UU = TensorAlgebra::compute_inverse_sym(vars.h);
+    const auto chris = TensorAlgebra::compute_christoffel(d1.h, h_UU);
+
+    // Energy Momentum Tensor
+    const auto emtensor = my_matter.compute_emtensor(vars, d1, h_UU, chris.ULL);
+
+    // Hamiltonain constraint
+    if (m_c_Ham >= 0 || m_c_Ham_abs_terms >= 0)
+    {
+        out.Ham += -16.0 * M_PI * m_G_Newton * emtensor.rho;
+        out.Ham_abs_terms += 16.0 * M_PI * m_G_Newton * abs(emtensor.rho);
+    }
+
+    // Momentum constraints
+    if (m_c_Moms.size() > 0 || m_c_Moms_abs_terms.size() > 0)
+    {
+        FOR1(i)
+        {
+            out.Mom[i] += -8.0 * M_PI * m_G_Newton * emtensor.Si[i];
+            out.Mom_abs_terms[i] +=
+                8.0 * M_PI * m_G_Newton * abs(emtensor.Si[i]);
+        }
+    }
+    // Write the constraints into the output FArrayBox
+    store_vars(out, current_cell);
+}
+
+#endif /* NEWMATTERCONSTRAINTS_IMPL_HPP_ */

--- a/Tests/CppChFConstraintComparison/ConstraintTest.cpp
+++ b/Tests/CppChFConstraintComparison/ConstraintTest.cpp
@@ -16,7 +16,7 @@
 #include "BoxIterator.H"
 #include "BoxLoops.hpp"
 #include "ConstraintTestF_F.H"
-#include "Constraints.hpp"
+#include "NewConstraints.hpp"
 
 #define CHF_FRAn(a, n, c)                                                      \
     a.dataPtr(n),                                                              \
@@ -194,11 +194,13 @@ int main()
     struct timeval begin, end;
 
     // Make sure instructions are hot in cache
-    BoxLoops::loop(Constraints(dx), in_fab, in_fab_cpp_result, box);
+    BoxLoops::loop(Constraints(dx, c_Ham, Interval(c_Mom1, c_Mom3)), in_fab,
+                   in_fab_cpp_result, box);
 
     gettimeofday(&begin, NULL);
 
-    BoxLoops::loop(Constraints(dx), in_fab, in_fab_cpp_result, box);
+    BoxLoops::loop(Constraints(dx, c_Ham, Interval(c_Mom1, c_Mom3)), in_fab,
+                   in_fab_cpp_result, box);
 
     gettimeofday(&end, NULL);
 


### PR DESCRIPTION
This class provides a user-friendly [and somewhat object oriented] interface to Chombo's `computeSum` and `computeNorm` functions and resolves #113.

I have also added flexibility to the `Constraints` and `MatterConstraints` compute classes:
A new constructor has been added to each of the `Constraints` and `MatterConstraints` classes which allows specifying the vars for
* `Ham`
* `Moms`
* `Ham_abs_terms`
* `Moms_abs_terms`
where the `Moms` are intervals. If `Ham...` is < 0, then it is ignored and not saved. If the size of the `Moms...` intervals is 0, then it is similarly ignored and not saved, if it is 1, then the pointwise norm is stored there and if it is 3 then it is stored as the usual 3-vector.

Unfortunately, it was necessary to add macro guards to the old Constraints constructor. This is necessary because these constructors assume the existence of `c_Ham` and `c_Mom1-3` in your `UserVariables.hpp` but this may not be the case if you want to use the new constructor.

As an example the ScalarField example has been modified to only have a single `c_Mom` var.