### PR TITLE
Update for extrapolating BC and update SF example to use them

### DIFF
--- a/Examples/BinaryBH/params.txt
+++ b/Examples/BinaryBH/params.txt
@@ -78,11 +78,10 @@ vars_parity_diagnostic = 0 1 2 3          #Ham and Mom
                          0 7              #Weyl
 
 # if sommerfeld boundaries selected, must select
-# asymptotic values (in order given by UserVariables.hpp)
-vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
-                         0.0 0.0 0.0 0.0 0.0 0.0 0.0 #K and Aij
-                         0.0 0.0 0.0 0.0             #Theta and Gamma
-                         1.0 0.0 0.0 0.0 0.0 0.0 0.0 #lapse shift and B
+# asymptotic values
+num_nonzero_asymptotic_vars = 5
+nonzero_asymptotic_vars = chi h11 h22 h33 lapse
+nonzero_asymptotic_values = 1.0 1.0 1.0 1.0 1.0
 
 # Lapse evolution
 lapse_advec_coeff = 1.0

--- a/Examples/BinaryBH/params_very_cheap.txt
+++ b/Examples/BinaryBH/params_very_cheap.txt
@@ -83,11 +83,10 @@ vars_parity_diagnostic = 0 1 2 3          #Ham and Mom
                          0 7              #Weyl
 
 # if sommerfeld boundaries selected, must select
-# asymptotic values (in order given by UserVariables.hpp)
-vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
-                         0.0 0.0 0.0 0.0 0.0 0.0 0.0 #K and Aij
-                         0.0 0.0 0.0 0.0             #Theta and Gamma
-                         1.0 0.0 0.0 0.0 0.0 0.0 0.0 #lapse shift and B
+# non zero asymptotic values
+num_nonzero_asymptotic_vars = 5
+nonzero_asymptotic_vars = chi h11 h22 h33 lapse
+nonzero_asymptotic_values = 1.0 1.0 1.0 1.0 1.0
 
 track_punctures = 1
 puncture_tracking_level = 1

--- a/Examples/KerrBH/params.txt
+++ b/Examples/KerrBH/params.txt
@@ -64,12 +64,10 @@ vars_parity            = 0 0 4 6 0 5 0    #chi and hij
 vars_parity_diagnostic = 0 1 2 3          #Ham and Mom
 
 # if sommerfeld boundaries selected, must select 
-# asymptotic values (in order given by UserVariables.hpp)
-vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
-                         0.0 0.0 0.0 0.0 0.0 0.0 0.0 #K and Aij
-                         0.0 0.0 0.0 0.0             #Theta and Gamma
-                         1.0 0.0 0.0 0.0 0.0 0.0 0.0 #lapse shift and B
-                         #0.0 0.0 0.0 0.0             #Ham and Mom
+# non zero asymptotic values
+num_nonzero_asymptotic_vars = 5
+nonzero_asymptotic_vars = chi h11 h22 h33 lapse
+nonzero_asymptotic_values = 1.0 1.0 1.0 1.0 1.0
 
 # Set up time steps
 # dt will be dx*dt_multiplier on each grid level
@@ -100,7 +98,6 @@ kappa3 = 0
 covariantZ4 = 0 # 0: default. 1: dampk1 -> dampk1/lapse
 
 # coefficient for KO numerical dissipation
-# NB must be less than 0.5 for stability
 sigma = 0.3
 
 #extraction params

--- a/Examples/KerrBH/params_cheap.txt
+++ b/Examples/KerrBH/params_cheap.txt
@@ -69,7 +69,6 @@ vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
                          0.0 0.0 0.0 0.0 0.0 0.0 0.0 #K and Aij
                          0.0 0.0 0.0 0.0             #Theta and Gamma
                          1.0 0.0 0.0 0.0 0.0 0.0 0.0 #lapse shift and B
-                         #0.0 0.0 0.0 0.0             #Ham and Mom
 
 # Set up time steps
 # dt will be dx*dt_multiplier on each grid level

--- a/Examples/ScalarField/GNUmakefile
+++ b/Examples/ScalarField/GNUmakefile
@@ -20,6 +20,6 @@ src_dirs := $(GRCHOMBO_SOURCE)/utils \
             $(GRCHOMBO_SOURCE)/GRChomboCore  \
             $(GRCHOMBO_SOURCE)/TaggingCriteria  \
             $(GRCHOMBO_SOURCE)/AMRInterpolator  \
-            $(GRCHOMBO_SOURCE)/InitialConditions/ScalarFields
+            $(GRCHOMBO_SOURCE)/InitialConditions/BlackHoles
 
 include $(CHOMBO_HOME)/mk/Make.test

--- a/Examples/ScalarField/InitialScalarData.hpp
+++ b/Examples/ScalarField/InitialScalarData.hpp
@@ -1,0 +1,60 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef INITIALSCALARDATA_HPP_
+#define INITIALSCALARDATA_HPP_
+
+#include "Cell.hpp"
+#include "Coordinates.hpp"
+#include "MatterCCZ4.hpp"
+#include "ScalarField.hpp"
+#include "Tensor.hpp"
+#include "UserVariables.hpp" //This files needs NUM_VARS - total no. components
+#include "VarsTools.hpp"
+#include "simd.hpp"
+
+//! Class which sets the initial scalar field matter config
+class InitialScalarData
+{
+  public:
+    //! A structure for the input params for scalar field properties and initial
+    //! conditions
+    struct params_t
+    {
+        double amplitude; //!< Amplitude of bump in initial SF bubble
+        std::array<double, CH_SPACEDIM>
+            center;   //!< Centre of perturbation in initial SF bubble
+        double width; //!< Width of bump in initial SF bubble
+    };
+
+    //! The constructor
+    InitialScalarData(params_t a_params, double a_dx)
+        : m_dx(a_dx), m_params(a_params)
+    {
+    }
+
+    //! Function to compute the value of all the initial vars on the grid
+    template <class data_t> void compute(Cell<data_t> current_cell) const
+    {
+        // where am i?
+        Coordinates<data_t> coords(current_cell, m_dx, m_params.center);
+        data_t rr = coords.get_radius();
+        data_t rr2 = rr * rr;
+
+        // calculate the field value
+        data_t phi = m_params.amplitude *
+                     (1.0 + 0.01 * rr2 * exp(-pow(rr / m_params.width, 2.0)));
+
+        // store the vars
+        current_cell.store_vars(phi, c_phi);
+        current_cell.store_vars(0.0, c_Pi);
+    }
+
+  protected:
+    double m_dx;
+    const params_t m_params; //!< The matter initial condition params
+};
+
+#endif /* INITIALSCALARDATA_HPP_ */

--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -106,5 +106,5 @@ void ScalarFieldLevel::computeTaggingCriterion(FArrayBox &tagging_criterion,
 {
     BoxLoops::loop(
         FixedGridsTaggingCriterion(m_dx, m_level, 2.0 * m_p.L, m_p.center),
-        current_state, tagging_criterion, disable_simd());
+        current_state, tagging_criterion);
 }

--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -17,13 +17,14 @@
 #include "NewMatterConstraints.hpp"
 
 // For tag cells
-#include "ChiAndPhiTaggingCriterion.hpp"
+#include "FixedGridsTaggingCriterion.hpp"
 
 // Problem specific includes
-#include "ChiRelaxation.hpp"
 #include "ComputePack.hpp"
+#include "GammaCalculator.hpp"
+#include "InitialScalarData.hpp"
+#include "KerrBH.hpp"
 #include "Potential.hpp"
-#include "ScalarBubble.hpp"
 #include "ScalarField.hpp"
 #include "SetValue.hpp"
 
@@ -50,10 +51,15 @@ void ScalarFieldLevel::initialData()
         pout() << "ScalarFieldLevel::initialData " << m_level << endl;
 
     // First set everything to zero then initial conditions for scalar field -
-    // here a bubble
-    BoxLoops::loop(make_compute_pack(SetValue(0.0),
-                                     ScalarBubble(m_p.initial_params, m_dx)),
-                   m_state_new, m_state_new, INCLUDE_GHOST_CELLS);
+    // here a Kerr BH and a scalar field profile
+    BoxLoops::loop(
+        make_compute_pack(SetValue(0.), KerrBH(m_p.kerr_params, m_dx),
+                          InitialScalarData(m_p.initial_params, m_dx)),
+        m_state_new, m_state_new, INCLUDE_GHOST_CELLS);
+
+    fillAllGhosts();
+    BoxLoops::loop(GammaCalculator(m_dx), m_state_new, m_state_new,
+                   EXCLUDE_GHOST_CELLS);
 }
 
 // Things to do before outputting a checkpoint file
@@ -72,41 +78,19 @@ void ScalarFieldLevel::prePlotLevel()
 void ScalarFieldLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
                                        const double a_time)
 {
+    // Enforce trace free A_ij and positive chi and alpha
+    BoxLoops::loop(
+        make_compute_pack(TraceARemoval(),
+                          PositiveChiAndAlpha(m_p.min_chi, m_p.min_lapse)),
+        a_soln, a_soln, INCLUDE_GHOST_CELLS);
 
-    // Relaxation function for chi - this will eventually be done separately
-    // with hdf5 as input
-    if (m_time < m_p.relaxtime)
-    {
-        // Calculate chi relaxation right hand side
-        // Note this assumes conformal chi and Mom constraint trivially
-        // satisfied  No evolution in other variables, which are assumed to
-        // satisfy constraints per initial conditions
-        Potential potential(m_p.potential_params);
-        ScalarFieldWithPotential scalar_field(potential);
-        ChiRelaxation<ScalarFieldWithPotential> relaxation(
-            scalar_field, m_dx, m_p.relaxspeed, m_p.G_Newton);
-        SetValue set_other_values_zero(0.0, Interval(c_h11, NUM_VARS - 1));
-        auto compute_pack1 =
-            make_compute_pack(relaxation, set_other_values_zero);
-        BoxLoops::loop(compute_pack1, a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
-    }
-    else
-    {
-
-        // Enforce trace free A_ij and positive chi and alpha
-        BoxLoops::loop(
-            make_compute_pack(TraceARemoval(),
-                              PositiveChiAndAlpha(m_p.min_chi, m_p.min_lapse)),
-            a_soln, a_soln, INCLUDE_GHOST_CELLS);
-
-        // Calculate MatterCCZ4 right hand side with matter_t = ScalarField
-        Potential potential(m_p.potential_params);
-        ScalarFieldWithPotential scalar_field(potential);
-        MatterCCZ4<ScalarFieldWithPotential> my_ccz4_matter(
-            scalar_field, m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation,
-            m_p.G_Newton);
-        BoxLoops::loop(my_ccz4_matter, a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
-    }
+    // Calculate MatterCCZ4 right hand side with matter_t = ScalarField
+    Potential potential(m_p.potential_params);
+    ScalarFieldWithPotential scalar_field(potential);
+    MatterCCZ4<ScalarFieldWithPotential> my_ccz4_matter(
+        scalar_field, m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation,
+        m_p.G_Newton);
+    BoxLoops::loop(my_ccz4_matter, a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
 }
 
 // Things to do at ODE update, after soln + rhs
@@ -120,7 +104,7 @@ void ScalarFieldLevel::specificUpdateODE(GRLevelData &a_soln,
 void ScalarFieldLevel::computeTaggingCriterion(FArrayBox &tagging_criterion,
                                                const FArrayBox &current_state)
 {
-    BoxLoops::loop(ChiAndPhiTaggingCriterion(m_dx, m_p.regrid_threshold_chi,
-                                             m_p.regrid_threshold_phi),
-                   current_state, tagging_criterion);
+    BoxLoops::loop(
+        FixedGridsTaggingCriterion(m_dx, m_level, 2.0 * m_p.L, m_p.center),
+        current_state, tagging_criterion, disable_simd());
 }

--- a/Examples/ScalarField/SimulationParameters.hpp
+++ b/Examples/ScalarField/SimulationParameters.hpp
@@ -12,8 +12,9 @@
 
 // Problem specific includes:
 #include "CCZ4.hpp"
+#include "InitialScalarData.hpp"
+#include "KerrBH.hpp"
 #include "Potential.hpp"
-#include "ScalarBubble.hpp"
 
 class SimulationParameters : public SimulationParametersBase
 {
@@ -26,33 +27,25 @@ class SimulationParameters : public SimulationParametersBase
 
     void readParams(GRParmParse &pp)
     {
-        // for regridding
-        pp.load("regrid_threshold_chi", regrid_threshold_chi);
-        pp.load("regrid_threshold_phi", regrid_threshold_phi);
-
-        // Initial and SF data
-        initial_params.centerSF =
+        // Initial scalar field data
+        initial_params.center =
             center; // already read in SimulationParametersBase
         pp.load("G_Newton", G_Newton, 1.0);
-        pp.load("amplitudeSF", initial_params.amplitudeSF);
-        pp.load("widthSF", initial_params.widthSF);
-        pp.load("r_zero", initial_params.r_zero);
+        pp.load("scalar_amplitude", initial_params.amplitude);
+        pp.load("scalar_width", initial_params.width);
         pp.load("scalar_mass", potential_params.scalar_mass);
 
-        // Relaxation params
-        pp.load("relaxtime", relaxtime);
-        pp.load("relaxspeed", relaxspeed);
+        // Initial Kerr data
+        pp.load("kerr_mass", kerr_params.mass, 1.0);
+        pp.load("kerr_spin", kerr_params.spin, 0.0);
+        pp.load("kerr_center", kerr_params.center, center);
     }
 
-    // Problem specific parameters
-    Real regrid_threshold_chi, regrid_threshold_phi;
-
-    // Initial data for matter and potential
+    // Initial data for matter and potential and BH
     double G_Newton;
-    ScalarBubble::params_t initial_params;
+    InitialScalarData::params_t initial_params;
     Potential::params_t potential_params;
-    // Relaxation params
-    Real relaxtime, relaxspeed;
+    KerrBH::params_t kerr_params;
 };
 
 #endif /* SIMULATIONPARAMETERS_HPP_ */

--- a/Examples/ScalarField/params.txt
+++ b/Examples/ScalarField/params.txt
@@ -12,34 +12,32 @@ plot_prefix = ScalarFieldp_
 # NB - if you have a non-cubic grid, you can specify 'N1' or 'N1_full', 
 # 'N2' or 'N2_full' and 'N3' or 'N3_full' ( then dx_coarsest = L/N(max) )
 # NB - the N values need to be multiples of the block_factor
-N_full = 64
-L_full =  32
+N_full = 128
+L_full = 256
 
-# Regridding
-# Thresholds on the change across a cell which prompts regrid
-regrid_threshold_chi = 0.1
-regrid_threshold_phi = 0.01
+# Regridding - in this example use a fixed grid
+tag_buffer_size = 0
 
 # Level data
 # Maximum number of times you can regrid above coarsest level
-max_level = 2 # There are (max_level+1) grids, so min is zero
+max_level = 6 # There are (max_level+1) grids, so min is zero
 # Frequency of regridding at each level
 # Need one for each level, ie max_level+1 items
-# Generally you do not need to regrid frequently on every level
-regrid_interval = 32 16 8 4
+# in this example turn off regridding
+regrid_interval = 0 0 0 0 0 0 0
 # Max and min box size - for load balancing
-max_box_size = 32
-min_box_size = 8
+max_box_size = 16
+min_box_size = 16
 
 #boundaries and periodicity of grid
 #Periodic directions - 0 = false, 1 = true
 isPeriodic = 0 0 0
 # if not periodic, then specify the boundary type
 # 0 = static, 1 = sommerfeld, 2 = reflective
+# 3 = extrapolating, 4 = mixed
 # (see BoundaryConditions.hpp for details)
-hi_boundary = 1 1 1
+hi_boundary = 4 4 4
 lo_boundary = 2 2 2
-center = 0.0 0.0 0.0
 
 # if reflective boundaries selected, must set
 # parity of all vars (in order given by UserVariables.hpp)
@@ -55,23 +53,25 @@ vars_parity            = 0 0 4 6 0 5 0    #chi and hij
 vars_parity_diagnostic = 0 1 2 3          #Ham and Mom
 
 # if sommerfeld boundaries selected, must select
-# asymptotic values (in order given by UserVariables.hpp)
-vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
-                         0.0 0.0 0.0 0.0 0.0 0.0 0.0 #K and Aij
-                         0.0 0.0 0.0 0.0             #Theta and Gamma
-                         1.0 0.0 0.0 0.0 0.0 0.0 0.0 #lapse shift and B
-                         0.0 0.0                     #phi and Pi
-                         #0.0 0.0 0.0 0.0             #Ham and Mom
+# non zero asymptotic values
+num_nonzero_asymptotic_vars = 5
+nonzero_asymptotic_vars = chi h11 h22 h33 lapse
+nonzero_asymptotic_values = 1.0 1.0 1.0 1.0 1.0
+
+# for extrapolating vars
+extrapolation_order = 1
+num_extrapolating_vars = 2
+extrapolating_vars = phi Pi
 
 # Set up time steps
 # dt will be dx*dt_multiplier on each grid level
 # HDF5files are written every dt = L/N*dt_multiplier*checkpoint_interval
-checkpoint_interval = 100
-plot_interval = 10
+checkpoint_interval = 500
+plot_interval = 1
 num_plot_vars = 2
 plot_vars = chi phi
 dt_multiplier = 0.25
-stop_time = 10.0
+stop_time = 100.0
 
 #Lapse evolution
 lapse_power = 1.0
@@ -92,22 +92,20 @@ kappa3 = 0
 covariantZ4 = 0 # 0: default. 1: dampk1 -> dampk1/lapse
 
 # coefficient for KO numerical dissipation
-# NB must be less than 0.5 for stability
 sigma = 0.3
 
 # Change the gravitational constant of the Universe!
 # Default is 1.0, for standard geometric units
-# G_Newton = 1.0
+# Here we decouple the evolution so the scalar evolved on the
+# metric background without backreaction (this avoids the need 
+# to solve the constaints)
+G_Newton = 0.0
 
-# SF Initial data
-amplitudeSF = 0.001
-widthSF = 1.0
-r_zero = 5.0
-scalar_mass = 0.001
+# Scalar field initial data
+scalar_amplitude = 0.1
+scalar_width = 5.0
+scalar_mass = 0.2
 
-# Relaxation paramters
-# how long and how fast to relax
-# (should be non zero if starting from phi data
-# for which constraints not solved)
-relaxtime = 0.0
-relaxspeed = 0.01
+# Kerr data
+kerr_mass = 1.0
+kerr_spin = 0.0

--- a/Source/GRChomboCore/BoundaryConditions.cpp
+++ b/Source/GRChomboCore/BoundaryConditions.cpp
@@ -46,8 +46,8 @@ void BoundaryConditions::params_t::set_hi_boundary(
 {
     FOR1(idir)
     {
-        hi_boundary[idir] = a_hi_boundary[idir];
         if (!is_periodic[idir])
+            hi_boundary[idir] = a_hi_boundary[idir];
         {
             if (hi_boundary[idir] == REFLECTIVE_BC)
             {
@@ -82,8 +82,8 @@ void BoundaryConditions::params_t::set_lo_boundary(
 {
     FOR1(idir)
     {
-        lo_boundary[idir] = a_lo_boundary[idir];
         if (!is_periodic[idir])
+            lo_boundary[idir] = a_lo_boundary[idir];
         {
             if (lo_boundary[idir] == REFLECTIVE_BC)
             {
@@ -484,7 +484,7 @@ void BoundaryConditions::fill_boundary_cells_dir(
     const int dir, const int boundary_condition, const VariableType var_type,
     const bool filling_rhs)
 {
-    const std::vector<int> comps =
+    const std::vector<int> &comps =
         (var_type == VariableType::evolution ? m_comps : m_diagnostic_comps);
 
     // iterate through the boxes, shared amongst threads

--- a/Source/GRChomboCore/BoundaryConditions.cpp
+++ b/Source/GRChomboCore/BoundaryConditions.cpp
@@ -7,6 +7,7 @@
 #include "FArrayBox.H"
 #include "ProblemDomain.H"
 #include "RealVect.H"
+#include <algorithm>
 #include <array>
 #include <map>
 #include <string>
@@ -23,8 +24,11 @@ BoundaryConditions::params_t::params_t()
     reflective_boundaries_exist = false;
     sommerfeld_boundaries_exist = false;
     vars_parity.fill(BoundaryConditions::UNDEFINED);
-    vars_parity_diagnostic.fill(BoundaryConditions::UNDEFINED);
+    vars_parity_diagnostic.fill(BoundaryConditions::EXTRAPOLATING_BC);
     vars_asymptotic_values.fill(0.0);
+    extrapolation_order = 1;
+    mixed_bc_extrapolating_vars.clear();
+    mixed_bc_sommerfeld_vars.clear();
 }
 
 void BoundaryConditions::params_t::set_is_periodic(
@@ -42,11 +46,12 @@ void BoundaryConditions::params_t::set_hi_boundary(
 {
     FOR1(idir)
     {
+        hi_boundary[idir] = a_hi_boundary[idir];
         if (!is_periodic[idir])
         {
-            hi_boundary[idir] = a_hi_boundary[idir];
             if (hi_boundary[idir] == REFLECTIVE_BC)
             {
+                boundary_rhs_enforced = true;
                 boundary_solution_enforced = true;
                 reflective_boundaries_exist = true;
             }
@@ -54,6 +59,20 @@ void BoundaryConditions::params_t::set_hi_boundary(
             {
                 boundary_rhs_enforced = true;
                 sommerfeld_boundaries_exist = true;
+            }
+            else if (hi_boundary[idir] == EXTRAPOLATING_BC)
+            {
+                boundary_rhs_enforced = true;
+                boundary_solution_enforced = true;
+                extrapolating_boundaries_exist = true;
+            }
+            else if (hi_boundary[idir] == MIXED_BC)
+            {
+                boundary_rhs_enforced = true;
+                boundary_solution_enforced = true;
+                sommerfeld_boundaries_exist = true;
+                extrapolating_boundaries_exist = true;
+                mixed_boundaries_exist = true;
             }
         }
     }
@@ -63,9 +82,9 @@ void BoundaryConditions::params_t::set_lo_boundary(
 {
     FOR1(idir)
     {
+        lo_boundary[idir] = a_lo_boundary[idir];
         if (!is_periodic[idir])
         {
-            lo_boundary[idir] = a_lo_boundary[idir];
             if (lo_boundary[idir] == REFLECTIVE_BC)
             {
                 boundary_solution_enforced = true;
@@ -76,12 +95,28 @@ void BoundaryConditions::params_t::set_lo_boundary(
                 boundary_rhs_enforced = true;
                 sommerfeld_boundaries_exist = true;
             }
+            else if (lo_boundary[idir] == EXTRAPOLATING_BC)
+            {
+                boundary_rhs_enforced = true;
+                boundary_solution_enforced = true;
+                extrapolating_boundaries_exist = true;
+            }
+            else if (lo_boundary[idir] == MIXED_BC)
+            {
+                boundary_rhs_enforced = true;
+                boundary_solution_enforced = true;
+                sommerfeld_boundaries_exist = true;
+                extrapolating_boundaries_exist = true;
+                mixed_boundaries_exist = true;
+            }
         }
     }
 }
 
 void BoundaryConditions::params_t::read_params(GRParmParse &pp)
 {
+    using namespace UserVariables; // for loading the arrays
+
     // still load even if not contained, to ensure printout saying parameters
     // were set to their default values
     std::array<bool, CH_SPACEDIM> isPeriodic;
@@ -107,7 +142,56 @@ void BoundaryConditions::params_t::read_params(GRParmParse &pp)
     }
     if (sommerfeld_boundaries_exist)
     {
-        pp.load("vars_asymptotic_values", vars_asymptotic_values);
+        if (pp.contains("num_nonzero_asymptotic_vars"))
+        {
+            int num_values = 0;
+            std::vector<std::pair<int, VariableType>> nonzero_asymptotic_vars;
+            load_vars_to_vector(pp, "nonzero_asymptotic_vars",
+                                "num_nonzero_asymptotic_vars",
+                                nonzero_asymptotic_vars, num_values);
+            const double default_value = 0.0;
+            load_values_to_array(pp, "nonzero_asymptotic_values",
+                                 nonzero_asymptotic_vars,
+                                 vars_asymptotic_values, default_value);
+        }
+        // for backwards compatibility, but above method should
+        // be preferred in future, as is less error prone
+        else
+        {
+            pp.load("vars_asymptotic_values", vars_asymptotic_values);
+        }
+    }
+    if (extrapolating_boundaries_exist)
+    {
+        pp.load("extrapolation_order", extrapolation_order, 1);
+    }
+    if (mixed_boundaries_exist)
+    {
+        int num_extrapolating_vars = 0;
+        std::vector<std::pair<int, VariableType>> extrapolating_vars;
+        load_vars_to_vector(pp, "extrapolating_vars", "num_extrapolating_vars",
+                            extrapolating_vars, num_extrapolating_vars);
+        for (int icomp = 0; icomp < NUM_VARS; icomp++)
+        {
+            bool is_extrapolating = false;
+            // if the variable is not in extrapolating vars, it
+            // is assumed to be sommerfeld by default
+            for (int icomp2 = 0; icomp2 < extrapolating_vars.size(); icomp2++)
+            {
+                if (icomp == extrapolating_vars[icomp2].first)
+                {
+                    // should be an evolution variable
+                    CH_assert(extrapolating_vars[icomp2].second ==
+                              VariableType::evolution);
+                    mixed_bc_extrapolating_vars.push_back(icomp);
+                    is_extrapolating = true;
+                }
+            }
+            if (!is_extrapolating)
+            {
+                mixed_bc_sommerfeld_vars.push_back(icomp);
+            }
+        }
     }
     if (nonperiodic_boundaries_exist)
     {
@@ -191,6 +275,33 @@ void BoundaryConditions::write_sommerfeld_conditions(int idir,
     // not done for diagnostics
 }
 
+void BoundaryConditions::write_mixed_conditions(int idir,
+                                                const params_t &a_params)
+{
+    // check all the vars have been assigned a BC - this should always be the
+    // case because of how the params are assigned
+    CH_assert(a_params.mixed_bc_sommerfeld_vars.size() +
+                  a_params.mixed_bc_extrapolating_vars.size() ==
+              NUM_VARS);
+
+    // now do the write out
+    pout()
+        << "The variables that use extrapolating bcs in this direction are : "
+        << endl;
+    for (int icomp = 0; icomp < NUM_VARS; icomp++)
+    {
+        std::vector<int> v = a_params.mixed_bc_extrapolating_vars;
+        if (std::binary_search(v.begin(), v.end(), icomp))
+        {
+            pout() << UserVariables::variable_names[icomp] << "    ";
+        }
+    }
+    pout() << endl;
+    pout() << "The other variables all use Sommerfeld boundary conditions."
+           << endl;
+    write_sommerfeld_conditions(idir, a_params);
+}
+
 /// write out boundary params (used during setup for debugging)
 void BoundaryConditions::write_boundary_conditions(const params_t &a_params)
 {
@@ -200,7 +311,9 @@ void BoundaryConditions::write_boundary_conditions(const params_t &a_params)
 
     std::map<int, std::string> bc_names = {{STATIC_BC, "Static"},
                                            {SOMMERFELD_BC, "Sommerfeld"},
-                                           {REFLECTIVE_BC, "Reflective"}};
+                                           {REFLECTIVE_BC, "Reflective"},
+                                           {EXTRAPOLATING_BC, "Extrapolating"},
+                                           {MIXED_BC, "Mixed"}};
     FOR1(idir)
     {
         if (!a_params.is_periodic[idir])
@@ -216,6 +329,10 @@ void BoundaryConditions::write_boundary_conditions(const params_t &a_params)
             {
                 write_sommerfeld_conditions(idir, a_params);
             }
+            else if (a_params.hi_boundary[idir] == MIXED_BC)
+            {
+                write_mixed_conditions(idir, a_params);
+            }
             pout() << endl;
 
             // low directions
@@ -228,6 +345,10 @@ void BoundaryConditions::write_boundary_conditions(const params_t &a_params)
             else if (a_params.lo_boundary[idir] == SOMMERFELD_BC)
             {
                 write_sommerfeld_conditions(idir, a_params);
+            }
+            else if (a_params.lo_boundary[idir] == MIXED_BC)
+            {
+                write_mixed_conditions(idir, a_params);
             }
             pout() << endl;
         }
@@ -242,9 +363,9 @@ void BoundaryConditions::write_boundary_conditions(const params_t &a_params)
 int BoundaryConditions::get_var_parity(int a_comp, int a_dir,
                                        const VariableType var_type) const
 {
-    int vars_parity = get_var_parity(a_comp, a_dir, m_params, var_type);
+    int var_parity = get_var_parity(a_comp, a_dir, m_params, var_type);
 
-    return vars_parity;
+    return var_parity;
 }
 
 /// static version used for initial output of boundary values
@@ -281,7 +402,7 @@ void BoundaryConditions::fill_rhs_boundaries(const Side::LoHiSide a_side,
                                              GRLevelData &a_rhs)
 {
     CH_assert(is_defined);
-    CH_TIME("BoundaryConditions::fill_boundary_rhs");
+    CH_TIME("BoundaryConditions::fill_rhs_boundaries");
 
     // cycle through the directions, filling the rhs
     FOR1(idir)
@@ -313,11 +434,15 @@ void BoundaryConditions::fill_solution_boundaries(const Side::LoHiSide a_side,
             int boundary_condition = get_boundary_condition(a_side, idir);
 
             // same copying of cells which we require for the rhs solution
-            // but tell it we are not filling the rhs in case required
-            if (boundary_condition == REFLECTIVE_BC)
+            // but tell it we are not filling the rhs for mixed condition
+            if ((boundary_condition == REFLECTIVE_BC) ||
+                (boundary_condition == EXTRAPOLATING_BC) ||
+                (boundary_condition == MIXED_BC))
             {
+                const bool filling_rhs = false;
                 fill_boundary_cells_dir(a_side, a_state, a_state, idir,
-                                        boundary_condition);
+                                        boundary_condition,
+                                        VariableType::evolution, filling_rhs);
             }
         }
     }
@@ -338,15 +463,16 @@ void BoundaryConditions::fill_diagnostic_boundaries(const Side::LoHiSide a_side,
         {
             int boundary_condition = get_boundary_condition(a_side, idir);
             // for any non reflective BC, we just want to fill the ghosts with
-            // zeros so set the boundary condition to be STATIC
-            // TODO: Make this extrapolating instead once that is implemented
+            // something non nan so set the boundary condition to be
+            // EXTRAPOLATING
             if (boundary_condition != REFLECTIVE_BC)
             {
-                boundary_condition = STATIC_BC;
+                boundary_condition = EXTRAPOLATING_BC;
             }
+            const bool filling_rhs = false;
             fill_boundary_cells_dir(a_side, a_state, a_state, idir,
                                     boundary_condition,
-                                    VariableType::diagnostic);
+                                    VariableType::diagnostic, filling_rhs);
         }
     }
 }
@@ -355,9 +481,10 @@ void BoundaryConditions::fill_diagnostic_boundaries(const Side::LoHiSide a_side,
 /// in the direction dir
 void BoundaryConditions::fill_boundary_cells_dir(
     const Side::LoHiSide a_side, const GRLevelData &a_soln, GRLevelData &a_out,
-    const int dir, const int boundary_condition, const VariableType var_type)
+    const int dir, const int boundary_condition, const VariableType var_type,
+    const bool filling_rhs)
 {
-    const std::vector<int> &comps =
+    const std::vector<int> comps =
         (var_type == VariableType::evolution ? m_comps : m_diagnostic_comps);
 
     // iterate through the boxes, shared amongst threads
@@ -408,6 +535,24 @@ void BoundaryConditions::fill_boundary_cells_dir(
                 fill_reflective_cell(out_box, iv, a_side, dir, comps, var_type);
                 break;
             }
+            case EXTRAPOLATING_BC:
+            {
+                fill_extrapolating_cell(out_box, iv, a_side, dir, comps,
+                                        m_params.extrapolation_order);
+                break;
+            }
+            case MIXED_BC:
+            {
+                fill_extrapolating_cell(out_box, iv, a_side, dir,
+                                        m_params.mixed_bc_extrapolating_vars,
+                                        m_params.extrapolation_order);
+                if (filling_rhs)
+                {
+                    fill_sommerfeld_cell(out_box, soln_box, iv,
+                                         m_params.mixed_bc_sommerfeld_vars);
+                }
+                break;
+            }
             default:
                 MayDay::Error(
                     "BoundaryCondition::Supplied boundary not supported.");
@@ -432,7 +577,7 @@ void BoundaryConditions::fill_sommerfeld_cell(
     IntVect lo_local_offset = iv - soln_box.smallEnd();
     IntVect hi_local_offset = soln_box.bigEnd() - iv;
 
-    // Apply Sommerfeld BCs to each variable
+    // Apply Sommerfeld BCs to each variable in sommerfeld_comps
     for (int icomp : sommerfeld_comps)
     {
         rhs_box(iv, icomp) = 0.0;
@@ -514,6 +659,100 @@ void BoundaryConditions::fill_reflective_cell(
     }
 }
 
+void BoundaryConditions::fill_extrapolating_cell(
+    FArrayBox &out_box, const IntVect iv, const Side::LoHiSide a_side,
+    const int dir, const std::vector<int> &extrapolating_comps,
+    const int order) const
+{
+    for (int icomp : extrapolating_comps)
+    {
+        // current radius
+        double radius = Coordinates<double>::get_radius(
+            iv, m_dx, {m_center[0], m_center[1], m_center[2]});
+
+        // vector of 2 nearest values and radii within the grid
+        std::array<double, 2> value_at_point;
+        std::array<double, 2> r_at_point;
+        // how many units are we from domain boundary?
+        int units_from_edge = 0;
+        if (a_side == Side::Hi)
+        {
+            // how many units are we from domain boundary?
+            units_from_edge = iv[dir] - m_domain_box.bigEnd(dir);
+            // vector of 2 nearest values and radii within the grid
+            for (int i = 0; i < 2; i++)
+            {
+                IntVect iv_tmp = iv;
+                iv_tmp[dir] += -units_from_edge - i;
+                FOR1(idir)
+                {
+                    if (iv_tmp[idir] > m_domain_box.bigEnd(idir))
+                    {
+                        iv_tmp[idir] = m_domain_box.bigEnd(idir);
+                    }
+                    else if (iv_tmp[idir] < m_domain_box.smallEnd(idir))
+                    {
+                        iv_tmp[idir] = m_domain_box.smallEnd(idir);
+                    }
+                }
+                value_at_point[i] = out_box(iv_tmp, icomp);
+                r_at_point[i] = Coordinates<double>::get_radius(
+                    iv_tmp, m_dx, {m_center[0], m_center[1], m_center[2]});
+            }
+        }
+        else // Lo side
+        {
+            // how many units are we from domain boundary?
+            units_from_edge = -iv[dir] + m_domain_box.smallEnd(dir);
+            // vector of 2 nearest values within the grid
+            for (int i = 0; i < 2; i++)
+            {
+                IntVect iv_tmp = iv;
+                iv_tmp[dir] += units_from_edge + i;
+                FOR1(idir)
+                {
+                    if (iv_tmp[idir] > m_domain_box.bigEnd(idir))
+                    {
+                        iv_tmp[idir] = m_domain_box.bigEnd(idir);
+                    }
+                    else if (iv_tmp[idir] < m_domain_box.smallEnd(idir))
+                    {
+                        iv_tmp[idir] = m_domain_box.smallEnd(idir);
+                    }
+                }
+                value_at_point[i] = out_box(iv_tmp, icomp);
+                r_at_point[i] = Coordinates<double>::get_radius(
+                    iv_tmp, m_dx, {m_center[0], m_center[1], m_center[2]});
+            }
+        }
+
+        // assume some radial dependence and fit it
+        double analytic_change = 0.0;
+        // comp = const
+        if (order == 0)
+        {
+            analytic_change = 0.0;
+        }
+        // comp = B + A*r
+        else if (order == 1)
+        {
+            double delta_r_in_domain = r_at_point[1] - r_at_point[0];
+            double A =
+                (value_at_point[1] - value_at_point[0]) / delta_r_in_domain;
+            double delta_r_here = radius - r_at_point[0];
+            analytic_change = A * delta_r_here;
+        }
+        // other orders not supported yet
+        else
+        {
+            MayDay::Error("Order not supported for boundary extrapolation.");
+        }
+
+        // set the value here to the extrapolated value
+        out_box(iv, icomp) = value_at_point[0] + analytic_change;
+    }
+}
+
 /// Copy the boundary values from src to dest
 /// NB only acts if same box layout of input and output data
 void BoundaryConditions::copy_boundary_cells(const Side::LoHiSide a_side,
@@ -558,7 +797,7 @@ void BoundaryConditions::copy_boundary_cells(const Side::LoHiSide a_side,
                     for (bit.begin(); bit.ok(); ++bit)
                     {
                         IntVect iv = bit();
-                        for (int icomp = 0; icomp < NUM_VARS; icomp++)
+                        for (int icomp : m_comps)
                         {
                             m_dest_box(iv, icomp) = a_src[dind](iv, icomp);
                         }
@@ -805,14 +1044,18 @@ Box ExpandGridsToBoundaries::operator()(const Box &a_in_box)
     {
         if (!m_boundaries.m_params.is_periodic[idir])
         {
-            if (m_boundaries.get_boundary_condition(Side::Lo, idir) ==
-                    BoundaryConditions::SOMMERFELD_BC &&
+            if ((m_boundaries.get_boundary_condition(Side::Lo, idir) ==
+                     BoundaryConditions::SOMMERFELD_BC ||
+                 m_boundaries.get_boundary_condition(Side::Lo, idir) ==
+                     BoundaryConditions::MIXED_BC) &&
                 offset_lo[idir] == 0)
             {
                 out_box.growLo(idir, m_boundaries.m_num_ghosts);
             }
-            if (m_boundaries.get_boundary_condition(Side::Hi, idir) ==
-                    BoundaryConditions::SOMMERFELD_BC &&
+            if ((m_boundaries.get_boundary_condition(Side::Hi, idir) ==
+                     BoundaryConditions::SOMMERFELD_BC ||
+                 m_boundaries.get_boundary_condition(Side::Hi, idir) ==
+                     BoundaryConditions::MIXED_BC) &&
                 offset_hi[idir] == 0)
             {
                 out_box.growHi(idir, m_boundaries.m_num_ghosts);
@@ -841,11 +1084,13 @@ void BoundaryConditions::expand_grids_to_boundaries(
     {
         if (!m_params.is_periodic[idir])
         {
-            if (get_boundary_condition(Side::Lo, idir) == SOMMERFELD_BC)
+            if ((get_boundary_condition(Side::Lo, idir) == SOMMERFELD_BC) ||
+                (get_boundary_condition(Side::Lo, idir) == MIXED_BC))
             {
                 domain_with_boundaries.growLo(idir, m_num_ghosts);
             }
-            if (get_boundary_condition(Side::Hi, idir) == SOMMERFELD_BC)
+            if ((get_boundary_condition(Side::Hi, idir) == SOMMERFELD_BC) ||
+                (get_boundary_condition(Side::Hi, idir) == MIXED_BC))
             {
                 domain_with_boundaries.growHi(idir, m_num_ghosts);
             }

--- a/Source/GRChomboCore/BoundaryConditions.cpp
+++ b/Source/GRChomboCore/BoundaryConditions.cpp
@@ -47,8 +47,8 @@ void BoundaryConditions::params_t::set_hi_boundary(
     FOR1(idir)
     {
         if (!is_periodic[idir])
-            hi_boundary[idir] = a_hi_boundary[idir];
         {
+            hi_boundary[idir] = a_hi_boundary[idir];
             if (hi_boundary[idir] == REFLECTIVE_BC)
             {
                 boundary_rhs_enforced = true;
@@ -83,8 +83,8 @@ void BoundaryConditions::params_t::set_lo_boundary(
     FOR1(idir)
     {
         if (!is_periodic[idir])
-            lo_boundary[idir] = a_lo_boundary[idir];
         {
+            lo_boundary[idir] = a_lo_boundary[idir];
             if (lo_boundary[idir] == REFLECTIVE_BC)
             {
                 boundary_solution_enforced = true;
@@ -213,16 +213,11 @@ void BoundaryConditions::define(double a_dx,
     m_domain_box = a_domain.domainBox();
     m_num_ghosts = a_num_ghosts;
     FOR1(i) { m_center[i] = a_center[i]; }
-    m_comps.resize(NUM_VARS);
-    for (int i = 0; i < NUM_VARS; i++)
-    {
-        m_comps[i] = i;
-    }
+    // make a vector of the vars indices, [0,1,2...NUM_VARS]
+    m_evolution_comps.resize(NUM_VARS);
+    std::iota(m_evolution_comps.begin(), m_evolution_comps.end(), 0);
     m_diagnostic_comps.resize(NUM_DIAGNOSTIC_VARS);
-    for (int i = 0; i < NUM_DIAGNOSTIC_VARS; i++)
-    {
-        m_diagnostic_comps[i] = i;
-    }
+    std::iota(m_diagnostic_comps.begin(), m_diagnostic_comps.end(), 0);
     is_defined = true;
 }
 
@@ -485,7 +480,8 @@ void BoundaryConditions::fill_boundary_cells_dir(
     const bool filling_rhs)
 {
     const std::vector<int> &comps =
-        (var_type == VariableType::evolution ? m_comps : m_diagnostic_comps);
+        (var_type == VariableType::evolution ? m_evolution_comps
+                                             : m_diagnostic_comps);
 
     // iterate through the boxes, shared amongst threads
     DataIterator dit = a_out.dataIterator();
@@ -797,7 +793,7 @@ void BoundaryConditions::copy_boundary_cells(const Side::LoHiSide a_side,
                     for (bit.begin(); bit.ok(); ++bit)
                     {
                         IntVect iv = bit();
-                        for (int icomp : m_comps)
+                        for (int icomp : m_evolution_comps)
                         {
                             m_dest_box(iv, icomp) = a_src[dind](iv, icomp);
                         }

--- a/Source/GRChomboCore/BoundaryConditions.cpp
+++ b/Source/GRChomboCore/BoundaryConditions.cpp
@@ -269,10 +269,10 @@ void BoundaryConditions::write_mixed_conditions(int idir,
 {
     // check all the vars have been assigned a BC - this should always be the
     // case because of how the params are assigned
-    CH_assert(a_params.mixed_bc_vars_map.size() == NUM_VARS)
+    CH_assert(a_params.mixed_bc_vars_map.size() == NUM_VARS);
 
-        // now do the write out
-        pout()
+    // now do the write out
+    pout()
         << "The variables that use extrapolating bcs in this direction are : "
         << endl;
     for (int icomp = 0; icomp < NUM_VARS; icomp++)

--- a/Source/GRChomboCore/BoundaryConditions.hpp
+++ b/Source/GRChomboCore/BoundaryConditions.hpp
@@ -85,13 +85,14 @@ class BoundaryConditions
 
   protected:
     // Member values
-    double m_dx;              // The grid spacing
-    int m_num_ghosts;         // the number of ghosts (usually 3)
-    params_t m_params;        // the boundary params
-    RealVect m_center;        // the position of the center of the grid
-    ProblemDomain m_domain;   // the problem domain (excludes boundary cells)
-    Box m_domain_box;         // The box representing the domain
-    std::vector<int> m_comps; // a vector of c_nums for all the evolution vars
+    double m_dx;            // The grid spacing
+    int m_num_ghosts;       // the number of ghosts (usually 3)
+    params_t m_params;      // the boundary params
+    RealVect m_center;      // the position of the center of the grid
+    ProblemDomain m_domain; // the problem domain (excludes boundary cells)
+    Box m_domain_box;       // The box representing the domain
+    std::vector<int>
+        m_evolution_comps; // a vector of c_nums for all the evolution vars
     std::vector<int>
         m_diagnostic_comps; // a vector of c_nums for all the diagnostic vars
     bool is_defined; // whether the BoundaryConditions class members are defined

--- a/Source/GRChomboCore/BoundaryConditions.hpp
+++ b/Source/GRChomboCore/BoundaryConditions.hpp
@@ -72,8 +72,9 @@ class BoundaryConditions
         std::array<int, NUM_DIAGNOSTIC_VARS>
             vars_parity_diagnostic; /* needed only in AMRInterpolator */
         std::array<double, NUM_VARS> vars_asymptotic_values;
-        std::vector<int> mixed_bc_extrapolating_vars;
-        std::vector<int> mixed_bc_sommerfeld_vars;
+        std::map<int, int> mixed_bc_vars_map;
+        // std::vector<int> mixed_bc_extrapolating_vars;
+        // std::vector<int> mixed_bc_sommerfeld_vars;
         int extrapolation_order;
         params_t(); // sets the defaults
         void
@@ -91,8 +92,6 @@ class BoundaryConditions
     RealVect m_center;      // the position of the center of the grid
     ProblemDomain m_domain; // the problem domain (excludes boundary cells)
     Box m_domain_box;       // The box representing the domain
-    std::vector<int>
-        m_evolution_comps; // a vector of c_nums for all the evolution vars
     std::vector<int>
         m_diagnostic_comps; // a vector of c_nums for all the diagnostic vars
     bool is_defined; // whether the BoundaryConditions class members are defined
@@ -132,20 +131,23 @@ class BoundaryConditions
                              const GRLevelData &a_soln, GRLevelData &a_rhs);
 
     /// enforce solution boundary conditions, e.g. after interpolation
-    void fill_solution_boundaries(const Side::LoHiSide a_side,
-                                  GRLevelData &a_state);
+    void fill_solution_boundaries(
+        const Side::LoHiSide a_side, GRLevelData &a_state,
+        const Interval &a_comps = Interval(0, NUM_VARS - 1));
 
     /// fill diagnostic boundaries - used in AMRInterpolator
-    void fill_diagnostic_boundaries(const Side::LoHiSide a_side,
-                                    GRLevelData &a_state);
+    void fill_diagnostic_boundaries(
+        const Side::LoHiSide a_side, GRLevelData &a_state,
+        const Interval &a_comps = Interval(0, NUM_DIAGNOSTIC_VARS - 1));
 
     /// Fill the boundary values appropriately based on the params set
     /// in the direction dir
-    void fill_boundary_cells_dir(
-        const Side::LoHiSide a_side, const GRLevelData &a_soln,
-        GRLevelData &a_out, const int dir, const int boundary_condition,
-        const VariableType var_type = VariableType::evolution,
-        const bool filling_rhs = true);
+    void fill_boundary_cells_dir(const Side::LoHiSide a_side,
+                                 const GRLevelData &a_soln, GRLevelData &a_out,
+                                 const int dir, const int boundary_condition,
+                                 const Interval &a_comps,
+                                 const VariableType var_type,
+                                 const bool filling_rhs);
 
     /// Copy the boundary values from src to dest
     /// NB assumes same box layout of input and output data

--- a/Source/GRChomboCore/BoundaryConditions.hpp
+++ b/Source/GRChomboCore/BoundaryConditions.hpp
@@ -73,8 +73,6 @@ class BoundaryConditions
             vars_parity_diagnostic; /* needed only in AMRInterpolator */
         std::array<double, NUM_VARS> vars_asymptotic_values;
         std::map<int, int> mixed_bc_vars_map;
-        // std::vector<int> mixed_bc_extrapolating_vars;
-        // std::vector<int> mixed_bc_sommerfeld_vars;
         int extrapolation_order;
         params_t(); // sets the defaults
         void
@@ -92,8 +90,6 @@ class BoundaryConditions
     RealVect m_center;      // the position of the center of the grid
     ProblemDomain m_domain; // the problem domain (excludes boundary cells)
     Box m_domain_box;       // The box representing the domain
-    std::vector<int>
-        m_diagnostic_comps; // a vector of c_nums for all the diagnostic vars
     bool is_defined; // whether the BoundaryConditions class members are defined
 
   public:

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -69,35 +69,8 @@ class ChomboParameters
         pp.load("write_plot_ghosts", write_plot_ghosts, false);
 
         // load vars to write to plot files
-        pp.load("num_plot_vars", num_plot_vars, 0);
-        std::vector<std::string> plot_var_names(num_plot_vars, "");
-        pp.load("plot_vars", plot_var_names, num_plot_vars, plot_var_names);
-        for (std::string var_name : plot_var_names)
-        {
-            // first assume plot_var is a normal evolution var
-            int var = UserVariables::variable_name_to_enum(var_name);
-            VariableType var_type = VariableType::evolution;
-            if (var < 0)
-            {
-                // if not an evolution var check if it's a diagnostic var
-                var = DiagnosticVariables::variable_name_to_enum(var_name);
-                if (var < 0)
-                {
-                    // it's neither :(
-                    pout() << "Variable with name " << var_name
-                           << " not found.\n";
-                }
-                else
-                {
-                    var_type = VariableType::diagnostic;
-                }
-            }
-            if (var >= 0)
-            {
-                plot_vars.emplace_back(var, var_type);
-            }
-        }
-        num_plot_vars = plot_vars.size();
+        UserVariables::load_vars_to_vector(pp, "plot_vars", "num_plot_vars",
+                                           plot_vars, num_plot_vars);
 
         // alias the weird chombo names to something more descriptive
         // for these box params, and default to some reasonable values

--- a/Source/GRChomboCore/UserVariables.inc.hpp
+++ b/Source/GRChomboCore/UserVariables.inc.hpp
@@ -70,7 +70,7 @@ template <class T>
 void load_values_to_array(
     GRParmParse &pp, const char *a_values_vector_string,
     const std::vector<std::pair<int, VariableType>> &a_vars_vector,
-    std::array<double, NUM_VARS> &a_values_array, const T a_default_value)
+    std::array<T, NUM_VARS> &a_values_array, const T a_default_value)
 {
     // how many values do I need to get?
     int num_values = a_vars_vector.size();
@@ -106,7 +106,7 @@ load_vars_to_vector(GRParmParse &pp, const char *a_vars_vector_string,
         pp.load(a_vars_vector_string, var_names, num_values, var_names);
         for (std::string var_name : var_names)
         {
-            // first assume plot_var is a normal evolution var
+            // first assume the variable is a normal evolution var
             int var = UserVariables::variable_name_to_enum(var_name);
             VariableType var_type = VariableType::evolution;
             if (var < 0)

--- a/Source/GRChomboCore/UserVariables.inc.hpp
+++ b/Source/GRChomboCore/UserVariables.inc.hpp
@@ -10,6 +10,8 @@
 #ifndef USERVARIABLES_INC_HPP
 #define USERVARIABLES_INC_HPP
 
+#include "GRParmParse.hpp"
+#include "VariableType.hpp"
 #include "parstream.H"
 #include <algorithm>
 #include <array>
@@ -58,5 +60,80 @@ static int variable_name_to_enum(const std::string &a_var_name)
 }
 
 } // namespace DiagnosticVariables
+
+namespace UserVariables
+{
+// where one has read in a subset of variables with some feature
+// this reads in a set of associated values and assigns it into a full
+// array of all NUM_VARS vars (setting other values to a default value)
+template <class T>
+void load_values_to_array(
+    GRParmParse &pp, const char *a_values_vector_string,
+    const std::vector<std::pair<int, VariableType>> &a_vars_vector,
+    std::array<double, NUM_VARS> &a_values_array, const T a_default_value)
+{
+    // how many values do I need to get?
+    int num_values = a_vars_vector.size();
+    // make a container for them, and load
+    std::vector<T> vars_values(num_values, a_default_value);
+    pp.load(a_values_vector_string, vars_values, num_values, vars_values);
+
+    // populate the values_array for the NUM_VARS values with those read in
+    a_values_array.fill(a_default_value);
+    for (int i = 0; i < num_values; i++)
+    {
+        int icomp = a_vars_vector[i].first;
+        CH_assert(a_vars_vector[i].second == VariableType::evolution);
+        a_values_array[icomp] = vars_values[i];
+    }
+}
+
+// function to create a vector of enums of vars by reading in their
+// names as strings from the params file and converting it to the enums
+inline void
+load_vars_to_vector(GRParmParse &pp, const char *a_vars_vector_string,
+                    const char *a_vector_size_string,
+                    std::vector<std::pair<int, VariableType>> &a_vars_vector,
+                    int &a_vars_vector_size)
+{
+    int num_values;
+    pp.load(a_vector_size_string, num_values, -1);
+    // only set a_vars_vector and a_var_vector_size if a_vector_size_string
+    // found
+    if (num_values >= 0)
+    {
+        std::vector<std::string> var_names(num_values, "");
+        pp.load(a_vars_vector_string, var_names, num_values, var_names);
+        for (std::string var_name : var_names)
+        {
+            // first assume plot_var is a normal evolution var
+            int var = UserVariables::variable_name_to_enum(var_name);
+            VariableType var_type = VariableType::evolution;
+            if (var < 0)
+            {
+                // if not an evolution var check if it's a diagnostic var
+                var = DiagnosticVariables::variable_name_to_enum(var_name);
+                if (var < 0)
+                {
+                    // it's neither :(
+                    pout() << "Variable with name " << var_name << " not found."
+                           << endl;
+                }
+                else
+                {
+                    var_type = VariableType::diagnostic;
+                }
+            }
+            if (var >= 0)
+            {
+                a_vars_vector.emplace_back(var, var_type);
+            }
+        }
+        // overwrites read in value if entries have been ignored
+        a_vars_vector_size = a_vars_vector.size();
+    }
+}
+
+} // namespace UserVariables
 
 #endif /* USERVARIABLES_INC_HPP_ */

--- a/Source/Matter/ScalarField.hpp
+++ b/Source/Matter/ScalarField.hpp
@@ -8,6 +8,7 @@
 
 #include "CCZ4Geometry.hpp"
 #include "DefaultPotential.hpp"
+#include "DimensionDefinitions.hpp"
 #include "FourthOrderDerivatives.hpp"
 #include "Tensor.hpp"
 #include "TensorAlgebra.hpp"
@@ -37,13 +38,6 @@ template <class potential_t = DefaultPotential> class ScalarField
   public:
     //!  Constructor of class ScalarField, inputs are the matter parameters.
     ScalarField(const potential_t a_potential) : my_potential(a_potential) {}
-
-    //! Structure containing the variables for the matter fields
-    template <class data_t> struct SFObject
-    {
-        data_t phi;
-        data_t Pi;
-    };
 
     //! Structure containing the rhs variables for the matter fields
     template <class data_t> struct Vars
@@ -90,11 +84,9 @@ template <class potential_t = DefaultPotential> class ScalarField
     //! derivatives, excluding the potential
     template <class data_t, template <typename> class vars_t>
     static void emtensor_excl_potential(
-        emtensor_t<data_t> &out,         //!< the em tensor output
-        const vars_t<data_t> &vars,      //!< the value of the variables
-        const SFObject<data_t> &vars_sf, //!< the value of the sf variables
-        const Tensor<1, data_t>
-            &d1_phi,                   //!< the value of the first deriv of phi
+        emtensor_t<data_t> &out,             //!< the em tensor output
+        const vars_t<data_t> &vars,          //!< the value of the variables
+        const vars_t<Tensor<1, data_t>> &d1, //!< the value of the first derivs
         const Tensor<2, data_t> &h_UU, //!< the inverse metric (raised indices).
         const Tensor<3, data_t>
             &chris_ULL); //!< the conformal christoffel symbol
@@ -114,16 +106,15 @@ template <class potential_t = DefaultPotential> class ScalarField
 
     //! The function which calculates the RHS for the matter field vars
     //! excluding the potential
-    template <class data_t, template <typename> class vars_t>
+    template <class data_t, template <typename> class vars_t,
+              template <typename> class diff2_vars_t,
+              template <typename> class rhs_vars_t>
     static void matter_rhs_excl_potential(
-        SFObject<data_t>
-            &rhs_sf, //!< the value of the RHS terms for the sf vars
-        const vars_t<data_t> &vars,      //!< the values of all the variables
-        const SFObject<data_t> &vars_sf, //!< the value of the sf variables
+        rhs_vars_t<data_t> &rhs, //!< the value of the RHS terms for the sf vars
+        const vars_t<data_t> &vars, //!< the values of all the variables
         const vars_t<Tensor<1, data_t>> &d1, //!< the value of the 1st derivs
-        const Tensor<1, data_t> &d1_phi, //!< the value of the 1st derivs of phi
-        const Tensor<2, data_t> &d2_phi, //!< the value of the 2nd derivs of phi
-        const SFObject<data_t> &advec_sf); //!< advection terms for the sf vars
+        const diff2_vars_t<Tensor<2, data_t>> &d2, //!< value of the 2nd derivs
+        const vars_t<data_t> &advec);
 };
 
 #include "ScalarField.impl.hpp"

--- a/Source/Matter/ScalarField.impl.hpp
+++ b/Source/Matter/ScalarField.impl.hpp
@@ -9,7 +9,6 @@
 
 #ifndef SCALARFIELD_IMPL_HPP_
 #define SCALARFIELD_IMPL_HPP_
-#include "DimensionDefinitions.hpp"
 
 // Calculate the stress energy tensor elements
 template <class potential_t>
@@ -20,13 +19,8 @@ emtensor_t<data_t> ScalarField<potential_t>::compute_emtensor(
 {
     emtensor_t<data_t> out;
 
-    // Copy the field vars into SFObject
-    SFObject<data_t> vars_sf;
-    vars_sf.phi = vars.phi;
-    vars_sf.Pi = vars.Pi;
-
     // call the function which computes the em tensor excluding the potential
-    emtensor_excl_potential(out, vars, vars_sf, d1.phi, h_UU, chris_ULL);
+    emtensor_excl_potential(out, vars, d1, h_UU, chris_ULL);
 
     // set the potential values
     data_t V_of_phi = 0.0;
@@ -47,29 +41,29 @@ template <class potential_t>
 template <class data_t, template <typename> class vars_t>
 void ScalarField<potential_t>::emtensor_excl_potential(
     emtensor_t<data_t> &out, const vars_t<data_t> &vars,
-    const SFObject<data_t> &vars_sf, const Tensor<1, data_t> &d1_phi,
-    const Tensor<2, data_t> &h_UU, const Tensor<3, data_t> &chris_ULL)
+    const vars_t<Tensor<1, data_t>> &d1, const Tensor<2, data_t> &h_UU,
+    const Tensor<3, data_t> &chris_ULL)
 {
     // Useful quantity Vt
-    data_t Vt = -vars_sf.Pi * vars_sf.Pi;
-    FOR2(i, j) { Vt += vars.chi * h_UU[i][j] * d1_phi[i] * d1_phi[j]; }
+    data_t Vt = -vars.Pi * vars.Pi;
+    FOR2(i, j) { Vt += vars.chi * h_UU[i][j] * d1.phi[i] * d1.phi[j]; }
 
     // Calculate components of EM Tensor
     // S_ij = T_ij
     FOR2(i, j)
     {
         out.Sij[i][j] =
-            -0.5 * vars.h[i][j] * Vt / vars.chi + d1_phi[i] * d1_phi[j];
+            -0.5 * vars.h[i][j] * Vt / vars.chi + d1.phi[i] * d1.phi[j];
     }
 
     // S = Tr_S_ij
     out.S = vars.chi * TensorAlgebra::compute_trace(out.Sij, h_UU);
 
     // S_i (note lower index) = - n^a T_ai
-    FOR1(i) { out.Si[i] = -d1_phi[i] * vars_sf.Pi; }
+    FOR1(i) { out.Si[i] = -d1.phi[i] * vars.Pi; }
 
     // rho = n^a n^b T_ab
-    out.rho = vars_sf.Pi * vars_sf.Pi + 0.5 * Vt;
+    out.rho = vars.Pi * vars.Pi + 0.5 * Vt;
 }
 
 // Adds in the RHS for the matter vars
@@ -87,40 +81,27 @@ void ScalarField<potential_t>::add_matter_rhs(
     // this may seem a bit long winded, but it makes the function
     // work for more multiple fields
 
-    SFObject<data_t> rhs_sf;
-    // advection terms
-    SFObject<data_t> advec_sf;
-    advec_sf.phi = advec.phi;
-    advec_sf.Pi = advec.Pi;
-    // the vars
-    SFObject<data_t> vars_sf;
-    vars_sf.phi = vars.phi;
-    vars_sf.Pi = vars.Pi;
-
     // call the function for the rhs excluding the potential
-    matter_rhs_excl_potential(rhs_sf, vars, vars_sf, d1, d1.phi, d2.phi,
-                              advec_sf);
+    matter_rhs_excl_potential(total_rhs, vars, d1, d2, advec);
 
     // set the potential values
     data_t V_of_phi = 0.0;
     data_t dVdphi = 0.0;
-
-    // compute potential
     my_potential.compute_potential(V_of_phi, dVdphi, vars);
 
     // adjust RHS for the potential term
-    total_rhs.phi = rhs_sf.phi;
-    total_rhs.Pi = rhs_sf.Pi - vars.lapse * dVdphi;
+    total_rhs.Pi += -vars.lapse * dVdphi;
 }
 
 // the RHS excluding the potential terms
 template <class potential_t>
-template <class data_t, template <typename> class vars_t>
+template <class data_t, template <typename> class vars_t,
+          template <typename> class diff2_vars_t,
+          template <typename> class rhs_vars_t>
 void ScalarField<potential_t>::matter_rhs_excl_potential(
-    SFObject<data_t> &rhs_sf, const vars_t<data_t> &vars,
-    const SFObject<data_t> &vars_sf, const vars_t<Tensor<1, data_t>> &d1,
-    const Tensor<1, data_t> &d1_phi, const Tensor<2, data_t> &d2_phi,
-    const SFObject<data_t> &advec_sf)
+    rhs_vars_t<data_t> &rhs, const vars_t<data_t> &vars,
+    const vars_t<Tensor<1, data_t>> &d1,
+    const diff2_vars_t<Tensor<2, data_t>> &d2, const vars_t<data_t> &advec)
 {
     using namespace TensorAlgebra;
 
@@ -128,19 +109,19 @@ void ScalarField<potential_t>::matter_rhs_excl_potential(
     const auto chris = compute_christoffel(d1.h, h_UU);
 
     // evolution equations for scalar field and (minus) its conjugate momentum
-    rhs_sf.phi = vars.lapse * vars_sf.Pi + advec_sf.phi;
-    rhs_sf.Pi = vars.lapse * vars.K * vars_sf.Pi + advec_sf.Pi;
+    rhs.phi = vars.lapse * vars.Pi + advec.phi;
+    rhs.Pi = vars.lapse * vars.K * vars.Pi + advec.Pi;
 
     FOR2(i, j)
     {
         // includes non conformal parts of chris not included in chris_ULL
-        rhs_sf.Pi += h_UU[i][j] * (-0.5 * d1.chi[j] * vars.lapse * d1_phi[i] +
-                                   vars.chi * vars.lapse * d2_phi[i][j] +
-                                   vars.chi * d1.lapse[i] * d1_phi[j]);
+        rhs.Pi += h_UU[i][j] * (-0.5 * d1.chi[j] * vars.lapse * d1.phi[i] +
+                                vars.chi * vars.lapse * d2.phi[i][j] +
+                                vars.chi * d1.lapse[i] * d1.phi[j]);
         FOR1(k)
         {
-            rhs_sf.Pi += -vars.chi * vars.lapse * h_UU[i][j] *
-                         chris.ULL[k][i][j] * d1_phi[k];
+            rhs.Pi += -vars.chi * vars.lapse * h_UU[i][j] * chris.ULL[k][i][j] *
+                      d1.phi[k];
         }
     }
 }

--- a/Source/TaggingCriteria/FixedGridsTaggingCriterion.hpp
+++ b/Source/TaggingCriteria/FixedGridsTaggingCriterion.hpp
@@ -1,0 +1,51 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef FIXEDGRIDSTAGGINGCRITERION_HPP_
+#define FIXEDGRIDSTAGGINGCRITERION_HPP_
+
+#include "Cell.hpp"
+#include "Coordinates.hpp"
+#include "DimensionDefinitions.hpp"
+#include "FourthOrderDerivatives.hpp"
+#include "Tensor.hpp"
+
+class FixedGridsTaggingCriterion
+{
+  protected:
+    const double m_dx;
+    const double m_L;
+    const FourthOrderDerivatives m_deriv;
+    const int m_level;
+    const std::array<double, CH_SPACEDIM> m_center;
+
+  public:
+    FixedGridsTaggingCriterion(const double dx, const int a_level,
+                               const double a_L,
+                               const std::array<double, CH_SPACEDIM> a_center)
+        : m_dx(dx), m_deriv(dx), m_level(a_level), m_L(a_L),
+          m_center(a_center){};
+
+    template <class data_t> void compute(Cell<data_t> current_cell) const
+    {
+        double criterion = 0.0;
+
+        // make sure the inner part is regridded around the horizon
+        // take L as the length of full grid, so tag inner 1/2
+        // of it, which means inner \pm L/4
+        double ratio = pow(2.0, -(m_level + 2.0));
+        const Coordinates<data_t> coords(current_cell, m_dx, m_center);
+        if (abs(coords.x) < m_L * ratio && abs(coords.y) < m_L * ratio &&
+            abs(coords.z) < m_L * ratio)
+        {
+            criterion = 100;
+        }
+
+        // Write back into the flattened Chombo box
+        current_cell.store_vars(criterion, 0);
+    }
+};
+
+#endif /* FIXEDGRIDSTAGGINGCRITERION_HPP_ */

--- a/Source/TaggingCriteria/FixedGridsTaggingCriterion.hpp
+++ b/Source/TaggingCriteria/FixedGridsTaggingCriterion.hpp
@@ -30,18 +30,16 @@ class FixedGridsTaggingCriterion
 
     template <class data_t> void compute(Cell<data_t> current_cell) const
     {
-        double criterion = 0.0;
-
+        data_t criterion = 0.0;
         // make sure the inner part is regridded around the horizon
         // take L as the length of full grid, so tag inner 1/2
         // of it, which means inner \pm L/4
         double ratio = pow(2.0, -(m_level + 2.0));
         const Coordinates<data_t> coords(current_cell, m_dx, m_center);
-        if (abs(coords.x) < m_L * ratio && abs(coords.y) < m_L * ratio &&
-            abs(coords.z) < m_L * ratio)
-        {
-            criterion = 100;
-        }
+        const data_t max_abs_xy = simd_max(abs(coords.x), abs(coords.y));
+        const data_t max_abs_xyz = simd_max(max_abs_xy, abs(coords.z));
+        auto regrid = simd_compare_lt(max_abs_xyz, m_L * ratio);
+        criterion = simd_conditional(regrid, 100.0, criterion);
 
         // Write back into the flattened Chombo box
         current_cell.store_vars(criterion, 0);

--- a/Source/utils/ArrayTools.hpp
+++ b/Source/utils/ArrayTools.hpp
@@ -8,8 +8,6 @@
 
 #include <algorithm>
 #include <array>
-#include <iostream>
-#include <iterator>
 
 /// A place for tools that operate on std::arrays
 namespace ArrayTools

--- a/Source/utils/ArrayTools.hpp
+++ b/Source/utils/ArrayTools.hpp
@@ -8,6 +8,8 @@
 
 #include <algorithm>
 #include <array>
+#include <iostream>
+#include <iterator>
 
 /// A place for tools that operate on std::arrays
 namespace ArrayTools


### PR DESCRIPTION
This is a new version of #81 which is now so out of date I decided to start afresh :-)

Key points:
- I have added an additional condition which is useful where one just wants to extrapolate values out of the grid to fill boundary ghosts. So far only zeroth and 1st order extrapolation (in r) is supported, but the framework is set so more orders could be added.
- There is the possibility of using this for a subset of vars and applying sommerfeld to the rest ("Mixed" boundaries)
- The extrapolating boundary condition is applied to (non reflective) diagnostic boundaries which will help in postprocessing to remove nans at boundaries and replace them with reasonable values
- I have amended the sommerfeld read in to allow specification of the non zero asymptotic values by var name, but the old way remains functional (you can try with the Kerr params_cheap.txt example) 
- I updated the scalar field example to use this in a physical case - a field around a BH with a non zero asymptotic value, with mixed bcs - extrapolating boundaries for the scalar field vars phi and Pi. To do this sensibly without solving the constraints I needed to remove backreaction so G=0 for now, and I removed the relaxation routine which is now obsolete anyway. This is not ideal but will be updated when I get round to putting in a proper SF example. 
- I cheekily took the chance to remove the SFObject thing (this change is effectively tested via the KclBssnTest) because it is so ugly... I know @TaigoFr will agree!

Comments /suggestions welcome!