### PR TITLE
Add total num boxes in GRAMRLevel::advance print

### DIFF
--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -107,9 +107,10 @@ Real GRAMRLevel::advance()
     // balancing)
     const DisjointBoxLayout &level_domain = m_state_new.disjointBoxLayout();
     int nbox = level_domain.dataIterator().size();
+    int total_nbox = level_domain.size();
     pout() << "GRAMRLevel::advance level " << m_level << " at time " << m_time
            << " (" << speed << " M/hr)"
-           << ". Boxes on this rank: " << nbox << "." << endl;
+           << ". Boxes on this rank: " << nbox << " / " << total_nbox << endl;
 
     // copy soln to old state to save it
     m_state_new.copyTo(m_state_new.interval(), m_state_old,


### PR DESCRIPTION
This is to aid with load balancing. It is arguably easier to read and access than the LB.txt file which is only generated when the environment variable `CH_TIMER` is set.