### PR TITLE
Remove hardcoded NUM_VARS in [most of] BoxUtils

### DIFF
--- a/Source/BoxUtils/BoxPointers.hpp
+++ b/Source/BoxUtils/BoxPointers.hpp
@@ -28,26 +28,29 @@ class BoxPointers
                                               //! two values corresponding to
                                               //! adjacent coordinates in all
                                               //! directions.
+    const int m_in_num_comps;
 
     std::vector<double *> m_out_ptr;
     std::array<int, CH_SPACEDIM> m_out_stride; //!< Distance in memory between
                                                //! two values corresponding to
                                                //! adjacent coordinates in all
                                                //! directions.
+    const int m_out_num_comps;
 
     BoxPointers(const FArrayBox &in, FArrayBox &out)
         : m_in_lo(in.loVect()), m_in_hi(in.hiVect()), m_out_lo(out.loVect()),
-          m_out_hi(out.hiVect())
+          m_out_hi(out.hiVect()), m_in_num_comps(in.nComp()),
+          m_out_num_comps(out.nComp())
     {
-        m_in_ptr.resize(in.nComp());
-        m_out_ptr.resize(out.nComp());
+        m_in_ptr.resize(m_in_num_comps);
+        m_out_ptr.resize(m_out_num_comps);
         // dataPtr in Chombo does CH_assert bound check
         // which we don't want to do in a loop
-        for (int i = 0; i < NUM_VARS; ++i)
+        for (int i = 0; i < m_in_num_comps; ++i)
             m_in_ptr[i] = in.dataPtr(i);
         // If the output FArrayBox doesn't have all components, just don't set
         // the pointers
-        for (int i = 0; i < out.nComp(); ++i)
+        for (int i = 0; i < m_out_num_comps; ++i)
             m_out_ptr[i] = out.dataPtr(i);
 
         m_in_stride[0] = 1;

--- a/Source/BoxUtils/Cell.hpp
+++ b/Source/BoxUtils/Cell.hpp
@@ -92,6 +92,14 @@ template <class data_t> class Cell
     ALWAYS_INLINE
     const BoxPointers &get_box_pointers() const { return m_box_pointers; }
 
+    /// Return the number of variables in the input FAB
+    ALWAYS_INLINE
+    int get_num_in_vars() const { return m_box_pointers.m_in_num_comps; }
+
+    /// Returns the number of variables in the output FAB
+    ALWAYS_INLINE
+    int get_num_out_vars() const { return m_box_pointers.m_out_num_comps; }
+
     /// Loads the variable of a given variable from the Chombo grid
     ALWAYS_INLINE
     data_t load_vars(int ivar) const;
@@ -101,7 +109,7 @@ template <class data_t> class Cell
     void load_vars(data_t &out, int ivar) const;
 
     /// Loads all variables into an array
-    void load_vars(data_t (&out)[NUM_VARS]) const;
+    template <int num_vars> void load_vars(data_t (&out)[num_vars]) const;
 
     /// Loads all variables defined in a vars class
     template <template <typename> class vars_t>
@@ -120,7 +128,8 @@ template <class data_t> class Cell
         const GRInterval<start_var, end_var> interval) const;
 
     /// Stores an array of all variables to the chombo grid
-    void store_vars(const std::array<data_t, NUM_VARS> &values) const;
+    template <int num_vars>
+    void store_vars(const std::array<data_t, num_vars> &values) const;
 
     /// Stores all variables defined in the vars object to the chombo grid
     template <template <typename> class vars_t>

--- a/Source/BoxUtils/Cell.impl.hpp
+++ b/Source/BoxUtils/Cell.impl.hpp
@@ -27,9 +27,10 @@ ALWAYS_INLINE void Cell<data_t>::load_vars(data_t &out, const int ivar) const
 }
 
 template <class data_t>
-void Cell<data_t>::load_vars(data_t (&out)[NUM_VARS]) const
+template <int num_vars>
+void Cell<data_t>::load_vars(data_t (&out)[num_vars]) const
 {
-    for (int ivar = 0; ivar < NUM_VARS; ++ivar)
+    for (int ivar = 0; ivar < num_vars; ++ivar)
     {
         out[ivar] = load_vars(ivar);
     }
@@ -71,10 +72,11 @@ ALWAYS_INLINE void Cell<data_t>::store_vars(
 }
 
 template <class data_t>
+template <int num_vars>
 ALWAYS_INLINE void
-Cell<data_t>::store_vars(const std::array<data_t, NUM_VARS> &values) const
+Cell<data_t>::store_vars(const std::array<data_t, num_vars> &values) const
 {
-    for (int ivar = 0; ivar < NUM_VARS; ++ivar)
+    for (int ivar = 0; ivar < num_vars; ++ivar)
     {
         store_vars(values[ivar], ivar);
     }

--- a/Source/BoxUtils/FourthOrderDerivatives.hpp
+++ b/Source/BoxUtils/FourthOrderDerivatives.hpp
@@ -139,14 +139,14 @@ class FourthOrderDerivatives
         });
     }
 
-    template <class data_t>
-    void diff2(Tensor<2, data_t> (&diffArray)[NUM_VARS],
+    template <class data_t, int num_vars>
+    void diff2(Tensor<2, data_t> (&diffArray)[num_vars],
                const Cell<data_t> &current_cell, int direction) const
     {
         const int stride =
             current_cell.get_box_pointers().m_in_stride[direction];
         const int in_index = current_cell.get_in_index();
-        for (int ivar = 0; ivar < NUM_VARS; ++ivar)
+        for (int ivar = 0; ivar < num_vars; ++ivar)
         {
             diffArray[ivar][direction][direction] =
                 diff2<data_t>(current_cell.get_box_pointers().m_in_ptr[ivar],
@@ -205,8 +205,8 @@ class FourthOrderDerivatives
         });
     }
 
-    template <class data_t>
-    void mixed_diff2(Tensor<2, data_t> (&diffArray)[NUM_VARS],
+    template <class data_t, int num_vars>
+    void mixed_diff2(Tensor<2, data_t> (&diffArray)[num_vars],
                      const Cell<data_t> &current_cell, int direction1,
                      int direction2) const
     {
@@ -215,7 +215,7 @@ class FourthOrderDerivatives
         const int stride2 =
             current_cell.get_box_pointers().m_in_stride[direction2];
         const int in_index = current_cell.get_in_index();
-        for (int ivar = 0; ivar < NUM_VARS; ++ivar)
+        for (int ivar = 0; ivar < num_vars; ++ivar)
         {
             data_t diff2_value = mixed_diff2<data_t>(
                 current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
@@ -305,15 +305,15 @@ class FourthOrderDerivatives
         });
     }
 
-    template <class data_t>
-    void add_advection(data_t (&out)[NUM_VARS],
+    template <class data_t, int num_vars>
+    void add_advection(data_t (&out)[num_vars],
                        const Cell<data_t> &current_cell, const data_t &vec_comp,
                        const int dir) const
     {
         const int stride = current_cell.get_box_pointers().m_in_stride[dir];
         auto shift_positive = simd_compare_gt(vec_comp, 0.0);
         const int in_index = current_cell.get_in_index();
-        for (int ivar = 0; ivar < NUM_VARS; ++ivar)
+        for (int ivar = 0; ivar < num_vars; ++ivar)
         {
             out[ivar] +=
                 advection_term(current_cell.get_box_pointers().m_in_ptr[ivar],
@@ -394,15 +394,15 @@ class FourthOrderDerivatives
         });
     }
 
-    template <class data_t>
-    void add_dissipation(data_t (&out)[NUM_VARS],
+    template <class data_t, int num_vars>
+    void add_dissipation(data_t (&out)[num_vars],
                          const Cell<data_t> &current_cell, const double factor,
                          const int direction) const
     {
         const int stride =
             current_cell.get_box_pointers().m_in_stride[direction];
         const int in_index = current_cell.get_in_index();
-        for (int ivar = 0; ivar < NUM_VARS; ++ivar)
+        for (int ivar = 0; ivar < num_vars; ++ivar)
         {
             out[ivar] +=
                 factor * dissipation_term<data_t>(

--- a/Source/BoxUtils/NanCheck.hpp
+++ b/Source/BoxUtils/NanCheck.hpp
@@ -31,7 +31,8 @@ class NanCheck
     void compute(Cell<double> current_cell) const
     {
         bool stop = false;
-        for (int ivar = 0; ivar < NUM_VARS; ++ivar)
+        int num_vars = current_cell.get_num_in_vars();
+        for (int ivar = 0; ivar < num_vars; ++ivar)
         {
             double val;
             current_cell.load_vars(val, ivar);
@@ -44,7 +45,7 @@ class NanCheck
             {
                 pout() << m_error_info
                        << "::Values have become nan. The current state is: \n";
-                for (int ivar = 0; ivar < NUM_VARS; ++ivar)
+                for (int ivar = 0; ivar < num_vars; ++ivar)
                 {
                     pout() << UserVariables::variable_names[ivar] << ": "
                            << current_cell.load_vars(ivar) << std::endl;

--- a/Source/BoxUtils/SetValue.hpp
+++ b/Source/BoxUtils/SetValue.hpp
@@ -23,14 +23,21 @@ class SetValue
     Interval m_interval;
 
   public:
-    SetValue(double a_value, Interval a_interval = Interval(0, NUM_VARS - 1))
+    SetValue(double a_value, Interval a_interval = Interval())
         : m_value(a_value), m_interval(a_interval)
     {
     }
 
     template <class data_t> void compute(Cell<data_t> current_cell) const
     {
-        for (int i = m_interval.begin(); i <= m_interval.end(); ++i)
+        int start_var = m_interval.begin();
+        int end_var = m_interval.end();
+        if (m_interval.size() == 0)
+        {
+            start_var = 0;
+            end_var = current_cell.get_num_out_vars() - 1;
+        }
+        for (int i = start_var; i <= end_var; ++i)
         {
             current_cell.store_vars(m_value, i);
         }

--- a/Source/BoxUtils/SetValue.hpp
+++ b/Source/BoxUtils/SetValue.hpp
@@ -8,6 +8,7 @@
 
 #include "Cell.hpp"
 #include "Interval.H"
+#include <limits>
 
 /// This compute class can be used to set the value of a cell
 /** This compute class together with BoxLoops::loop(...) can be used to set the
@@ -23,7 +24,8 @@ class SetValue
     Interval m_interval;
 
   public:
-    SetValue(double a_value, Interval a_interval = Interval())
+    SetValue(double a_value,
+             Interval a_interval = Interval(0, std::numeric_limits<int>::max()))
         : m_value(a_value), m_interval(a_interval)
     {
     }
@@ -31,12 +33,8 @@ class SetValue
     template <class data_t> void compute(Cell<data_t> current_cell) const
     {
         int start_var = m_interval.begin();
-        int end_var = m_interval.end();
-        if (m_interval.size() == 0)
-        {
-            start_var = 0;
-            end_var = current_cell.get_num_out_vars() - 1;
-        }
+        int end_var =
+            std::min(m_interval.end(), current_cell.get_num_out_vars() - 1);
         for (int i = start_var; i <= end_var; ++i)
         {
             current_cell.store_vars(m_value, i);


### PR DESCRIPTION
The Cell class now has member functions which allow querying the number of in or out components at runtime. Some other functions have been templated over a `num_vars` int.

Naively, one might expect that the changes to the `SetValue` and `NanCheck` compute classes hurts performance so I tried the following:
* `SetValue` is most often used in examples which haven't been updated to use diagnostic vars (in order to set the diagnostic-like vars to zero in the RHS evaluation). I added Chombo timers to the SetValueUnitTest and measured the time for the loop with this compute class. I did not see any noticeable increase in the time taken in this loop (for some reason it actually went faster on average with the changes). 
* For `NanCheck`, I added timers to the BinaryBH example. As one might expect, the proportion of time spent in this loop is virtually negligible so I don't think there's any point worrying about this. One might argue that the changes are unnecessary as one should only really want to use `NanCheck` on evolution variables but I would argue that the user should be able to check their diagnostic variables too.

This resolves #129.