### PR TITLE
Rewrite GRLevelData::plus with OpenMP and SIMD

### DIFF
--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -937,7 +937,9 @@ void GRAMRLevel::evalRHS(GRLevelData &rhs, GRLevelData &soln,
 void GRAMRLevel::updateODE(GRLevelData &soln, const GRLevelData &rhs, Real dt)
 {
     CH_TIME("GRAMRLevel::updateODE");
-    soln.plus(rhs, dt);
+    // m_grown_grids will include outer boundary ghosts in the case of
+    // nonperiodic BCs but will just be the problem domain otherwise.
+    soln.plus(rhs, dt, m_grown_grids);
 
     specificUpdateODE(soln, rhs, dt);
     fillBdyGhosts(soln);

--- a/Source/GRChomboCore/GRLevelData.cpp
+++ b/Source/GRChomboCore/GRLevelData.cpp
@@ -43,14 +43,79 @@ void GRLevelData::setVal(const double a_val, const Interval a_comps)
     }
 }
 
-// a_src and this must have the same box layout
-void GRLevelData::plus(const GRLevelData &a_src, const double a_scale)
+void GRLevelData::plus(const GRLevelData &a_src, const double a_scale,
+                       const DisjointBoxLayout &a_disjoint_box_layout)
 {
-    DataIterator dit = m_disjointBoxLayout.dataIterator();
+    CH_TIME("GRLevelData::plus");
+    DataIterator dit = a_disjoint_box_layout.dataIterator();
     for (dit.begin(); dit.ok(); ++dit)
     {
         FArrayBox &fab = (*this)[dit];
         const FArrayBox &src_fab = a_src[dit];
-        fab.plus(src_fab, a_scale);
+        Real *fab_data = fab.dataPtr();
+        const Real *const src_fab_data = src_fab.dataPtr();
+
+        const Box &this_box = fab.box();
+        const Box &src_box = src_fab.box();
+        const Box loop_box = a_disjoint_box_layout[dit];
+        const int *this_lo = this_box.loVect();
+        const int *src_lo = src_box.loVect();
+        const int *loop_lo = loop_box.loVect();
+        const int *loop_hi = loop_box.hiVect();
+        const IntVect &this_size = this_box.size();
+        const IntVect &src_size = src_box.size();
+        const int num_comps = fab.nComp();
+
+        CH_assert(num_comps == src_fab.nComp());
+#ifdef _OPENMP
+#pragma omp parallel for default(shared) collapse(CH_SPACEDIM)
+#endif
+        for (int icomp = 0; icomp < num_comps; ++icomp)
+#if CH_SPACEDIM == 3
+            for (int iz = loop_lo[2]; iz <= loop_hi[2]; ++iz)
+#endif
+                for (int iy = loop_lo[1]; iy <= loop_hi[1]; ++iy)
+                {
+#pragma omp simd
+                    for (int ix = loop_lo[0]; ix <= loop_hi[0]; ++ix)
+                    {
+                        const int this_index =
+                            ix - this_lo[0] + (iy - this_lo[1]) * this_size[0] +
+#if CH_SPACEDIM == 3
+                            (iz - this_lo[2]) * this_size[0] * this_size[1] +
+#endif
+                            icomp * this_size[0] * this_size[1]
+#if CH_SPACEDIM == 3
+                                * this_size[2]
+#endif
+                            ;
+                        const int src_index =
+                            ix - src_lo[0] + (iy - src_lo[1]) * src_size[0] +
+#if CH_SPACEDIM == 3
+                            (iz - src_lo[2]) * src_size[0] * src_size[1] +
+#endif
+                            icomp * src_size[0] * src_size[1]
+#if CH_SPACEDIM == 3
+                                * src_size[2]
+#endif
+                            ;
+                        fab_data[this_index] +=
+                            a_scale * src_fab_data[src_index];
+                    }
+                }
     }
 }
+
+// old plus function
+// void GRLevelData::plus(const GRLevelData &a_src, const double a_scale,
+//                        const DisjointBoxLayout &a_disjoint_box_layout)
+// {
+//    CH_TIME("GRLevelData::plus");
+//    DataIterator dit = a_disjoint_box_layout.dataIterator();
+//     for (dit.begin(); dit.ok(); ++dit)
+//     {
+//         FArrayBox &fab = (*this)[dit];
+//         const FArrayBox &src_fab = a_src[dit];
+//         fab.plus(src_fab, a_scale);
+//     }
+// }

--- a/Source/GRChomboCore/GRLevelData.hpp
+++ b/Source/GRChomboCore/GRLevelData.hpp
@@ -20,8 +20,9 @@ class GRLevelData : public LevelData<FArrayBox>
 
     void setVal(const double a_val, const Interval a_comps);
 
-    // a_src and this must have the same box layout
-    void plus(const GRLevelData &a_src, const double a_scale);
+    // loop only goes over a_disjoint_box_layout
+    void plus(const GRLevelData &a_src, const double a_scale,
+              const DisjointBoxLayout &a_disjoint_box_layout);
 };
 
 #endif /* GRLEVELDATA_HPP_ */


### PR DESCRIPTION
Note that the prototype has also changed so that this function now only loops over the `Box`es in the passed `DisjointBoxLayout` rather than the intersection of the two `FArrayBox`es' `Box`es. This saves a little in not looping through the interior ghost cells but in `GRAMRLevel::updateODE`, `m_grown_grids` is passed which includes the outer boundary ghosts in the case of Sommerfeld BCs (and extrapolating/mixed BCs once #140 is merged). As far as I can see this should be the only case where we want to add the RHS to `soln` in the outer boundary ghosts.

It was probably unncessary but I generated an Intel compiler optimisation report to confirm the loop is being vectorized (although I suspect the old loop was probably being autovectorized anyway): [GRLevelData.optrpt](https://github.com/GRChombo/GRChombo/files/5719631/GRLevelData.optrpt.txt). Note that the lines numbers will differ a bit to what is in this PR as this was before I added the `#if CH_SPACEDIM == 3` macros.

I also had a look at the Chombo timer output for one of my own BBH examples over 8 timesteps with a few different numbers of OpenMP threads. Summing over all of the `GRAMRLevel::updateODE`s, the time taken in each case (on rank 0)

**Before changes**
1 thread: 59.09279s
2 threads: 50.31753s
4 threads: 49.14452s
6 threads: 48.26825s

**After changes**
1 thread: 54.51439s
2 threads: 28.94410s
4 threads: 18.28667s
6 threads: 15.18297s

@TaigoFr, I attempted to make this compatible with 2D but since you are more familiar with that than me, would you be able to check this is correct?