### PR TITLE
Speed up SurfaceExtraction

### DIFF
--- a/Source/AMRInterpolator/SphericalExtraction.hpp
+++ b/Source/AMRInterpolator/SphericalExtraction.hpp
@@ -82,7 +82,8 @@ class SphericalExtraction : public SurfaceExtraction<SphericalGeometry>
         int es, int el, int em, const complex_function_t &a_function,
         std::pair<std::vector<double>, std::vector<double>> &out_integrals,
         const IntegrationMethod &a_method_theta = IntegrationMethod::simpson,
-        const IntegrationMethod &a_method_phi = IntegrationMethod::trapezium)
+        const IntegrationMethod &a_method_phi = IntegrationMethod::trapezium,
+        const bool a_broadcast_integral = false)
     {
         auto integrand_re = [center = m_center, &geom = m_geom, es, el, em,
                              &a_function](std::vector<double> &a_data_here,
@@ -100,7 +101,7 @@ class SphericalExtraction : public SurfaceExtraction<SphericalGeometry>
                    (r * r);
         };
         add_integrand(integrand_re, out_integrals.first, a_method_theta,
-                      a_method_phi);
+                      a_method_phi, a_broadcast_integral);
 
         auto integrand_im = [center = m_center, &geom = m_geom, es, el, em,
                              &a_function](std::vector<double> &a_data_here,
@@ -118,7 +119,7 @@ class SphericalExtraction : public SurfaceExtraction<SphericalGeometry>
                    (r * r);
         };
         add_integrand(integrand_im, out_integrals.second, a_method_theta,
-                      a_method_phi);
+                      a_method_phi, a_broadcast_integral);
     }
 
     //! If you only want to extract one mode, you can use this function which

--- a/Source/AMRInterpolator/SurfaceExtraction.hpp
+++ b/Source/AMRInterpolator/SurfaceExtraction.hpp
@@ -85,6 +85,7 @@ template <class SurfaceGeometry> class SurfaceExtraction
     std::vector<integrand_t> m_integrands;
     std::vector<std::array<IntegrationMethod, 2>> m_integration_methods;
     std::vector<std::reference_wrapper<std::vector<double>>> m_integrals;
+    std::vector<bool> m_broadcast_integrals;
 
     bool m_done_extraction; //!< whether or not the extract function has been
                             //!< called for this object
@@ -141,28 +142,37 @@ template <class SurfaceGeometry> class SurfaceExtraction
     //! for integrate() to integrate over.
     //! Note the area_element is already included from the SurfaceGeometry
     //! template class
+    //! The last argument is whether to broadcast the result to all MPI ranks
+    //! or just keep on rank 0. Most use cases won't need this set to true.
     void add_integrand(
         const integrand_t &a_integrand, std::vector<double> &out_integrals,
         const IntegrationMethod &a_method_u = IntegrationMethod::trapezium,
-        const IntegrationMethod &a_method_v = IntegrationMethod::trapezium);
+        const IntegrationMethod &a_method_v = IntegrationMethod::trapezium,
+        const bool a_broadcast_integral = false);
 
     //! Add an integrand which is just a single var. The a_var argument should
     //! correspond to the order in which the desired var was added to this
     //! object with add_var
+    //! The last argument is whether to broadcast the result to all MPI ranks
+    //! or just keep on rank 0. Most use cases won't need this set to true.
     void add_var_integrand(
         int a_var, std::vector<double> &out_integrals,
         const IntegrationMethod &a_method_u = IntegrationMethod::trapezium,
-        const IntegrationMethod &a_method_v = IntegrationMethod::trapezium);
+        const IntegrationMethod &a_method_v = IntegrationMethod::trapezium,
+        const bool a_broadcast_integral = false);
 
     //! Integrate the integrands added using add_integrand
     void integrate();
 
     //! This integrate function can be used if you only want to integrate one
     //! integrand. It calls add_integrand() and integrate()
+    //! The last argument is whether to broadcast the result to all MPI ranks
+    //! or just keep on rank 0. Most use cases won't need this set to true.
     std::vector<double> integrate(
         integrand_t a_integrand,
         const IntegrationMethod &a_method_u = IntegrationMethod::trapezium,
-        const IntegrationMethod &a_method_v = IntegrationMethod::trapezium);
+        const IntegrationMethod &a_method_v = IntegrationMethod::trapezium,
+        const bool a_broadcast_integral = false);
 
     //! Write the interpolated data to a file with a block for each surface
     void write_extraction(std::string a_file_prefix) const;

--- a/Source/AMRInterpolator/SurfaceExtraction.impl.hpp
+++ b/Source/AMRInterpolator/SurfaceExtraction.impl.hpp
@@ -18,29 +18,34 @@ SurfaceExtraction<SurfaceGeometry>::SurfaceExtraction(
     double a_time, bool a_first_step, double a_restart_time)
     : m_geom(a_geom), m_params(a_params), m_dt(a_dt), m_time(a_time),
       m_first_step(a_first_step), m_restart_time(a_restart_time),
-      m_num_points(m_params.num_points_u * m_params.num_points_v),
+      m_num_interp_points((procID() == 0)
+                              ? m_params.num_surfaces * m_params.num_points_u *
+                                    m_params.num_points_v
+                              : 0),
       m_du(m_geom.du(m_params.num_points_u)),
       m_dv(m_geom.dv(m_params.num_points_v)), m_done_extraction(false)
 {
-    FOR1(idir)
+    // only interp points on rank 0
+    if (procID() == 0)
     {
-        m_interp_coords[idir].resize(m_num_points * m_params.num_surfaces);
-    }
+        FOR1(idir) { m_interp_coords[idir].resize(m_num_interp_points); }
 
-    for (int isurface = 0; isurface < m_params.num_surfaces; ++isurface)
-    {
-        double surface_param_value = m_params.surface_param_values[isurface];
-        for (int iu = 0; iu < m_params.num_points_u; ++iu)
+        for (int isurface = 0; isurface < m_params.num_surfaces; ++isurface)
         {
-            double u = m_geom.u(iu, m_params.num_points_u);
-            for (int iv = 0; iv < m_params.num_points_v; ++iv)
+            double surface_param_value =
+                m_params.surface_param_values[isurface];
+            for (int iu = 0; iu < m_params.num_points_u; ++iu)
             {
-                double v = m_geom.v(iv, m_params.num_points_v);
-                FOR1(idir)
+                double u = m_geom.u(iu, m_params.num_points_u);
+                for (int iv = 0; iv < m_params.num_points_v; ++iv)
                 {
-                    int idx = index(isurface, iu, iv);
-                    m_interp_coords[idir][idx] =
-                        m_geom.get_grid_coord(idir, surface_param_value, u, v);
+                    double v = m_geom.v(iv, m_params.num_points_v);
+                    FOR1(idir)
+                    {
+                        int idx = index(isurface, iu, iv);
+                        m_interp_coords[idir][idx] = m_geom.get_grid_coord(
+                            idir, surface_param_value, u, v);
+                    }
                 }
             }
         }
@@ -55,7 +60,8 @@ void SurfaceExtraction<SurfaceGeometry>::add_var(int a_var,
 {
     CH_assert(!m_done_extraction);
     m_vars.push_back(std::make_tuple(a_var, a_var_type, a_deriv));
-    m_interp_data.emplace_back(m_num_points * m_params.num_surfaces);
+    // m_num_interp_points is 0 on ranks > 0
+    m_interp_data.emplace_back(m_num_interp_points);
 }
 
 //! add a vector of variables/derivatives of variables
@@ -96,8 +102,8 @@ void SurfaceExtraction<SurfaceGeometry>::add_diagnostic_vars(
 template <class SurfaceGeometry>
 SurfaceExtraction<SurfaceGeometry>::SurfaceExtraction(
     const SurfaceGeometry &a_geom, const params_t &a_params,
-    const std::vector<std::pair<int, Derivative>> &a_vars, double a_dt,
-    double a_time, bool a_first_step, double a_restart_time)
+    const std::vector<std::tuple<int, VariableType, Derivative>> &a_vars,
+    double a_dt, double a_time, bool a_first_step, double a_restart_time)
     : SurfaceExtraction<SurfaceGeometry>(a_geom, a_params, a_dt, a_time,
                                          a_first_step, a_restart_time)
 {
@@ -114,7 +120,7 @@ SurfaceExtraction<SurfaceGeometry>::SurfaceExtraction(
     : SurfaceExtraction<SurfaceExtraction>(a_geom, a_params, a_dt, a_time,
                                            a_first_step, a_restart_time)
 {
-    add_vars(a_vars);
+    add_evolution_vars(a_vars);
 }
 
 //! Do the extraction
@@ -127,8 +133,8 @@ void SurfaceExtraction<SurfaceGeometry>::extract(
     {
         MayDay::Error("SurfaceExtraction: invalid AMRInterpolator pointer");
     }
-    // set up the interpolation query
-    InterpolationQuery query(m_num_points * m_params.num_surfaces);
+    // m_num_interp_points is 0 on ranks > 0
+    InterpolationQuery query(m_num_interp_points);
     FOR1(idir) { query.setCoords(idir, m_interp_coords[idir].data()); }
     for (int ivar = 0; ivar < m_vars.size(); ++ivar)
     {
@@ -151,47 +157,50 @@ void SurfaceExtraction<SurfaceGeometry>::add_integrand(
     const integrand_t &a_integrand, std::vector<double> &out_integrals,
     const IntegrationMethod &a_method_u, const IntegrationMethod &a_method_v)
 {
-    // store the integrand
-    m_integrands.push_back(a_integrand);
+    if (procID() == 0)
+    {
+        // store the integrand
+        m_integrands.push_back(a_integrand);
 
-    // resize the out_integrals and store a reference to it
-    out_integrals.resize(m_params.num_surfaces);
-    std::fill(out_integrals.begin(), out_integrals.end(), 0.0);
-    m_integrals.push_back(std::ref(out_integrals));
+        // resize the out_integrals and store a reference to it
+        out_integrals.resize(m_params.num_surfaces);
+        std::fill(out_integrals.begin(), out_integrals.end(), 0.0);
+        m_integrals.push_back(std::ref(out_integrals));
 
-    // check if integration methods are valid given periodicity and number of
-    // points
-    bool valid_u =
-        a_method_u.is_valid(m_params.num_points_u, m_geom.is_u_periodic());
-    bool valid_v =
-        a_method_v.is_valid(m_params.num_points_v, m_geom.is_v_periodic());
+        // check if integration methods are valid given periodicity and number
+        // of points
+        bool valid_u =
+            a_method_u.is_valid(m_params.num_points_u, m_geom.is_u_periodic());
+        bool valid_v =
+            a_method_v.is_valid(m_params.num_points_v, m_geom.is_v_periodic());
 
-    // default to using the trapezium rule if provided methods are not valid
-    IntegrationMethod method_u = IntegrationMethod::trapezium;
-    IntegrationMethod method_v = IntegrationMethod::trapezium;
-    if (!valid_u)
-    {
-        MayDay::Warning(
-            "SurfaceExtraction<SurfaceGeometry>::integrate: Provided "
-            "IntegrationMethod for u is not valid with\nthis num_points_u; "
-            "reverting to trapezium rule.");
+        // default to using the trapezium rule if provided methods are not valid
+        IntegrationMethod method_u = IntegrationMethod::trapezium;
+        IntegrationMethod method_v = IntegrationMethod::trapezium;
+        if (!valid_u)
+        {
+            MayDay::Warning(
+                "SurfaceExtraction<SurfaceGeometry>::integrate: Provided "
+                "IntegrationMethod for u is not valid with\nthis num_points_u; "
+                "reverting to trapezium rule.");
+        }
+        else
+        {
+            method_u = a_method_u;
+        }
+        if (!valid_v)
+        {
+            MayDay::Warning(
+                "SurfaceExtraction<SurfaceGeometry>::integrate: Provided "
+                "IntegrationMethod for v is not valid with\nthis num_points_v; "
+                "reverting to trapezium rule.");
+        }
+        else
+        {
+            method_v = a_method_v;
+        }
+        m_integration_methods.push_back({method_u, method_v});
     }
-    else
-    {
-        method_u = a_method_u;
-    }
-    if (!valid_v)
-    {
-        MayDay::Warning(
-            "SurfaceExtraction<SurfaceGeometry>::integrate: Provided "
-            "IntegrationMethod for v is not valid with\nthis num_points_v; "
-            "reverting to trapezium rule.");
-    }
-    else
-    {
-        method_v = a_method_v;
-    }
-    m_integration_methods.push_back({method_u, method_v});
 }
 
 //! Add an integrand which is just a single var. The a_var argument should
@@ -213,44 +222,51 @@ template <class SurfaceGeometry>
 void SurfaceExtraction<SurfaceGeometry>::integrate()
 {
     CH_assert(m_done_extraction);
-    CH_assert(m_integrands.size() == m_integration_methods.size() &&
-              m_integrals.size() > 0);
-    int num_integrals = m_integrals.size();
-
-    for (int isurface = 0; isurface < m_params.num_surfaces; ++isurface)
+    if (procID() == 0)
     {
-        double surface_param_value = m_params.surface_param_values[isurface];
-        for (int iu = 0; iu < m_params.num_points_u; ++iu)
+        CH_assert(m_integrands.size() == m_integration_methods.size() &&
+                  m_integrals.size() > 0);
+        int num_integrals = m_integrals.size();
+
+        for (int isurface = 0; isurface < m_params.num_surfaces; ++isurface)
         {
-            double u = m_geom.u(iu, m_params.num_points_u);
-            std::vector<double> inner_integral(num_integrals, 0.0);
-            for (int iv = 0; iv < m_params.num_points_v; ++iv)
+            double surface_param_value =
+                m_params.surface_param_values[isurface];
+            for (int iu = 0; iu < m_params.num_points_u; ++iu)
             {
-                double v = m_geom.v(iv, m_params.num_points_v);
-                std::vector<double> data_here(m_vars.size());
-                for (int ivar = 0; ivar < m_vars.size(); ++ivar)
+                double u = m_geom.u(iu, m_params.num_points_u);
+                std::vector<double> inner_integral(num_integrals, 0.0);
+                for (int iv = 0; iv < m_params.num_points_v; ++iv)
                 {
-                    data_here[ivar] =
-                        m_interp_data[ivar][index(isurface, iu, iv)];
+                    double v = m_geom.v(iv, m_params.num_points_v);
+                    std::vector<double> data_here(m_vars.size());
+                    for (int ivar = 0; ivar < m_vars.size(); ++ivar)
+                    {
+                        data_here[ivar] =
+                            m_interp_data[ivar][index(isurface, iu, iv)];
+                    }
+                    for (int iintegral = 0; iintegral < num_integrals;
+                         ++iintegral)
+                    {
+                        auto integrand = m_integrands[iintegral];
+                        double integrand_with_area_element =
+                            integrand(data_here, surface_param_value, u, v) *
+                            m_geom.area_element(surface_param_value, u, v);
+                        double weight =
+                            m_integration_methods[iintegral][1].weight(
+                                iv, m_params.num_points_v,
+                                m_geom.is_v_periodic());
+                        inner_integral[iintegral] +=
+                            weight * m_dv * integrand_with_area_element;
+                    }
                 }
                 for (int iintegral = 0; iintegral < num_integrals; ++iintegral)
                 {
-                    auto integrand = m_integrands[iintegral];
-                    double integrand_with_area_element =
-                        integrand(data_here, surface_param_value, u, v) *
-                        m_geom.area_element(surface_param_value, u, v);
-                    double weight = m_integration_methods[iintegral][1].weight(
-                        iv, m_params.num_points_v, m_geom.is_v_periodic());
-                    inner_integral[iintegral] +=
-                        weight * m_dv * integrand_with_area_element;
+                    double weight = m_integration_methods[iintegral][0].weight(
+                        iu, m_params.num_points_u, m_geom.is_u_periodic());
+                    (m_integrals[iintegral].get())[isurface] +=
+                        weight * m_du * inner_integral[iintegral];
                 }
-            }
-            for (int iintegral = 0; iintegral < num_integrals; ++iintegral)
-            {
-                double weight = m_integration_methods[iintegral][0].weight(
-                    iu, m_params.num_points_u, m_geom.is_u_periodic());
-                (m_integrals[iintegral].get())[isurface] +=
-                    weight * m_du * inner_integral[iintegral];
             }
         }
     }
@@ -284,62 +300,67 @@ void SurfaceExtraction<SurfaceGeometry>::write_extraction(
     std::string a_file_prefix) const
 {
     CH_assert(m_done_extraction);
-    SmallDataIO extraction_file(a_file_prefix, m_dt, m_time, m_restart_time,
-                                SmallDataIO::NEW, m_first_step);
-
-    for (int isurface = 0; isurface < m_params.num_surfaces; ++isurface)
+    if (procID() == 0)
     {
-        // Write headers
-        std::vector<std::string> header1_strings = {
-            "time = " + std::to_string(m_time) + ",",
-            m_geom.param_name() + " = " +
-                std::to_string(m_params.surface_param_values[isurface])};
-        extraction_file.write_header_line(header1_strings, "");
-        std::vector<std::string> components(m_vars.size());
-        for (int ivar = 0; ivar < m_vars.size(); ++ivar)
-        {
-            if (std::get<2>(m_vars[ivar]) != Derivative::LOCAL)
-            {
-                components[ivar] =
-                    Derivative::name(std::get<2>(m_vars[ivar])) + "_";
-            }
-            else
-            {
-                components[ivar] = "";
-            }
-            if (std::get<1>(m_vars[ivar]) == VariableType::evolution)
-            {
-                components[ivar] +=
-                    UserVariables::variable_names[std::get<0>(m_vars[ivar])];
-            }
-            else
-            {
-                components[ivar] +=
-                    DiagnosticVariables::variable_names[std::get<0>(
-                        m_vars[ivar])];
-            }
-        }
-        std::vector<std::string> coords = {m_geom.u_name(), m_geom.v_name()};
-        extraction_file.write_header_line(components, coords);
+        SmallDataIO extraction_file(a_file_prefix, m_dt, m_time, m_restart_time,
+                                    SmallDataIO::NEW, m_first_step);
 
-        // Now the data
-        for (int iu = 0; iu < m_params.num_points_u; ++iu)
+        for (int isurface = 0; isurface < m_params.num_surfaces; ++isurface)
         {
-            double u = m_geom.u(iu, m_params.num_points_u);
-            for (int iv = 0; iv < m_params.num_points_v; ++iv)
+            // Write headers
+            std::vector<std::string> header1_strings = {
+                "time = " + std::to_string(m_time) + ",",
+                m_geom.param_name() + " = " +
+                    std::to_string(m_params.surface_param_values[isurface])};
+            extraction_file.write_header_line(header1_strings, "");
+            std::vector<std::string> components(m_vars.size());
+            for (int ivar = 0; ivar < m_vars.size(); ++ivar)
             {
-                double v = m_geom.v(iv, m_params.num_points_v);
-                int idx = index(isurface, iu, iv);
-                std::vector<double> data(m_vars.size());
-                for (int ivar = 0; ivar < m_vars.size(); ++ivar)
+                if (std::get<2>(m_vars[ivar]) != Derivative::LOCAL)
                 {
-                    data[ivar] = m_interp_data[ivar][idx];
+                    components[ivar] =
+                        Derivative::name(std::get<2>(m_vars[ivar])) + "_";
                 }
-
-                extraction_file.write_data_line(data, {u, v});
+                else
+                {
+                    components[ivar] = "";
+                }
+                if (std::get<1>(m_vars[ivar]) == VariableType::evolution)
+                {
+                    components[ivar] +=
+                        UserVariables::variable_names[std::get<0>(
+                            m_vars[ivar])];
+                }
+                else
+                {
+                    components[ivar] +=
+                        DiagnosticVariables::variable_names[std::get<0>(
+                            m_vars[ivar])];
+                }
             }
+            std::vector<std::string> coords = {m_geom.u_name(),
+                                               m_geom.v_name()};
+            extraction_file.write_header_line(components, coords);
+
+            // Now the data
+            for (int iu = 0; iu < m_params.num_points_u; ++iu)
+            {
+                double u = m_geom.u(iu, m_params.num_points_u);
+                for (int iv = 0; iv < m_params.num_points_v; ++iv)
+                {
+                    double v = m_geom.v(iv, m_params.num_points_v);
+                    int idx = index(isurface, iu, iv);
+                    std::vector<double> data(m_vars.size());
+                    for (int ivar = 0; ivar < m_vars.size(); ++ivar)
+                    {
+                        data[ivar] = m_interp_data[ivar][idx];
+                    }
+
+                    extraction_file.write_data_line(data, {u, v});
+                }
+            }
+            extraction_file.line_break();
         }
-        extraction_file.line_break();
     }
 }
 
@@ -350,69 +371,73 @@ void SurfaceExtraction<SurfaceGeometry>::write_integrals(
     const std::vector<std::vector<double>> &a_integrals,
     const std::vector<std::string> &a_labels) const
 {
-    const int num_integrals_per_surface = a_integrals.size();
-    // if labels are provided there must be the same number of labels as
-    // there are integrals
-    if (!a_labels.empty())
+    if (procID() == 0)
     {
-        CH_assert(num_integrals_per_surface == a_labels.size());
-    }
-    // each inner vector element of a_integrals must have the same number of
-    // elements as there are surfaces (i.e. one integral per surface)
-    for (auto vect : a_integrals)
-    {
-        CH_assert(vect.size() == m_params.num_surfaces);
-    }
-    // open file for writing
-    SmallDataIO integral_file(a_filename, m_dt, m_time, m_restart_time,
-                              SmallDataIO::APPEND, m_first_step);
+        const int num_integrals_per_surface = a_integrals.size();
+        // if labels are provided there must be the same number of labels as
+        // there are integrals
+        if (!a_labels.empty())
+        {
+            CH_assert(num_integrals_per_surface == a_labels.size());
+        }
+        // each inner vector element of a_integrals must have the same number of
+        // elements as there are surfaces (i.e. one integral per surface)
+        for (auto vect : a_integrals)
+        {
+            CH_assert(vect.size() == m_params.num_surfaces);
+        }
+        // open file for writing
+        SmallDataIO integral_file(a_filename, m_dt, m_time, m_restart_time,
+                                  SmallDataIO::APPEND, m_first_step);
 
-    // remove any duplicate data if this is a restart
-    integral_file.remove_duplicate_time_data();
+        // remove any duplicate data if this is a restart
+        integral_file.remove_duplicate_time_data();
 
-    if (m_first_step)
-    {
-        // make header strings
-        std::vector<std::string> header1_strings(num_integrals_per_surface *
-                                                 m_params.num_surfaces);
-        std::vector<std::string> header2_strings(num_integrals_per_surface *
-                                                 m_params.num_surfaces);
+        if (m_first_step)
+        {
+            // make header strings
+            std::vector<std::string> header1_strings(num_integrals_per_surface *
+                                                     m_params.num_surfaces);
+            std::vector<std::string> header2_strings(num_integrals_per_surface *
+                                                     m_params.num_surfaces);
+            for (int isurface = 0; isurface < m_params.num_surfaces; ++isurface)
+            {
+                for (int iintegral = 0; iintegral < num_integrals_per_surface;
+                     ++iintegral)
+                {
+                    int idx = isurface * num_integrals_per_surface + iintegral;
+                    if (a_labels.empty())
+                        header1_strings[idx] = "";
+                    else
+                        header1_strings[idx] = a_labels[iintegral];
+                    header2_strings[idx] =
+                        std::to_string(m_params.surface_param_values[isurface]);
+                }
+            }
+            std::string pre_header2_string = m_geom.param_name() + " = ";
+
+            // write headers
+            integral_file.write_header_line(header1_strings);
+            integral_file.write_header_line(header2_strings,
+                                            pre_header2_string);
+        }
+
+        // make vector of data for writing
+        std::vector<double> data_for_writing(num_integrals_per_surface *
+                                             m_params.num_surfaces);
         for (int isurface = 0; isurface < m_params.num_surfaces; ++isurface)
         {
             for (int iintegral = 0; iintegral < num_integrals_per_surface;
                  ++iintegral)
             {
                 int idx = isurface * num_integrals_per_surface + iintegral;
-                if (a_labels.empty())
-                    header1_strings[idx] = "";
-                else
-                    header1_strings[idx] = a_labels[iintegral];
-                header2_strings[idx] =
-                    std::to_string(m_params.surface_param_values[isurface]);
+                data_for_writing[idx] = a_integrals[iintegral][isurface];
             }
         }
-        std::string pre_header2_string = m_geom.param_name() + " = ";
 
-        // write headers
-        integral_file.write_header_line(header1_strings);
-        integral_file.write_header_line(header2_strings, pre_header2_string);
+        // write data
+        integral_file.write_time_data_line(data_for_writing);
     }
-
-    // make vector of data for writing
-    std::vector<double> data_for_writing(num_integrals_per_surface *
-                                         m_params.num_surfaces);
-    for (int isurface = 0; isurface < m_params.num_surfaces; ++isurface)
-    {
-        for (int iintegral = 0; iintegral < num_integrals_per_surface;
-             ++iintegral)
-        {
-            int idx = isurface * num_integrals_per_surface + iintegral;
-            data_for_writing[idx] = a_integrals[iintegral][isurface];
-        }
-    }
-
-    // write data
-    integral_file.write_time_data_line(data_for_writing);
 }
 
 //! convenience caller for write_integrals in the case of just one integral per

--- a/Tests/SphericalExtractionTest/SphericalExtractionTest.cpp
+++ b/Tests/SphericalExtractionTest/SphericalExtractionTest.cpp
@@ -131,52 +131,59 @@ int runSphericalExtractionTest(int argc, char *argv[])
     int status = 0;
     pout() << std::setprecision(10);
 
-    for (int iradius = 0;
-         iradius < sim_params.extraction_params_lo.num_extraction_radii;
-         ++iradius)
+    if (procID() == 0)
     {
-        double r = sim_params.extraction_params_lo.extraction_radii[iradius];
-        double integral_re_lo_trapezium =
-            (integral_lo_trapezium.first)[iradius];
-        double integral_re_hi_trapezium =
-            (integral_hi_trapezium.first)[iradius];
-        double integral_re_lo_simpson = (integral_lo_simpson.first)[iradius];
-        double integral_re_hi_simpson = (integral_hi_simpson.first)[iradius];
-        double integral_re_lo_boole = (integral_lo_boole.first)[iradius];
-        double integral_re_hi_boole = (integral_hi_boole.first)[iradius];
-        double analytic_integral = 1.0;
+        for (int iradius = 0;
+             iradius < sim_params.extraction_params_lo.num_extraction_radii;
+             ++iradius)
+        {
+            double r =
+                sim_params.extraction_params_lo.extraction_radii[iradius];
+            double integral_re_lo_trapezium =
+                (integral_lo_trapezium.first)[iradius];
+            double integral_re_hi_trapezium =
+                (integral_hi_trapezium.first)[iradius];
+            double integral_re_lo_simpson =
+                (integral_lo_simpson.first)[iradius];
+            double integral_re_hi_simpson =
+                (integral_hi_simpson.first)[iradius];
+            double integral_re_lo_boole = (integral_lo_boole.first)[iradius];
+            double integral_re_hi_boole = (integral_hi_boole.first)[iradius];
+            double analytic_integral = 1.0;
 
-        double convergence_factor_trapezium =
-            std::abs((integral_re_lo_trapezium - analytic_integral) /
-                     (integral_re_hi_trapezium - analytic_integral));
-        double convergence_factor_simpson =
-            std::abs((integral_re_lo_simpson - analytic_integral) /
-                     (integral_re_hi_simpson - analytic_integral));
-        double convergence_factor_boole =
-            std::abs((integral_re_lo_boole - analytic_integral) /
-                     (integral_re_hi_boole - analytic_integral));
+            double convergence_factor_trapezium =
+                std::abs((integral_re_lo_trapezium - analytic_integral) /
+                         (integral_re_hi_trapezium - analytic_integral));
+            double convergence_factor_simpson =
+                std::abs((integral_re_lo_simpson - analytic_integral) /
+                         (integral_re_hi_simpson - analytic_integral));
+            double convergence_factor_boole =
+                std::abs((integral_re_lo_boole - analytic_integral) /
+                         (integral_re_hi_boole - analytic_integral));
 
-        double convergence_order_trapezium =
-            std::log2(convergence_factor_trapezium);
-        double convergence_order_simpson =
-            std::log2(convergence_factor_simpson);
-        double convergence_order_boole = std::log2(convergence_factor_boole);
+            double convergence_order_trapezium =
+                std::log2(convergence_factor_trapezium);
+            double convergence_order_simpson =
+                std::log2(convergence_factor_simpson);
+            double convergence_order_boole =
+                std::log2(convergence_factor_boole);
 
-        // trapezium rule should have second order convergence
-        status |= (convergence_order_trapezium < 1.5);
-        // Simpson's rule should have fourth order convergence
-        status |= (convergence_order_simpson < 3.5);
-        // Boole's rule should have sixth order convergence
-        status |= (convergence_order_boole < 5.5);
+            // trapezium rule should have second order convergence
+            status |= (convergence_order_trapezium < 1.5);
+            // Simpson's rule should have fourth order convergence
+            status |= (convergence_order_simpson < 3.5);
+            // Boole's rule should have sixth order convergence
+            status |= (convergence_order_boole < 5.5);
 
-        pout() << "At r = " << r << ":\n";
-        pout() << "convergence_order_trapezium = "
-               << convergence_order_trapezium << "\n";
-        pout() << "convergence_order_simpson = " << convergence_order_simpson
-               << "\n";
-        pout() << "convergence_order_boole = " << convergence_order_boole
-               << "\n"
-               << endl;
+            pout() << "At r = " << r << ":\n";
+            pout() << "convergence_order_trapezium = "
+                   << convergence_order_trapezium << "\n";
+            pout() << "convergence_order_simpson = "
+                   << convergence_order_simpson << "\n";
+            pout() << "convergence_order_boole = " << convergence_order_boole
+                   << "\n"
+                   << endl;
+        }
     }
 
     return status;

--- a/Tests/SphericalExtractionTest/SphericalExtractionTest.cpp
+++ b/Tests/SphericalExtractionTest/SphericalExtractionTest.cpp
@@ -99,30 +99,38 @@ int runSphericalExtractionTest(int argc, char *argv[])
 
     // add the spherical harmonic mode integrands for each resolution and for
     // the trapezium rule, Simpson's rule and Boole's rule
+    // Always use trapezium rule in phi as this is periodic
+    bool broadcast_integral = true;
     std::pair<std::vector<double>, std::vector<double>> integral_lo_trapezium,
         integral_hi_trapezium;
     spherical_extraction_lo.add_mode_integrand(
         sim_params.es, sim_params.el, sim_params.em, extracted_harmonic,
-        integral_lo_trapezium, IntegrationMethod::trapezium);
+        integral_lo_trapezium, IntegrationMethod::trapezium,
+        IntegrationMethod::trapezium, broadcast_integral);
     spherical_extraction_hi.add_mode_integrand(
         sim_params.es, sim_params.el, sim_params.em, extracted_harmonic,
-        integral_hi_trapezium, IntegrationMethod::trapezium);
+        integral_hi_trapezium, IntegrationMethod::trapezium,
+        IntegrationMethod::trapezium, broadcast_integral);
     std::pair<std::vector<double>, std::vector<double>> integral_lo_simpson,
         integral_hi_simpson;
     spherical_extraction_lo.add_mode_integrand(
         sim_params.es, sim_params.el, sim_params.em, extracted_harmonic,
-        integral_lo_simpson, IntegrationMethod::simpson);
+        integral_lo_simpson, IntegrationMethod::simpson,
+        IntegrationMethod::trapezium, broadcast_integral);
     spherical_extraction_hi.add_mode_integrand(
         sim_params.es, sim_params.el, sim_params.em, extracted_harmonic,
-        integral_hi_simpson, IntegrationMethod::simpson);
+        integral_hi_simpson, IntegrationMethod::simpson,
+        IntegrationMethod::trapezium, broadcast_integral);
     std::pair<std::vector<double>, std::vector<double>> integral_lo_boole,
         integral_hi_boole;
     spherical_extraction_lo.add_mode_integrand(
         sim_params.es, sim_params.el, sim_params.em, extracted_harmonic,
-        integral_lo_boole, IntegrationMethod::boole);
+        integral_lo_boole, IntegrationMethod::boole,
+        IntegrationMethod::trapezium, broadcast_integral);
     spherical_extraction_hi.add_mode_integrand(
         sim_params.es, sim_params.el, sim_params.em, extracted_harmonic,
-        integral_hi_boole, IntegrationMethod::boole);
+        integral_hi_boole, IntegrationMethod::boole,
+        IntegrationMethod::trapezium, broadcast_integral);
 
     // do the surface integration
     spherical_extraction_lo.integrate();
@@ -131,59 +139,52 @@ int runSphericalExtractionTest(int argc, char *argv[])
     int status = 0;
     pout() << std::setprecision(10);
 
-    if (procID() == 0)
+    for (int iradius = 0;
+         iradius < sim_params.extraction_params_lo.num_extraction_radii;
+         ++iradius)
     {
-        for (int iradius = 0;
-             iradius < sim_params.extraction_params_lo.num_extraction_radii;
-             ++iradius)
-        {
-            double r =
-                sim_params.extraction_params_lo.extraction_radii[iradius];
-            double integral_re_lo_trapezium =
-                (integral_lo_trapezium.first)[iradius];
-            double integral_re_hi_trapezium =
-                (integral_hi_trapezium.first)[iradius];
-            double integral_re_lo_simpson =
-                (integral_lo_simpson.first)[iradius];
-            double integral_re_hi_simpson =
-                (integral_hi_simpson.first)[iradius];
-            double integral_re_lo_boole = (integral_lo_boole.first)[iradius];
-            double integral_re_hi_boole = (integral_hi_boole.first)[iradius];
-            double analytic_integral = 1.0;
+        double r = sim_params.extraction_params_lo.extraction_radii[iradius];
+        double integral_re_lo_trapezium =
+            (integral_lo_trapezium.first)[iradius];
+        double integral_re_hi_trapezium =
+            (integral_hi_trapezium.first)[iradius];
+        double integral_re_lo_simpson = (integral_lo_simpson.first)[iradius];
+        double integral_re_hi_simpson = (integral_hi_simpson.first)[iradius];
+        double integral_re_lo_boole = (integral_lo_boole.first)[iradius];
+        double integral_re_hi_boole = (integral_hi_boole.first)[iradius];
+        double analytic_integral = 1.0;
 
-            double convergence_factor_trapezium =
-                std::abs((integral_re_lo_trapezium - analytic_integral) /
-                         (integral_re_hi_trapezium - analytic_integral));
-            double convergence_factor_simpson =
-                std::abs((integral_re_lo_simpson - analytic_integral) /
-                         (integral_re_hi_simpson - analytic_integral));
-            double convergence_factor_boole =
-                std::abs((integral_re_lo_boole - analytic_integral) /
-                         (integral_re_hi_boole - analytic_integral));
+        double convergence_factor_trapezium =
+            std::abs((integral_re_lo_trapezium - analytic_integral) /
+                     (integral_re_hi_trapezium - analytic_integral));
+        double convergence_factor_simpson =
+            std::abs((integral_re_lo_simpson - analytic_integral) /
+                     (integral_re_hi_simpson - analytic_integral));
+        double convergence_factor_boole =
+            std::abs((integral_re_lo_boole - analytic_integral) /
+                     (integral_re_hi_boole - analytic_integral));
 
-            double convergence_order_trapezium =
-                std::log2(convergence_factor_trapezium);
-            double convergence_order_simpson =
-                std::log2(convergence_factor_simpson);
-            double convergence_order_boole =
-                std::log2(convergence_factor_boole);
+        double convergence_order_trapezium =
+            std::log2(convergence_factor_trapezium);
+        double convergence_order_simpson =
+            std::log2(convergence_factor_simpson);
+        double convergence_order_boole = std::log2(convergence_factor_boole);
 
-            // trapezium rule should have second order convergence
-            status |= (convergence_order_trapezium < 1.5);
-            // Simpson's rule should have fourth order convergence
-            status |= (convergence_order_simpson < 3.5);
-            // Boole's rule should have sixth order convergence
-            status |= (convergence_order_boole < 5.5);
+        // trapezium rule should have second order convergence
+        status |= (convergence_order_trapezium < 1.5);
+        // Simpson's rule should have fourth order convergence
+        status |= (convergence_order_simpson < 3.5);
+        // Boole's rule should have sixth order convergence
+        status |= (convergence_order_boole < 5.5);
 
-            pout() << "At r = " << r << ":\n";
-            pout() << "convergence_order_trapezium = "
-                   << convergence_order_trapezium << "\n";
-            pout() << "convergence_order_simpson = "
-                   << convergence_order_simpson << "\n";
-            pout() << "convergence_order_boole = " << convergence_order_boole
-                   << "\n"
-                   << endl;
-        }
+        pout() << "At r = " << r << ":\n";
+        pout() << "convergence_order_trapezium = "
+               << convergence_order_trapezium << "\n";
+        pout() << "convergence_order_simpson = " << convergence_order_simpson
+               << "\n";
+        pout() << "convergence_order_boole = " << convergence_order_boole
+               << "\n"
+               << endl;
     }
 
     return status;


### PR DESCRIPTION
Now only rank 0 queries points for interpolation and does the integration. This significantly reduces the amount of communication the interpolator needs to do. The only potential problem is if a user assumes a calculated integral is available on all ranks (e.g. like in the test before I changed it).

I tested the speed up using the Chombo timers. The relevant spherical extraction parameters are:
`num_extraction_radii = 8`,
`num_points_phi = 32`,
`num_points_theta = 48`,
`num_modes = 45`.
Below is the timer output for rank 0 before and after these changes. Note how `WeylExtraction` goes from being `[34]` and taking 49.51462 s to `[60]` and taking 19.96405 s:
[after.time.table.0](https://github.com/GRChombo/GRChombo/files/5696424/after.time.table.0.txt)
[before.time.table.0](https://github.com/GRChombo/GRChombo/files/5696425/before.time.table.0.txt)


