### PR TITLE
Fix the filling of diagnostics ghosts

### DIFF
--- a/Examples/BinaryBH/params.txt
+++ b/Examples/BinaryBH/params.txt
@@ -83,8 +83,6 @@ vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
                          0.0 0.0 0.0 0.0 0.0 0.0 0.0 #K and Aij
                          0.0 0.0 0.0 0.0             #Theta and Gamma
                          1.0 0.0 0.0 0.0 0.0 0.0 0.0 #lapse shift and B
-                         #0.0 0.0 0.0 0.0             #Ham and Mom
-                         #0.0 0.0                     #Weyl
 
 # Lapse evolution
 lapse_advec_coeff = 1.0

--- a/Examples/BinaryBH/params_very_cheap.txt
+++ b/Examples/BinaryBH/params_very_cheap.txt
@@ -90,8 +90,6 @@ vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
                          0.0 0.0 0.0 0.0 0.0 0.0 0.0 #K and Aij
                          0.0 0.0 0.0 0.0             #Theta and Gamma
                          1.0 0.0 0.0 0.0 0.0 0.0 0.0 #lapse shift and B
-                         #0.0 0.0 0.0 0.0             #Ham and Mom
-                         #0.0 0.0                     #Weyl
 
 # extraction params
 # default of extraction_center is center, uncomment to change

--- a/Source/AMRInterpolator/AMRInterpolator.hpp
+++ b/Source/AMRInterpolator/AMRInterpolator.hpp
@@ -56,13 +56,13 @@ template <typename InterpAlgo> class AMRInterpolator
 
     /// set values of member 'm_lo_boundary_reflective' and
     /// 'm_hi_boundary_reflective'
-    void set_symmetric_BC();
+    void set_reflective_BC();
     int get_var_parity(int comp, const VariableType type, int point_idx,
                        const InterpolationQuery &query,
                        const Derivative &deriv) const;
     /// reflect coordinates if BC set to reflective in that direction
-    double apply_symmetric_BC_on_coord(const InterpolationQuery &query,
-                                       double dir, int point_idx) const;
+    double apply_reflective_BC_on_coord(const InterpolationQuery &query,
+                                        double dir, int point_idx) const;
 
     const AMR &m_amr;
 
@@ -99,7 +99,7 @@ template <typename InterpAlgo> class AMRInterpolator
     // Identifies the printout as originating from this class.
     const static string TAG;
 
-    // Variables for symmetric BC
+    // Variables for reflective BC
     // m_bc_params can't be a 'const' reference as we need a
     // constructor with backward compatibility that builds an artificial
     // 'BoundaryConditions::params_t'

--- a/Source/AMRInterpolator/AMRInterpolator.impl.hpp
+++ b/Source/AMRInterpolator/AMRInterpolator.impl.hpp
@@ -33,7 +33,7 @@ AMRInterpolator<InterpAlgo>::AMRInterpolator(
       m_num_levels(const_cast<AMR &>(m_amr).getAMRLevels().size()),
       m_verbosity(verbosity), m_bc_params(a_bc_params)
 {
-    set_symmetric_BC();
+    set_reflective_BC();
 }
 
 template <typename InterpAlgo> void AMRInterpolator<InterpAlgo>::refresh()
@@ -374,7 +374,7 @@ AMRInterpolator<InterpAlgo>::findBoxes(InterpolationQuery &query)
                     for (int i = 0; i < CH_SPACEDIM; ++i)
                     {
                         double coord =
-                            apply_symmetric_BC_on_coord(query, i, point_idx);
+                            apply_reflective_BC_on_coord(query, i, point_idx);
                         grid_coord[i] = (coord - m_origin[level_idx][i]) /
                                         m_dx[level_idx][i];
 
@@ -497,7 +497,7 @@ void AMRInterpolator<InterpAlgo>::prepareMPI(InterpolationQuery &query,
         {
             // m_query_coords[i][idx] = query.m_coords[i][point_idx];
             m_query_coords[i][idx] =
-                apply_symmetric_BC_on_coord(query, i, point_idx);
+                apply_reflective_BC_on_coord(query, i, point_idx);
         }
 
         m_mpi_mapping[point_idx] = idx;
@@ -747,7 +747,7 @@ void AMRInterpolator<InterpAlgo>::exchangeMPIAnswer()
 }
 
 template <typename InterpAlgo>
-void AMRInterpolator<InterpAlgo>::set_symmetric_BC()
+void AMRInterpolator<InterpAlgo>::set_reflective_BC()
 {
     const IntVect &big_end = const_cast<AMR &>(m_amr)
                                  .getAMRLevels()[0]
@@ -776,8 +776,9 @@ int AMRInterpolator<InterpAlgo>::get_var_parity(int comp,
     // check done every time because only one of the variables may be of
     // diagnostic type
     if (type == VariableType::diagnostic &&
-        m_bc_params.vars_parity_diagnostic[comp] == BoundaryConditions::UNDEF &&
-        m_bc_params.symmetric_boundaries_exist)
+        m_bc_params.vars_parity_diagnostic[comp] ==
+            BoundaryConditions::UNDEFINED &&
+        m_bc_params.reflective_boundaries_exist)
         MayDay::Error("Please provide parameter 'vars_parity_diagnostic' if "
                       "extracting diagnostic variables with reflective BC");
 
@@ -799,7 +800,7 @@ int AMRInterpolator<InterpAlgo>::get_var_parity(int comp,
 }
 
 template <typename InterpAlgo>
-double AMRInterpolator<InterpAlgo>::apply_symmetric_BC_on_coord(
+double AMRInterpolator<InterpAlgo>::apply_reflective_BC_on_coord(
     const InterpolationQuery &query, double dir, int point_idx) const
 {
     double coord = query.m_coords[dir][point_idx];

--- a/Source/GRChomboCore/BoundaryConditions.cpp
+++ b/Source/GRChomboCore/BoundaryConditions.cpp
@@ -525,7 +525,7 @@ void BoundaryConditions::copy_boundary_cells(const Side::LoHiSide a_side,
     CH_TIME("BoundaryConditions::copy_boundary_cells");
 
     CH_assert(is_defined);
-    CH_assert(a_src.size() == NUM_VARS);
+    CH_assert(a_src.nComp() == NUM_VARS);
     if (a_src.boxLayout() == a_dest.boxLayout())
     {
         // cycle through the directions
@@ -578,8 +578,8 @@ void BoundaryConditions::interp_boundaries(GRLevelData &a_fine_state,
                                            const Side::LoHiSide a_side)
 {
     CH_assert(is_defined);
-    CH_assert(a_fine_state.size() == NUM_VARS);
-    CH_assert(a_coarse_state.size() == NUM_VARS);
+    CH_assert(a_fine_state.nComp() == NUM_VARS);
+    CH_assert(a_coarse_state.nComp() == NUM_VARS);
     CH_TIME("BoundaryConditions::interp_boundaries");
 
     // cycle through the directions

--- a/Source/GRChomboCore/BoundaryConditions.cpp
+++ b/Source/GRChomboCore/BoundaryConditions.cpp
@@ -419,8 +419,8 @@ void BoundaryConditions::fill_boundary_cells_dir(
 }
 
 void BoundaryConditions::fill_sommerfeld_cell(
-    FArrayBox &rhs_box, const FArrayBox &soln_box,
-    const IntVect iv, const std::vector<int> &sommerfeld_comps) const
+    FArrayBox &rhs_box, const FArrayBox &soln_box, const IntVect iv,
+    const std::vector<int> &sommerfeld_comps) const
 {
     // assumes an asymptotic value + radial waves and permits them
     // to exit grid with minimal reflections

--- a/Source/GRChomboCore/BoundaryConditions.cpp
+++ b/Source/GRChomboCore/BoundaryConditions.cpp
@@ -130,6 +130,16 @@ void BoundaryConditions::define(double a_dx,
     m_domain_box = a_domain.domainBox();
     m_num_ghosts = a_num_ghosts;
     FOR1(i) { m_center[i] = a_center[i]; }
+    m_comps.resize(NUM_VARS);
+    for (int i = 0; i < NUM_VARS; i++)
+    {
+        m_comps[i] = i;
+    }
+    m_diagnostic_comps.resize(NUM_DIAGNOSTIC_VARS);
+    for (int i = 0; i < NUM_DIAGNOSTIC_VARS; i++)
+    {
+        m_diagnostic_comps[i] = i;
+    }
     is_defined = true;
 }
 
@@ -267,9 +277,9 @@ int BoundaryConditions::get_vars_parity(int a_comp, int a_dir,
 }
 
 /// Fill the rhs boundary values appropriately based on the params set
-void BoundaryConditions::fill_boundary_rhs(const Side::LoHiSide a_side,
-                                           const GRLevelData &a_soln,
-                                           GRLevelData &a_rhs)
+void BoundaryConditions::fill_rhs_boundaries(const Side::LoHiSide a_side,
+                                             const GRLevelData &a_soln,
+                                             GRLevelData &a_rhs)
 {
     CH_assert(is_defined);
     CH_TIME("BoundaryConditions::fill_boundary_rhs");
@@ -280,14 +290,137 @@ void BoundaryConditions::fill_boundary_rhs(const Side::LoHiSide a_side,
         // only do something if this direction is not periodic
         if (!m_params.is_periodic[idir])
         {
-            fill_boundary_cells_dir(a_side, a_soln, a_rhs, idir);
+            int boundary_condition = get_boundary_condition(a_side, idir);
+            fill_boundary_cells_dir(a_side, a_soln, a_rhs, idir,
+                                    boundary_condition);
         }
     }
 }
 
-void BoundaryConditions::fill_sommerfeld_cell(FArrayBox &rhs_box,
-                                              const FArrayBox &soln_box,
-                                              const IntVect iv) const
+/// fill solution boundary conditions, e.g. after interpolation
+void BoundaryConditions::fill_solution_boundaries(const Side::LoHiSide a_side,
+                                                  GRLevelData &a_state)
+{
+    CH_assert(is_defined);
+    CH_TIME("BoundaryConditions::fill_solution_boundaries");
+
+    // cycle through the directions
+    FOR1(idir)
+    {
+        // only do something if this direction is not periodic and solution
+        // boundary enforced in this direction
+        if (!m_params.is_periodic[idir])
+        {
+            int boundary_condition = get_boundary_condition(a_side, idir);
+
+            // same copying of cells which we require for the rhs solution
+            // but tell it we are not filling the rhs in case required
+            if (boundary_condition == REFLECTIVE_BC)
+            {
+                fill_boundary_cells_dir(a_side, a_state, a_state, idir,
+                                        boundary_condition);
+            }
+        }
+    }
+}
+
+/// fill diagnostic boundaries
+void BoundaryConditions::fill_diagnostic_boundaries(const Side::LoHiSide a_side,
+                                                    GRLevelData &a_state)
+{
+    CH_assert(is_defined);
+    CH_TIME("BoundaryConditions::fill_diagnostic_boundaries");
+
+    // cycle through the directions
+    FOR1(idir)
+    {
+        // only do something if this direction is not periodic
+        if (!m_params.is_periodic[idir])
+        {
+            int boundary_condition = get_boundary_condition(a_side, idir);
+            // for any non reflective BC, we just want to fill the ghosts with
+            // zeros so set the boundary condition to be STATIC
+            // TODO: Make this extrapolating instead once that is implemented
+            if (boundary_condition != REFLECTIVE_BC)
+            {
+                boundary_condition = STATIC_BC;
+            }
+            fill_boundary_cells_dir(a_side, a_state, a_state, idir,
+                                    boundary_condition,
+                                    VariableType::diagnostic);
+        }
+    }
+}
+
+/// Fill the boundary values appropriately based on the params set
+/// in the direction dir
+void BoundaryConditions::fill_boundary_cells_dir(
+    const Side::LoHiSide a_side, const GRLevelData &a_soln, GRLevelData &a_out,
+    const int dir, const int boundary_condition, const VariableType var_type)
+{
+    std::vector<int> a_comps =
+        (var_type == VariableType::evolution ? m_comps : m_diagnostic_comps);
+
+    // iterate through the boxes, shared amongst threads
+    DataIterator dit = a_out.dataIterator();
+    int nbox = dit.size();
+#pragma omp parallel for default(shared)
+    for (int ibox = 0; ibox < nbox; ++ibox)
+    {
+        DataIndex dind = dit[ibox];
+        FArrayBox &out_box = a_out[dind];
+        const FArrayBox &soln_box = a_soln[dind];
+        Box this_box = out_box.box();
+        IntVect offset_lo = -this_box.smallEnd() + m_domain_box.smallEnd();
+        IntVect offset_hi = +this_box.bigEnd() - m_domain_box.bigEnd();
+
+        // reduce box to the intersection of the box and the
+        // problem domain ie remove all outer ghost cells
+        this_box &= m_domain_box;
+        // get the boundary box (may be Empty)
+        Box boundary_box =
+            get_boundary_box(a_side, dir, offset_lo, offset_hi, this_box);
+
+        // now we have the appropriate box, fill it!
+        BoxIterator bit(boundary_box);
+        for (bit.begin(); bit.ok(); ++bit)
+        {
+            IntVect iv = bit();
+            switch (boundary_condition)
+            {
+            // simplest case - boundary values are set to zero
+            case STATIC_BC:
+            {
+                for (int icomp : a_comps)
+                {
+                    out_box(iv, icomp) = 0.0;
+                }
+                break;
+            }
+            // Sommerfeld is outgoing radiation - only applies to rhs
+            case SOMMERFELD_BC:
+            {
+                fill_sommerfeld_cell(out_box, soln_box, iv, a_comps);
+                break;
+            }
+            // Enforce a reflective symmetry in some direction
+            case REFLECTIVE_BC:
+            {
+                fill_reflective_cell(out_box, iv, a_side, dir, a_comps,
+                                     var_type);
+                break;
+            }
+            default:
+                MayDay::Error(
+                    "BoundaryCondition::Supplied boundary not supported.");
+            } // end switch
+        }     // end iterate over box
+    }         // end iterate over boxes
+}
+
+void BoundaryConditions::fill_sommerfeld_cell(
+    FArrayBox &rhs_box, const FArrayBox &soln_box,
+    const IntVect iv, const std::vector<int> &sommerfeld_comps) const
 {
     // assumes an asymptotic value + radial waves and permits them
     // to exit grid with minimal reflections
@@ -302,7 +435,7 @@ void BoundaryConditions::fill_sommerfeld_cell(FArrayBox &rhs_box,
     IntVect hi_local_offset = soln_box.bigEnd() - iv;
 
     // Apply Sommerfeld BCs to each variable
-    for (int icomp = 0; icomp < NUM_VARS; icomp++)
+    for (int icomp : sommerfeld_comps)
     {
         rhs_box(iv, icomp) = 0.0;
         FOR1(idir2)
@@ -355,10 +488,10 @@ void BoundaryConditions::fill_sommerfeld_cell(FArrayBox &rhs_box,
     }
 }
 
-void BoundaryConditions::fill_reflective_cell(FArrayBox &out_box,
-                                              const IntVect iv,
-                                              const Side::LoHiSide a_side,
-                                              const int dir) const
+void BoundaryConditions::fill_reflective_cell(
+    FArrayBox &out_box, const IntVect iv, const Side::LoHiSide a_side,
+    const int dir, const std::vector<int> &reflective_comps,
+    const VariableType var_type) const
 {
     // assume boundary is a reflection of values within the grid
     // care must be taken with variable parity to maintain correct
@@ -376,78 +509,15 @@ void BoundaryConditions::fill_reflective_cell(FArrayBox &out_box,
     }
 
     // replace value at iv with value at iv_copy
-    for (int icomp = 0; icomp < NUM_VARS; icomp++)
+    for (int icomp : reflective_comps)
     {
-        int parity = get_vars_parity(icomp, dir); // evolution variable
+        int parity = get_vars_parity(icomp, dir, var_type);
         out_box(iv, icomp) = parity * out_box(iv_copy, icomp);
     }
 }
 
-/// Fill the boundary values appropriately based on the params set
-/// in the direction dir
-void BoundaryConditions::fill_boundary_cells_dir(const Side::LoHiSide a_side,
-                                                 const GRLevelData &a_soln,
-                                                 GRLevelData &a_out,
-                                                 const int dir,
-                                                 const bool filling_rhs_cells)
-{
-    // iterate through the boxes, shared amongst threads
-    DataIterator dit = a_out.dataIterator();
-    int nbox = dit.size();
-#pragma omp parallel for default(shared)
-    for (int ibox = 0; ibox < nbox; ++ibox)
-    {
-        DataIndex dind = dit[ibox];
-        FArrayBox &out_box = a_out[dind];
-        const FArrayBox &soln_box = a_soln[dind];
-        Box this_box = out_box.box();
-        IntVect offset_lo = -this_box.smallEnd() + m_domain_box.smallEnd();
-        IntVect offset_hi = +this_box.bigEnd() - m_domain_box.bigEnd();
-
-        // reduce box to the intersection of the box and the
-        // problem domain ie remove all outer ghost cells
-        this_box &= m_domain_box;
-        // get the boundary box (may be Empty) and the condition on it
-        int boundary_condition = get_boundary_condition(a_side, dir);
-        Box boundary_box =
-            get_boundary_box(a_side, dir, offset_lo, offset_hi, this_box);
-
-        // now we have the appropriate box, fill it!
-        BoxIterator bit(boundary_box);
-        for (bit.begin(); bit.ok(); ++bit)
-        {
-            IntVect iv = bit();
-            switch (boundary_condition)
-            {
-            // simplest case - boundary values are fixed to the initial ones
-            case STATIC_BC:
-            {
-                for (int icomp = 0; icomp < NUM_VARS; icomp++)
-                {
-                    out_box(iv, icomp) = 0.0;
-                }
-                break;
-            }
-            case SOMMERFELD_BC:
-            {
-                fill_sommerfeld_cell(out_box, soln_box, iv);
-                break;
-            }
-            case REFLECTIVE_BC:
-            {
-                fill_reflective_cell(out_box, iv, a_side, dir);
-                break;
-            }
-            default:
-                MayDay::Error(
-                    "BoundaryCondition::Supplied boundary not supported.");
-            } // end switch
-        }     // end iterate over box
-    }         // end iterate over boxes
-}
-
 /// Copy the boundary values from src to dest
-/// NB assumes same box layout of input and output data
+/// NB only acts if same box layout of input and output data
 void BoundaryConditions::copy_boundary_cells(const Side::LoHiSide a_side,
                                              const GRLevelData &a_src,
                                              GRLevelData &a_dest)
@@ -455,6 +525,7 @@ void BoundaryConditions::copy_boundary_cells(const Side::LoHiSide a_side,
     CH_TIME("BoundaryConditions::copy_boundary_cells");
 
     CH_assert(is_defined);
+    CH_assert(a_src.size() == NUM_VARS);
     if (a_src.boxLayout() == a_dest.boxLayout())
     {
         // cycle through the directions
@@ -500,34 +571,6 @@ void BoundaryConditions::copy_boundary_cells(const Side::LoHiSide a_side,
     }                 // end test for same box layout
 }
 
-/// enforce solution boundary conditions, e.g. after interpolation
-void BoundaryConditions::enforce_solution_boundaries(
-    const Side::LoHiSide a_side, GRLevelData &a_state)
-{
-    CH_assert(is_defined);
-    CH_TIME("BoundaryConditions::enforce_solution_boundaries");
-
-    // cycle through the directions
-    FOR1(idir)
-    {
-        // only do something if this direction is not periodic and solution
-        // boundary enforced
-        if (!m_params.is_periodic[idir])
-        {
-            int boundary_condition = get_boundary_condition(a_side, idir);
-
-            // same copying of cells which we require for the rhs solution
-            // but tell it we are not filling the rhs in case required
-            if (boundary_condition == REFLECTIVE_BC)
-            {
-                const bool filling_rhs_cells = false;
-                fill_boundary_cells_dir(a_side, a_state, a_state, idir,
-                                        filling_rhs_cells);
-            }
-        }
-    }
-}
-
 /// Fill the fine boundary values in a_state
 /// Required for interpolating onto finer levels at boundaries
 void BoundaryConditions::interp_boundaries(GRLevelData &a_fine_state,
@@ -535,6 +578,8 @@ void BoundaryConditions::interp_boundaries(GRLevelData &a_fine_state,
                                            const Side::LoHiSide a_side)
 {
     CH_assert(is_defined);
+    CH_assert(a_fine_state.size() == NUM_VARS);
+    CH_assert(a_coarse_state.size() == NUM_VARS);
     CH_TIME("BoundaryConditions::interp_boundaries");
 
     // cycle through the directions

--- a/Source/GRChomboCore/BoundaryConditions.hpp
+++ b/Source/GRChomboCore/BoundaryConditions.hpp
@@ -126,7 +126,7 @@ class BoundaryConditions
     void fill_solution_boundaries(const Side::LoHiSide a_side,
                                   GRLevelData &a_state);
 
-    /// enforce solution boundary conditions, e.g. after interpolation
+    /// fill diagnostic boundaries - used in AMRInterpolator
     void fill_diagnostic_boundaries(const Side::LoHiSide a_side,
                                     GRLevelData &a_state);
 
@@ -134,7 +134,7 @@ class BoundaryConditions
     /// in the direction dir
     void fill_boundary_cells_dir(
         const Side::LoHiSide a_side, const GRLevelData &a_soln,
-        GRLevelData &a_rhs, const int dir, const int boundary_condition,
+        GRLevelData &a_out, const int dir, const int boundary_condition,
         const VariableType var_type = VariableType::evolution);
 
     /// Copy the boundary values from src to dest

--- a/Source/GRChomboCore/BoundaryConditions.hpp
+++ b/Source/GRChomboCore/BoundaryConditions.hpp
@@ -18,7 +18,7 @@
 
 /// Class which deals with the boundaries at the edge of the physical domain in
 /// cases where they are not periodic. Currently only options are static BCs,
-/// sommerfeld (outgoing radiation) and symmetric. The conditions can differ in
+/// sommerfeld (outgoing radiation) and reflective. The conditions can differ in
 /// the high and low directions.
 /// In cases where different variables/boundaries are required, the user should
 /// (usually) write their own conditions class which inherits from this one.
@@ -47,7 +47,7 @@ class BoundaryConditions
         ODD_YZ,
         ODD_XZ,
         ODD_XYZ,
-        UNDEF
+        UNDEFINED
     };
 
     /// Structure containing the boundary condition params
@@ -57,7 +57,9 @@ class BoundaryConditions
         std::array<int, CH_SPACEDIM> lo_boundary;
         std::array<bool, CH_SPACEDIM> is_periodic;
         bool nonperiodic_boundaries_exist;
-        bool symmetric_boundaries_exist;
+        bool boundary_solution_enforced;
+        bool boundary_rhs_enforced;
+        bool reflective_boundaries_exist;
         bool sommerfeld_boundaries_exist;
 
         std::array<int, NUM_VARS> vars_parity;
@@ -119,18 +121,18 @@ class BoundaryConditions
 
     /// Fill the boundary values appropriately based on the params set
     /// in the direction dir
-    void fill_boundary_rhs_dir(const Side::LoHiSide a_side,
-                               const GRLevelData &a_soln, GRLevelData &a_rhs,
-                               const int dir);
+    void fill_boundary_cells_dir(const Side::LoHiSide a_side,
+                                 const GRLevelData &a_soln, GRLevelData &a_rhs,
+                                 const int dir, const bool filling_rhs = true);
 
     /// Copy the boundary values from src to dest
     /// NB assumes same box layout of input and output data
     void copy_boundary_cells(const Side::LoHiSide a_side,
                              const GRLevelData &a_src, GRLevelData &a_dest);
 
-    /// enforce symmetric boundary conditions, e.g. after interpolation
-    void enforce_symmetric_boundaries(const Side::LoHiSide a_side,
-                                      GRLevelData &a_state);
+    /// enforce solution boundary conditions, e.g. after interpolation
+    void enforce_solution_boundaries(const Side::LoHiSide a_side,
+                                     GRLevelData &a_state);
 
     /// Fill the fine boundary values in a_state
     /// Required for interpolating onto finer levels at boundaries

--- a/Source/GRChomboCore/BoundaryConditions.hpp
+++ b/Source/GRChomboCore/BoundaryConditions.hpp
@@ -77,12 +77,15 @@ class BoundaryConditions
 
   protected:
     // Member values
-    double m_dx;            // The grid spacing
-    int m_num_ghosts;       // the number of ghosts (usually 3)
-    params_t m_params;      // the boundary params
-    RealVect m_center;      // the position of the center of the grid
-    ProblemDomain m_domain; // the problem domain (excludes boundary cells)
-    Box m_domain_box;       // The box representing the domain
+    double m_dx;              // The grid spacing
+    int m_num_ghosts;         // the number of ghosts (usually 3)
+    params_t m_params;        // the boundary params
+    RealVect m_center;        // the position of the center of the grid
+    ProblemDomain m_domain;   // the problem domain (excludes boundary cells)
+    Box m_domain_box;         // The box representing the domain
+    std::vector<int> m_comps; // a vector of c_nums for all the evolution vars
+    std::vector<int>
+        m_diagnostic_comps; // a vector of c_nums for all the diagnostic vars
     bool is_defined; // whether the BoundaryConditions class members are defined
 
   public:
@@ -116,23 +119,28 @@ class BoundaryConditions
                     const VariableType var_type = VariableType::evolution);
 
     /// Fill the rhs boundary values appropriately based on the params set
-    void fill_boundary_rhs(const Side::LoHiSide a_side,
-                           const GRLevelData &a_soln, GRLevelData &a_rhs);
+    void fill_rhs_boundaries(const Side::LoHiSide a_side,
+                             const GRLevelData &a_soln, GRLevelData &a_rhs);
+
+    /// enforce solution boundary conditions, e.g. after interpolation
+    void fill_solution_boundaries(const Side::LoHiSide a_side,
+                                  GRLevelData &a_state);
+
+    /// enforce solution boundary conditions, e.g. after interpolation
+    void fill_diagnostic_boundaries(const Side::LoHiSide a_side,
+                                    GRLevelData &a_state);
 
     /// Fill the boundary values appropriately based on the params set
     /// in the direction dir
-    void fill_boundary_cells_dir(const Side::LoHiSide a_side,
-                                 const GRLevelData &a_soln, GRLevelData &a_rhs,
-                                 const int dir, const bool filling_rhs = true);
+    void fill_boundary_cells_dir(
+        const Side::LoHiSide a_side, const GRLevelData &a_soln,
+        GRLevelData &a_rhs, const int dir, const int boundary_condition,
+        const VariableType var_type = VariableType::evolution);
 
     /// Copy the boundary values from src to dest
     /// NB assumes same box layout of input and output data
     void copy_boundary_cells(const Side::LoHiSide a_side,
                              const GRLevelData &a_src, GRLevelData &a_dest);
-
-    /// enforce solution boundary conditions, e.g. after interpolation
-    void enforce_solution_boundaries(const Side::LoHiSide a_side,
-                                     GRLevelData &a_state);
 
     /// Fill the fine boundary values in a_state
     /// Required for interpolating onto finer levels at boundaries
@@ -166,9 +174,12 @@ class BoundaryConditions
     static void write_sommerfeld_conditions(int idir, const params_t &a_params);
 
     void fill_sommerfeld_cell(FArrayBox &rhs_box, const FArrayBox &soln_box,
-                              const IntVect iv) const;
-    void fill_reflective_cell(FArrayBox &rhs_box, const IntVect iv,
-                              const Side::LoHiSide a_side, const int dir) const;
+                              const IntVect iv,
+                              const std::vector<int> &sommerfeld_comps) const;
+    void fill_reflective_cell(
+        FArrayBox &rhs_box, const IntVect iv, const Side::LoHiSide a_side,
+        const int dir, const std::vector<int> &reflective_comps,
+        const VariableType var_type = VariableType::evolution) const;
 };
 
 /// This derived class is used by expand_grids_to_boundaries to grow the

--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -924,8 +924,8 @@ void GRAMRLevel::evalRHS(GRLevelData &rhs, GRLevelData &soln,
     // evolution of the boundaries according to conditions
     if (m_p.boundary_params.nonperiodic_boundaries_exist)
     {
-        m_boundaries.fill_boundary_rhs(Side::Lo, soln, rhs);
-        m_boundaries.fill_boundary_rhs(Side::Hi, soln, rhs);
+        m_boundaries.fill_rhs_boundaries(Side::Lo, soln, rhs);
+        m_boundaries.fill_rhs_boundaries(Side::Hi, soln, rhs);
     }
 }
 
@@ -1006,6 +1006,14 @@ void GRAMRLevel::fillAllDiagnosticsGhosts()
             0, 0, NUM_DIAGNOSTIC_VARS);
     }
     m_state_diagnostics.exchange(m_exchange_copier);
+
+    // We should always fill the boundary ghosts to avoid nans
+    // if we have non periodic directions
+    if (m_p.boundary_params.nonperiodic_boundaries_exist)
+    {
+        m_boundaries.fill_diagnostic_boundaries(Side::Hi, m_state_diagnostics);
+        m_boundaries.fill_diagnostic_boundaries(Side::Lo, m_state_diagnostics);
+    }
 }
 
 void GRAMRLevel::fillIntralevelGhosts()
@@ -1019,8 +1027,8 @@ void GRAMRLevel::fillBdyGhosts(GRLevelData &a_state)
     // enforce solution BCs after filling ghosts
     if (m_p.boundary_params.boundary_solution_enforced)
     {
-        m_boundaries.enforce_solution_boundaries(Side::Hi, a_state);
-        m_boundaries.enforce_solution_boundaries(Side::Lo, a_state);
+        m_boundaries.fill_solution_boundaries(Side::Hi, a_state);
+        m_boundaries.fill_solution_boundaries(Side::Lo, a_state);
     }
 }
 

--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -158,7 +158,7 @@ Real GRAMRLevel::advance()
     }
 
     specificAdvance();
-    // enforce symmetric BCs - in case of updates in specificAdvance
+    // enforce solution BCs - in case of updates in specificAdvance
     fillBdyGhosts(m_state_new);
 
     m_time += m_dt;
@@ -182,7 +182,7 @@ void GRAMRLevel::postTimeStep()
 
     specificPostTimeStep();
 
-    // enforce symmetric BCs - this is required after the averaging
+    // enforce solution BCs - this is required after the averaging
     // and postentially after specificPostTimeStep actions
     fillBdyGhosts(m_state_new);
 
@@ -326,7 +326,7 @@ void GRAMRLevel::regrid(const Vector<Box> &a_new_grids)
     // interpolated)
     copyBdyGhosts(m_state_old, m_state_new);
 
-    // enforce symmetric BCs (overwriting any interpolation)
+    // enforce solution BCs (overwriting any interpolation)
     fillBdyGhosts(m_state_new);
 
     m_state_old.define(level_domain, NUM_VARS, iv_ghosts);
@@ -1016,11 +1016,11 @@ void GRAMRLevel::fillIntralevelGhosts()
 
 void GRAMRLevel::fillBdyGhosts(GRLevelData &a_state)
 {
-    // enforce symmetric BCs after filling ghosts
-    if (m_p.boundary_params.symmetric_boundaries_exist)
+    // enforce solution BCs after filling ghosts
+    if (m_p.boundary_params.boundary_solution_enforced)
     {
-        m_boundaries.enforce_symmetric_boundaries(Side::Hi, a_state);
-        m_boundaries.enforce_symmetric_boundaries(Side::Lo, a_state);
+        m_boundaries.enforce_solution_boundaries(Side::Hi, a_state);
+        m_boundaries.enforce_solution_boundaries(Side::Lo, a_state);
     }
 }
 


### PR DESCRIPTION
This at least compiles and runs, and in principle should fill the diagnostic ghosts with either zeros (default) or if symmetric with the symmetric conditions, using the appropriate parity conditions. Once we have extrapolating BCs I would amend the code to use these instead, but at least zeros will prevent nans, and physically one should not extract near static or sommerfeld BCs anyway.

I also took the opportunity to tidy up the naming and to make a few changes which will help once the extrapolating BCs go in - especially to allow a subset of vars to be filled in the sommerfeld and reflective cases.