### PR TITLE
Add Github action to run tests with Intel compiler

### DIFF
--- a/.github/workflows/run-grchombo-tests-gcc.yml
+++ b/.github/workflows/run-grchombo-tests-gcc.yml
@@ -1,10 +1,10 @@
-name: Run GRChombo Tests
+name: Run GRChombo Tests (GCC)
 
-on: [pull_request]
+on: [push]
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       CHOMBO_HOME: ${{ github.workspace }}/Chombo/lib
       OMP_NUM_THREADS: 1
@@ -24,13 +24,13 @@ jobs:
     - name: Install Chombo dependencies
       run: |
         sudo apt-get update
-        sudo apt-get -y --no-install-recommends install csh make gfortran-8 g++-8 cpp-8 libhdf5-dev libhdf5-openmpi-dev openmpi-bin libblas-dev liblapack-dev libgetopt-complete-perl ssh
+        sudo apt-get -y --no-install-recommends install csh gfortran-10 g++-10 cpp-10 libhdf5-dev libhdf5-openmpi-dev openmpi-bin libblas-dev liblapack-dev libgetopt-complete-perl
 
     - name: Set Compilers
       run: |
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-8 80
-        sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-8 80
-        sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-8 80
+        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
+        sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-10 100
+        sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-10 100
 
     - name: Build Chombo
       run: |

--- a/.github/workflows/run-grchombo-tests-intel.yml
+++ b/.github/workflows/run-grchombo-tests-intel.yml
@@ -1,0 +1,54 @@
+name: Run GRChombo Tests (Intel)
+
+on: [push]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-20.04
+    env:
+      CHOMBO_HOME: ${{ github.workspace }}/Chombo/lib
+      OMP_NUM_THREADS: 1
+
+    steps:
+    - name: Checkout Chombo
+      uses: actions/checkout@v2
+      with:
+        repository: GRChombo/Chombo
+        path: Chombo
+
+    - name: Checkout GRChombo
+      uses: actions/checkout@v2
+      with:
+        path: GRChombo
+
+    - name: Install Chombo dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get -y --no-install-recommends install csh libgetopt-complete-perl
+
+    - name: Install Intel compilers/MPI
+      run: |
+        wget https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo apt-key add GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB
+        sudo add-apt-repository "deb https://apt.repos.intel.com/oneapi all main"
+        sudo apt-get -y install intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic intel-oneapi-compiler-fortran intel-oneapi-mkl intel-oneapi-mpi intel-oneapi-mpi-devel intel-oneapi-openmp
+      working-directory: /tmp
+
+    - name: Build Chombo
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        cp $GITHUB_WORKSPACE/GRChombo/InstallNotes/MakeDefsLocalExamples/intel-no-hdf5-minimal.Make.defs.local $CHOMBO_HOME/mk/Make.defs.local
+        make -j 4 AMRTimeDependent AMRTools BaseTools BoxTools
+      working-directory: ${{ env.CHOMBO_HOME }}
+
+    - name: Build GRChombo Tests
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        make test -j 4
+      working-directory: ${{ github.workspace }}/GRChombo
+
+    - name: Run GRChombo Tests
+      run: |
+        source /opt/intel/oneapi/setvars.sh
+        make run -j 2
+      working-directory: ${{ github.workspace }}/GRChombo

--- a/InstallNotes/MakeDefsLocalExamples/intel-no-hdf5-minimal.Make.defs.local
+++ b/InstallNotes/MakeDefsLocalExamples/intel-no-hdf5-minimal.Make.defs.local
@@ -1,0 +1,22 @@
+#begin  -- dont change this line
+# This is used for the github action that builds and runs the tests
+# with the Intel C++ compiler and MPI implementation
+
+DIM            = 3
+DEBUG          = TRUE
+PRECISION      = DOUBLE
+OPT            = TRUE
+PROFILE        = FALSE
+CXX            = icpc
+FC             = ifort
+MPI            = TRUE
+OPENMPCC       = TRUE
+MPICXX         = mpiicpc
+USE_64         = TRUE
+USE_HDF        = FALSE
+USE_MT         = FALSE
+cxxoptflags    = -xHost -O3
+foptflags      = -xHost -O3
+syslibflags    = -mkl=sequential
+
+#end  -- dont change this line

--- a/Source/GRChomboCore/GRAMRLevel.hpp
+++ b/Source/GRChomboCore/GRAMRLevel.hpp
@@ -15,6 +15,7 @@
 #include "InterpSource.hpp"
 #include "LevelFluxRegister.H" //We don't actually use flux conservation but Chombo assumes we do
 #include "LevelRK4.H"
+#include "LoadBalance.H"
 #include "SimulationParameters.hpp"
 #include "UserVariables.hpp" // need NUM_VARS
 #include <fstream>


### PR DESCRIPTION
Since we have occasionally had a few PRs which compiled fine with GCC (and passed the corresponding Github action) but then had errors with the Intel compiler, I have added an action to build and run the tests with the Intel compiler. 

Changes/notes below:
* The Intel compiler version used is whatever the latest "classic" version is in the Intel apt software repositories (currently 2021.1.1-189).
* Fix GRAMRLevel.cpp includes to allow compiling without HDF5 (the LoadBalance.H header was only included before in the case `USE_HDF = TRUE` which caused errors otherwise).
* A new minimal Make.defs.local example for the Intel compiler has been added for this action.
* Since there is no suitable HDF5 package for the Intel compiler in the Ubuntu repositories, `USE_HDF` is set to false in the Make.defs.local.
* Also update GCC action to use the Ubuntu 20.04 github runner and GCC v10.
* Both of these actions are set to run on every commit rather than just on PRs (I think we have more than enough action minutes to be able to do this).