### PR TITLE
Add class to call specificPostTimeStep at t=0

### DIFF
--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -102,7 +102,8 @@ void BinaryBHLevel::specificPostTimeStep()
 {
     CH_TIME("BinaryBHLevel::specificPostTimeStep");
 
-    bool first_step = (m_time == m_dt);
+    bool first_step = (m_time == 0.); // called at t=0 from Main
+    // bool first_step = (m_time == m_dt); // not called in Main
 
     if (m_p.activate_extraction == 1)
     {
@@ -123,7 +124,8 @@ void BinaryBHLevel::specificPostTimeStep()
                 // Now refresh the interpolator and do the interpolation
                 m_gr_amr.m_interpolator->refresh();
                 WeylExtraction my_extraction(m_p.extraction_params, m_dt,
-                                             m_time, m_restart_time);
+                                             m_time, first_step,
+                                             m_restart_time);
                 my_extraction.execute_query(m_gr_amr.m_interpolator);
             }
         }
@@ -154,12 +156,15 @@ void BinaryBHLevel::specificPostTimeStep()
     // do puncture tracking on requested level
     if (m_p.track_punctures && m_level == m_p.puncture_tracking_level)
     {
-        CH_TIME("PunctureTracking");
-        // only do the write out for every coarsest level timestep
-        int coarsest_level = 0;
-        bool write_punctures = at_level_timestep_multiple(coarsest_level);
-        m_bh_amr.m_puncture_tracker.execute_tracking(m_time, m_restart_time,
-                                                     m_dt, write_punctures);
+        if (m_time != 0) // already done at t=0 in Main
+        {
+            CH_TIME("PunctureTracking");
+            // only do the write out for every coarsest level timestep
+            int coarsest_level = 0;
+            bool write_punctures = at_level_timestep_multiple(coarsest_level);
+            m_bh_amr.m_puncture_tracker.execute_tracking(m_time, m_restart_time,
+                                                         m_dt, write_punctures);
+        }
     }
 }
 

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -59,8 +59,7 @@ void BinaryBHLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
     BoxLoops::loop(make_compute_pack(TraceARemoval(), PositiveChiAndAlpha()),
                    a_soln, a_soln, INCLUDE_GHOST_CELLS);
 
-    // Calculate CCZ4 right hand side and set constraints to zero to avoid
-    // undefined values
+    // Calculate CCZ4 right hand side
     BoxLoops::loop(CCZ4(m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation),
                    a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
 }
@@ -102,8 +101,10 @@ void BinaryBHLevel::specificPostTimeStep()
 {
     CH_TIME("BinaryBHLevel::specificPostTimeStep");
 
-    bool first_step = (m_time == 0.); // called at t=0 from Main
-    // bool first_step = (m_time == m_dt); // not called in Main
+    bool first_step =
+        (m_time == 0.); // this form is used when 'specificPostTimeStep' was
+                        // called during setup at t=0 from Main
+    // bool first_step = (m_time == m_dt); // if not called in Main
 
     if (m_p.activate_extraction == 1)
     {
@@ -156,15 +157,12 @@ void BinaryBHLevel::specificPostTimeStep()
     // do puncture tracking on requested level
     if (m_p.track_punctures && m_level == m_p.puncture_tracking_level)
     {
-        if (m_time != 0) // already done at t=0 in Main
-        {
-            CH_TIME("PunctureTracking");
-            // only do the write out for every coarsest level timestep
-            int coarsest_level = 0;
-            bool write_punctures = at_level_timestep_multiple(coarsest_level);
-            m_bh_amr.m_puncture_tracker.execute_tracking(m_time, m_restart_time,
-                                                         m_dt, write_punctures);
-        }
+        CH_TIME("PunctureTracking");
+        // only do the write out for every coarsest level timestep
+        int coarsest_level = 0;
+        bool write_punctures = at_level_timestep_multiple(coarsest_level);
+        m_bh_amr.m_puncture_tracker.execute_tracking(m_time, m_restart_time,
+                                                     m_dt, write_punctures);
     }
 }
 

--- a/Examples/BinaryBH/Main_BinaryBH.cpp
+++ b/Examples/BinaryBH/Main_BinaryBH.cpp
@@ -17,6 +17,7 @@
 #include "GRParmParse.hpp"
 #include "SetupFunctions.hpp"
 #include "SimulationParameters.hpp"
+#include "CallFunctionOverLevels.hpp"
 
 // Problem specific includes:
 #include "BinaryBHLevel.hpp"
@@ -66,6 +67,13 @@ int runGRChombo(int argc, char *argv[])
     using Minutes = std::chrono::duration<double, std::ratio<60, 1>>;
 
     std::chrono::time_point<Clock> start_time = Clock::now();
+
+    // Add a scheduler to GRAMR to calls specificPostTimeStep on every AMRLevel
+    // at time 0
+    CallFunctionOverLevelsPtr<> call_now(
+        [](GRAMRLevel *level) { level->specificPostTimeStep(); });
+    call_now.execute(bh_amr); // call 'now' really now
+    // bh_amr.schedule(call_now); // or call 'now', after 1st plot level is done
 
     bh_amr.run(sim_params.stop_time, sim_params.max_steps);
 

--- a/Examples/KerrBH/KerrBHLevel.cpp
+++ b/Examples/KerrBH/KerrBHLevel.cpp
@@ -63,8 +63,7 @@ void KerrBHLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
     BoxLoops::loop(make_compute_pack(TraceARemoval(), PositiveChiAndAlpha()),
                    a_soln, a_soln, INCLUDE_GHOST_CELLS);
 
-    // Calculate CCZ4 right hand side and set constraints to zero to avoid
-    // undefined values
+    // Calculate CCZ4 right hand side
     BoxLoops::loop(CCZ4(m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation),
                    a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
 }

--- a/InstallNotes/MakeDefsLocalExamples/MN4.Make.defs.local
+++ b/InstallNotes/MakeDefsLocalExamples/MN4.Make.defs.local
@@ -1,11 +1,12 @@
 DIM            = 3
-DEBUG          = TRUE
-OPT            = TRUE
+DEBUG          = FALSE
+OPT            = HIGH
 PRECISION      = DOUBLE
 CXX            = icpc -std=c++14 -qopenmp -mkl=sequential
 FC             = ifort -qopenmp -mkl=sequential
 MPI            = TRUE
 MPICXX         = mpiicpc -std=c++14 -qopenmp -mkl=sequential -lmpi
+XTRACONFIG     = .Intel # This just appends to all object files and executables
 USE_64         = TRUE
 USE_HDF        = TRUE
 HDFINCFLAGS    = -I/apps/HDF5/1.8.19/INTEL/IMPI/include
@@ -14,8 +15,7 @@ HDFMPIINCFLAGS = -I/apps/HDF5/1.8.19/INTEL/IMPI/include
 HDFMPILIBFLAGS = -L/apps/HDF5/1.8.19/INTEL/IMPI/lib -lhdf5 -lz
 USE_MT         = FALSE
 OPENMPCC       = TRUE
-cxxdbgflags    = -g -Wl,--eh-frame-hdr
-cxxoptflags    = -O3 -qoverride-limits -xSSE4.2 -axAVX
-fdbgflags      = -g -Wl,--eh-frame-hdr
-foptflags      = -O3 -qoverride-limits -xSSE4.2 -axAVX
-cxxcppflags    = -DDISABLE_AHFINDER
+cxxdbgflags    = -g
+cxxoptflags    = -O3 -xSSE4.2 -axAVX
+fdbgflags      = -g
+foptflags      = -O3 -xSSE4.2 -axAVX

--- a/Source/BlackHoles/PunctureTracker.cpp
+++ b/Source/BlackHoles/PunctureTracker.cpp
@@ -132,7 +132,8 @@ void PunctureTracker::execute_tracking(double a_time, double a_restart_time,
                                        double a_dt, const bool write_punctures)
 {
     CH_TIME("PunctureTracker::execute_tracking");
-    if (m_num_punctures == 0)
+    // leave if this is called at t=0, we don't want to move the puncture yet
+    if (m_num_punctures == 0 || a_time == 0.)
         return;
     CH_assert(m_interpolator != nullptr); // sanity check
 

--- a/Source/utils/CallFunctionOverLevels.hpp
+++ b/Source/utils/CallFunctionOverLevels.hpp
@@ -1,0 +1,92 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef CALL_FUCNTION_OVER_LEVELS
+#define CALL_FUCNTION_OVER_LEVELS
+
+#include "AMR.H"
+#include "GRAMRLevel.hpp"
+#include "Scheduler.H"
+
+#include <limits> // std::numeric_limits
+
+//! This is just an interface for the AMR scheduler to call some GRAMRLevel (or
+//! any other Example specific level) function on every AMRLevel
+//! Satisfies syntax of Chmbo's Scheduler such that it can be passed to GRAMR
+//! and be scheduled
+template <class Level = GRAMRLevel>
+class CallFunctionOverLevels : public Scheduler::PeriodicFunction
+{
+    bool m_reverse_levels;
+    std::function<void(Level *)> m_func;
+
+    // Use default condstructor of PeriodicFunction
+    using PeriodicFunction::PeriodicFunction;
+
+    AMR *m_amr_ptr; //! pointer to AMR object
+
+  public:
+    CallFunctionOverLevels(std::function<void(Level *)> a_func,
+                           bool a_reverse_levels = true)
+        : m_func(a_func), m_reverse_levels(a_reverse_levels)
+    {
+    }
+
+    // required from Scheduler::PeriodicFunction
+    virtual void setUp(AMR &a_AMR, int a_interval = -1) override
+    {
+        m_amr_ptr = &a_AMR;
+    }
+
+    // required from Scheduler::PeriodicFunction
+    virtual void operator()(int a_step = 0, Real a_time = 0.) override
+    {
+        auto amr_level_ptrs = m_amr_ptr->getAMRLevels().stdVector();
+
+        // need to reverse this vector so that m_func is called in order of
+        // finest level to coarsest. This is important for example for
+        // 'specificPostTimeStep', which is always run in reverse order of
+        // levels
+        if (m_reverse_levels)
+            std::reverse(std::begin(amr_level_ptrs), std::end(amr_level_ptrs));
+
+        for (AMRLevel *amr_level_ptr : amr_level_ptrs)
+            m_func(Level::gr_cast(amr_level_ptr));
+    }
+};
+
+//! This is just an interface for the AMR scheduler to call some Level
+//! function on every AMRLevel
+//! This can either be called directly by calling execute, or passed to an AMR
+//! (as GRAMR) by doing gr_amr.schedule(me) (this version will make it be called
+//! only after plot files are written, if that is ever an interest)
+template <class Level = GRAMRLevel>
+class CallFunctionOverLevelsPtr : public RefCountedPtr<Scheduler>
+{
+    RefCountedPtr<CallFunctionOverLevels<Level>> m_ptr_to_func;
+
+  public:
+    //! interval defines the frequency with which the scheduler will be called
+    //! if added to an AMR
+    CallFunctionOverLevelsPtr(std::function<void(Level *)> a_func,
+                              bool a_reverse_levels = true,
+                              int a_interval = std::numeric_limits<int>::max())
+        : RefCountedPtr<Scheduler>(new Scheduler),
+          m_ptr_to_func(
+              new CallFunctionOverLevels<Level>(a_func, a_reverse_levels))
+    // the two 'new' pointers are deleted by RefCountedPtr, no memory leak
+    {
+        (*this)->schedule(m_ptr_to_func, a_interval);
+    }
+
+    // run immediately!
+    void execute(AMR &amr)
+    {
+        m_ptr_to_func->setUp(amr);
+        (*m_ptr_to_func)();
+    }
+};
+
+#endif /* CALL_FUCNTION_OVER_LEVELS */

--- a/Source/utils/MultiLevelTask.hpp
+++ b/Source/utils/MultiLevelTask.hpp
@@ -3,8 +3,8 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-#ifndef MULTI_LEVEL_TASK
-#define MULTI_LEVEL_TASK
+#ifndef MULTILEVELTASK_HPP_
+#define MULTILEVELTASK_HPP_
 
 #include "AMR.H"
 #include "GRAMRLevel.hpp"
@@ -14,13 +14,13 @@
 
 //! This is just an interface for the AMR scheduler to call some GRAMRLevel (or
 //! any other Example specific level) function on every AMRLevel
-//! Satisfies syntax of Chmbo's Scheduler such that it can be passed to GRAMR
+//! Satisfies syntax of Chombo's Scheduler such that it can be passed to GRAMR
 //! and be scheduled
-template <class Level = GRAMRLevel>
+template <class level_t = GRAMRLevel>
 class MultiLevelTask : public Scheduler::PeriodicFunction
 {
+    std::function<void(level_t *)> m_func;
     bool m_reverse_levels;
-    std::function<void(Level *)> m_func;
 
     // Use default condstructor of PeriodicFunction
     using PeriodicFunction::PeriodicFunction;
@@ -28,7 +28,7 @@ class MultiLevelTask : public Scheduler::PeriodicFunction
     AMR *m_amr_ptr; //! pointer to AMR object
 
   public:
-    MultiLevelTask(std::function<void(Level *)> a_func,
+    MultiLevelTask(std::function<void(level_t *)> a_func,
                    bool a_reverse_levels = true)
         : m_func(a_func), m_reverse_levels(a_reverse_levels)
     {
@@ -53,28 +53,28 @@ class MultiLevelTask : public Scheduler::PeriodicFunction
             std::reverse(std::begin(amr_level_ptrs), std::end(amr_level_ptrs));
 
         for (AMRLevel *amr_level_ptr : amr_level_ptrs)
-            m_func(Level::gr_cast(amr_level_ptr));
+            m_func(level_t::gr_cast(amr_level_ptr));
     }
 };
 
-//! This is just an interface for the AMR scheduler to call some Level
+//! This is just an interface for the AMR scheduler to call some level_t
 //! function on every AMRLevel
 //! This can either be called directly by calling execute, or passed to an AMR
 //! (as GRAMR) by doing gr_amr.schedule(me) (this version will make it be called
 //! only after plot files are written, if that is ever an interest)
-template <class Level = GRAMRLevel>
+template <class level_t = GRAMRLevel>
 class MultiLevelTaskPtr : public RefCountedPtr<Scheduler>
 {
-    RefCountedPtr<MultiLevelTask<Level>> m_ptr_to_func;
+    RefCountedPtr<MultiLevelTask<level_t>> m_ptr_to_func;
 
   public:
     //! interval defines the frequency with which the scheduler will be called
     //! if added to an AMR
-    MultiLevelTaskPtr(std::function<void(Level *)> a_func,
+    MultiLevelTaskPtr(std::function<void(level_t *)> a_func,
                       bool a_reverse_levels = true,
                       int a_interval = std::numeric_limits<int>::max())
         : RefCountedPtr<Scheduler>(new Scheduler),
-          m_ptr_to_func(new MultiLevelTask<Level>(a_func, a_reverse_levels))
+          m_ptr_to_func(new MultiLevelTask<level_t>(a_func, a_reverse_levels))
     // the two 'new' pointers are deleted by RefCountedPtr, no memory leak
     {
         if (a_interval <= 0) // the user probably means "never again"
@@ -90,4 +90,4 @@ class MultiLevelTaskPtr : public RefCountedPtr<Scheduler>
     }
 };
 
-#endif /* MULTI_LEVEL_TASK */
+#endif /* MULTILEVELTASK_HPP_ */

--- a/Source/utils/MultiLevelTask.hpp
+++ b/Source/utils/MultiLevelTask.hpp
@@ -3,8 +3,8 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-#ifndef CALL_FUCNTION_OVER_LEVELS
-#define CALL_FUCNTION_OVER_LEVELS
+#ifndef MULTI_LEVEL_TASK
+#define MULTI_LEVEL_TASK
 
 #include "AMR.H"
 #include "GRAMRLevel.hpp"
@@ -17,7 +17,7 @@
 //! Satisfies syntax of Chmbo's Scheduler such that it can be passed to GRAMR
 //! and be scheduled
 template <class Level = GRAMRLevel>
-class CallFunctionOverLevels : public Scheduler::PeriodicFunction
+class MultiLevelTask : public Scheduler::PeriodicFunction
 {
     bool m_reverse_levels;
     std::function<void(Level *)> m_func;
@@ -28,8 +28,8 @@ class CallFunctionOverLevels : public Scheduler::PeriodicFunction
     AMR *m_amr_ptr; //! pointer to AMR object
 
   public:
-    CallFunctionOverLevels(std::function<void(Level *)> a_func,
-                           bool a_reverse_levels = true)
+    MultiLevelTask(std::function<void(Level *)> a_func,
+                   bool a_reverse_levels = true)
         : m_func(a_func), m_reverse_levels(a_reverse_levels)
     {
     }
@@ -63,21 +63,22 @@ class CallFunctionOverLevels : public Scheduler::PeriodicFunction
 //! (as GRAMR) by doing gr_amr.schedule(me) (this version will make it be called
 //! only after plot files are written, if that is ever an interest)
 template <class Level = GRAMRLevel>
-class CallFunctionOverLevelsPtr : public RefCountedPtr<Scheduler>
+class MultiLevelTaskPtr : public RefCountedPtr<Scheduler>
 {
-    RefCountedPtr<CallFunctionOverLevels<Level>> m_ptr_to_func;
+    RefCountedPtr<MultiLevelTask<Level>> m_ptr_to_func;
 
   public:
     //! interval defines the frequency with which the scheduler will be called
     //! if added to an AMR
-    CallFunctionOverLevelsPtr(std::function<void(Level *)> a_func,
-                              bool a_reverse_levels = true,
-                              int a_interval = std::numeric_limits<int>::max())
+    MultiLevelTaskPtr(std::function<void(Level *)> a_func,
+                      bool a_reverse_levels = true,
+                      int a_interval = std::numeric_limits<int>::max())
         : RefCountedPtr<Scheduler>(new Scheduler),
-          m_ptr_to_func(
-              new CallFunctionOverLevels<Level>(a_func, a_reverse_levels))
+          m_ptr_to_func(new MultiLevelTask<Level>(a_func, a_reverse_levels))
     // the two 'new' pointers are deleted by RefCountedPtr, no memory leak
     {
+        if (a_interval <= 0) // the user probably means "never again"
+            a_interval = std::numeric_limits<int>::max();
         (*this)->schedule(m_ptr_to_func, a_interval);
     }
 
@@ -89,4 +90,4 @@ class CallFunctionOverLevelsPtr : public RefCountedPtr<Scheduler>
     }
 };
 
-#endif /* CALL_FUCNTION_OVER_LEVELS */
+#endif /* MULTI_LEVEL_TASK */


### PR DESCRIPTION
I think many of us suffer from not having our specificPostTimeStep processing also at `t=0` (Weyl Extraction or any other extraction you do). This PR comes to fix it. I have done many hacks in the past to fix it, but it's quite tricky because specificPostTimeStep has to be called in reverse order of levels, so it cannot be really called in initialData or smth like that.

This was mostly done by @mirenradia, I just generalized it a bit and above all: try to make it really user friendly.

The idea is basically you can now add just a few lines to Main, and specificPostTimeStep will be called (at t=0). You just have to be careful with defining the `first_step` to `m_time==0.` instead of `dt` as we commonly had before (sometimes by default, so be careful) EXCEPT for the PunctureTracker, that is also called in Main at `t=0`, and hence a `if (m_time != 0)` guard saves it inside `specificPostTimeStep`.

But it really is quite general. You can call any GRAMRLevel function, including custom ones you may define in your own Example (hence why a template `Level`), and you may choose not to revert the order of the levels. Plus, it's also made to be an AMR Scheduler, mostly due to how I inherited @mirenradia's version, but it's nice that like that you can also choose to use it as a function that is called at regular time intervals (say every 10 timesteps). A bit overkill I agree, but who knows...

The name 'CallFunctionOverLevels' is not amazing, but seemed quite generic. Feel free to offer suggestions if you find better alternatives.

P.S. I also edited MareNostrum's Make.defs.local under to hood.