### PR TITLE
Add multiple regrid thresholds with backward compatibility

### DIFF
--- a/Examples/KerrBH/params.txt
+++ b/Examples/KerrBH/params.txt
@@ -23,16 +23,18 @@ kerr_spin = 0.5
 #kerr_center = 64 64 64
 
 # Regridding
-# Thresholds on the change across a cell which prompts regrid
-regrid_threshold = 0.3
 
 # Level data
 # Maximum number of times you can regrid above coarsest level
 max_level = 6 # There are (max_level+1) grids, so min is zero
-# Frequency of regridding at each level
+
+# Frequency of regridding at each level and thresholds on the tagging
 # Need one for each level, ie max_level+1 items
 # Generally you do not need to regrid frequently on every level
-regrid_interval = 50 25 5 5 5 5 5
+# Level Regridding:   0   1   2   3   4   5   6
+regrid_interval   =  50  25   5   5   5   5   5
+regrid_thresholds = 0.3 0.3 0.3 0.3 0.3 0.3 0.3
+
 # Max box sizes
 max_grid_size = 16
 # Min box size

--- a/Examples/KerrBH/params_cheap.txt
+++ b/Examples/KerrBH/params_cheap.txt
@@ -23,16 +23,18 @@ kerr_spin = 0.5
 #kerr_center = 64 64 64
 
 # Regridding
-# Thresholds on the change across a cell which prompts regrid
-regrid_threshold = 0.3
 
 # Level data
 # Maximum number of times you can regrid above coarsest level
-max_level = 3 #4 There are (max_level+1) grids, so min is zero
-# Frequency of regridding at each level
+max_level = 4 #4 There are (max_level+1) grids, so min is zero
+
+# Frequency of regridding at each level and thresholds on the tagging
 # Need one for each level, ie max_level+1 items
 # Generally you do not need to regrid frequently on every level
-regrid_interval = 50 25 5 5 5 5 5
+# Level Regridding:   0   1   2   3   4   5   6
+regrid_interval   =  50  25   5   5   5   5   5
+regrid_thresholds = 0.3 0.3 0.3 0.3 0.3
+
 # Max box sizes
 max_grid_size = 16
 # Min box size

--- a/Source/GRChomboCore/BoundaryConditions.cpp
+++ b/Source/GRChomboCore/BoundaryConditions.cpp
@@ -14,8 +14,8 @@
 BoundaryConditions::params_t::params_t()
 {
     // set defaults
-    hi_boundary = {STATIC_BC, STATIC_BC, STATIC_BC};
-    lo_boundary = {STATIC_BC, STATIC_BC, STATIC_BC};
+    hi_boundary.fill(STATIC_BC);
+    lo_boundary.fill(STATIC_BC);
     is_periodic.fill(true);
     nonperiodic_boundaries_exist = false;
     boundary_solution_enforced = false;

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -22,7 +22,6 @@ class ChomboParameters
     {
         pp.load("verbosity", verbosity, 0);
         // Grid setup
-        pp.load("regrid_threshold", regrid_threshold, 0.5);
         pp.load("num_ghosts", num_ghosts, 3);
         pp.load("tag_buffer_size", tag_buffer_size, 3);
         pp.load("dt_multiplier", dt_multiplier, 0.25);
@@ -46,6 +45,19 @@ class ChomboParameters
         ref_ratios.resize(max_level + 1);
         ref_ratios.assign(2);
         pp.getarr("regrid_interval", regrid_interval, 0, max_level + 1);
+
+        if (pp.contains("regrid_thresholds"))
+        {
+            pout() << "Using multiple regrid thresholds." << std::endl;
+            pp.getarr("regrid_thresholds", regrid_thresholds, 0, max_level + 1);
+        }
+        else
+        {
+            pout() << "Using single regrid threshold." << std::endl;
+            double regrid_threshold;
+            pp.load("regrid_threshold", regrid_threshold, 0.5);
+            regrid_thresholds = Vector<double>(max_level + 1, regrid_threshold);
+        }
 
         // time stepping outputs and regrid data
         pp.load("checkpoint_interval", checkpoint_interval, 1);
@@ -241,9 +253,15 @@ class ChomboParameters
 
         // Grid center
         // now that L is surely set, get center
+#if CH_SPACEDIM == 3
         pp.load("center", center,
                 {0.5 * Ni[0] * coarsest_dx, 0.5 * Ni[1] * coarsest_dx,
                  0.5 * Ni[2] * coarsest_dx}); // default to center
+#elif CH_SPACEDIM == 2
+        pp.load("center", center,
+                {0.5 * Ni[0] * coarsest_dx,
+                 0.5 * Ni[1] * coarsest_dx}); // default to center
+#endif
 
         FOR1(idir)
         {
@@ -294,7 +312,7 @@ class ChomboParameters
     BoundaryConditions::params_t boundary_params; // set boundaries in each dir
 
     // For tagging
-    double regrid_threshold;
+    Vector<double> regrid_thresholds;
 };
 
 #endif /* CHOMBOPARAMETERS_HPP_ */

--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -235,7 +235,8 @@ void GRAMRLevel::tagCells(IntVectSet &a_tags)
                 for (int ix = xmin; ix <= xmax; ++ix)
                 {
                     IntVect iv(ix, iy, iz);
-                    if (tagging_criterion(iv, 0) >= m_p.regrid_threshold)
+                    if (tagging_criterion(iv, 0) >=
+                        m_p.regrid_thresholds[m_level])
                     {
 // local_tags |= is not thread safe.
 #pragma omp critical


### PR DESCRIPTION
This solves #95 .

In this small PR, a parameter `regrid_thresholds` is introduced. `regrid_threshold` can be used as before, or instead `regrid_thresholds` can be given as a vector of `max_level+1` components, just like `regrid_interval`.

The idea mainly came from @paufigueras and @Chenxiagu , but I saw it in the pending issues and realized it was quick to add to the public code.