### PR TITLE
Add parameter checking

### DIFF
--- a/Examples/BinaryBH/Main_BinaryBH.cpp
+++ b/Examples/BinaryBH/Main_BinaryBH.cpp
@@ -25,6 +25,9 @@ int runGRChombo(int argc, char *argv[])
     GRParmParse pp(argc - 2, argv + 2, NULL, in_file);
     SimulationParameters sim_params(pp);
 
+    if (sim_params.just_check_params)
+        return 0;
+
     BHAMR bh_amr;
     // must be before 'setupAMRObject' to define punctures for tagging criteria
     if (sim_params.track_punctures)

--- a/Examples/BinaryBH/SimulationParameters.hpp
+++ b/Examples/BinaryBH/SimulationParameters.hpp
@@ -20,7 +20,7 @@ class SimulationParameters : public SimulationParametersBase
     SimulationParameters(GRParmParse &pp) : SimulationParametersBase(pp)
     {
         read_params(pp);
-        check_params()
+        check_params();
     }
 
     /// Read parameters from the parameter file
@@ -60,7 +60,7 @@ class SimulationParameters : public SimulationParametersBase
     {
         warn_parameter("massA", bh1_params.mass, bh1_params.mass >= 0,
                        "should be >= 0");
-        warn_parameter("massB", bh2_params.mass, bh2_params.mass >= 0 &&,
+        warn_parameter("massB", bh2_params.mass, bh2_params.mass >= 0,
                        "should be >= 0");
         warn_array_parameter(
             "momentumA", bh1_params.momentum,

--- a/Examples/BinaryBH/SimulationParameters.hpp
+++ b/Examples/BinaryBH/SimulationParameters.hpp
@@ -11,6 +11,7 @@
 #include "SimulationParametersBase.hpp"
 
 // Problem specific includes:
+#include "ArrayTools.hpp"
 #include "BoostedBH.hpp"
 
 class SimulationParameters : public SimulationParametersBase
@@ -18,11 +19,12 @@ class SimulationParameters : public SimulationParametersBase
   public:
     SimulationParameters(GRParmParse &pp) : SimulationParametersBase(pp)
     {
-        readParams(pp);
+        read_params(pp);
+        check_params()
     }
 
     /// Read parameters from the parameter file
-    void readParams(GRParmParse &pp)
+    void read_params(GRParmParse &pp)
     {
         // Initial data
         pp.load("massA", bh1_params.mass);
@@ -52,6 +54,43 @@ class SimulationParameters : public SimulationParametersBase
         pp.load("puncture_tracking_level", puncture_tracking_level, max_level);
         pp.load("calculate_constraint_norms", calculate_constraint_norms,
                 false);
+    }
+
+    void check_params()
+    {
+        warn_parameter("massA", bh1_params.mass, bh1_params.mass >= 0,
+                       "should be >= 0");
+        warn_parameter("massB", bh2_params.mass, bh2_params.mass >= 0 &&,
+                       "should be >= 0");
+        warn_array_parameter(
+            "momentumA", bh1_params.momentum,
+            std::sqrt(ArrayTools::norm2(bh1_params.momentum)) <
+                0.3 * bh1_params.mass,
+            "approximation used for boosted BH only valid for small boosts");
+        warn_array_parameter(
+            "momentumB", bh2_params.momentum,
+            std::sqrt(ArrayTools::norm2(bh2_params.momentum)) <
+                0.3 * bh1_params.mass,
+            "approximation used for boosted BH only valid for small boosts");
+        FOR1(idir)
+        {
+            std::string nameA = "centerA[" + std::to_string(idir) + "]";
+            std::string nameB = "centerB[" + std::to_string(idir) + "]";
+            double center_A_dir = bh1_params.center[idir];
+            double center_B_dir = bh2_params.center[idir];
+            warn_parameter(nameA, center_A_dir,
+                           (center_A_dir >= 0.0) &&
+                               (center_A_dir <= (ivN[idir] + 1) * coarsest_dx),
+                           "should be within the computational domain");
+            warn_parameter(nameB, center_B_dir,
+                           (center_B_dir >= 0.0) &&
+                               (center_B_dir <= (ivN[idir] + 1) * coarsest_dx),
+                           "should be within the computational domain");
+        }
+        check_parameter("puncture_tracking_level", puncture_tracking_level,
+                        (puncture_tracking_level >= 0) &&
+                            (puncture_tracking_level <= max_level),
+                        "must be between 0 and max_level (inclusive)");
     }
 
     // Initial data

--- a/Examples/BinaryBH/params.txt
+++ b/Examples/BinaryBH/params.txt
@@ -34,11 +34,11 @@ massB = 0.48847892320123
 offsetB = 0.0 -6.10679 0.0
 momentumB =  0.0841746  0.000510846 0.0
 
-# regridding control, specify frequency on each level
-# so need max_level + 1 entries for interval
+# regridding control, specify threshold (same on each level)
 regrid_threshold = 0.05
 max_level = 9
-regrid_interval = 0 0 0 64 64 64 64 64 64 0
+# need max_level entries for regrid interval
+regrid_interval = 0 0 0 64 64 64 64 64 64
 
 # Max and min box sizes
 max_grid_size = 16

--- a/Examples/KerrBH/Main_KerrBH.cpp
+++ b/Examples/KerrBH/Main_KerrBH.cpp
@@ -23,6 +23,9 @@ int runGRChombo(int argc, char *argv[])
     GRParmParse pp(argc - 2, argv + 2, NULL, in_file);
     SimulationParameters sim_params(pp);
 
+    if (sim_params.just_check_params)
+        return 0;
+
     // The line below selects the problem that is simulated
     // (To simulate a different problem, define a new child of AMRLevel
     // and an associated LevelFactory)

--- a/Examples/KerrBH/SimulationParameters.hpp
+++ b/Examples/KerrBH/SimulationParameters.hpp
@@ -20,7 +20,7 @@ class SimulationParameters : public SimulationParametersBase
     SimulationParameters(GRParmParse &pp) : SimulationParametersBase(pp)
     {
         read_params(pp);
-        check_params;
+        check_params();
     }
 
     /// Read parameters from the parameter file

--- a/Examples/KerrBH/SimulationParameters.hpp
+++ b/Examples/KerrBH/SimulationParameters.hpp
@@ -19,16 +19,36 @@ class SimulationParameters : public SimulationParametersBase
   public:
     SimulationParameters(GRParmParse &pp) : SimulationParametersBase(pp)
     {
-        readParams(pp);
+        read_params(pp);
+        check_params;
     }
 
     /// Read parameters from the parameter file
-    void readParams(GRParmParse &pp)
+    void read_params(GRParmParse &pp)
     {
         // Initial Kerr data
         pp.load("kerr_mass", kerr_params.mass);
         pp.load("kerr_spin", kerr_params.spin);
         pp.load("kerr_center", kerr_params.center, center);
+    }
+
+    void check_params()
+    {
+        warn_parameter("kerr_mass", kerr_params.mass, kerr_params.mass >= 0.0,
+                       "should be >= 0.0");
+        check_parameter("kerr_spin", kerr_params.spin,
+                        std::abs(kerr_params.spin) <= kerr_params.mass,
+                        "must satisfy |a| <= M = " +
+                            std::to_string(kerr_params.mass));
+        FOR1(idir)
+        {
+            std::string name = "kerr_center[" + std::to_string(idir) + "]";
+            warn_parameter(
+                name, kerr_params.center[idir],
+                (kerr_params.center[idir] >= 0) &&
+                    (kerr_params.center[idir] <= (ivN[idir] + 1) * coarsest_dx),
+                "should be within the computational domain");
+        }
     }
 
     KerrBH::params_t kerr_params;

--- a/Examples/KerrBH/params.txt
+++ b/Examples/KerrBH/params.txt
@@ -29,11 +29,11 @@ kerr_spin = 0.5
 max_level = 6 # There are (max_level+1) grids, so min is zero
 
 # Frequency of regridding at each level and thresholds on the tagging
-# Need one for each level, ie max_level+1 items
+# Need one for each level except the top one, ie max_level items
 # Generally you do not need to regrid frequently on every level
-# Level Regridding:   0   1   2   3   4   5   6
-regrid_interval   =  50  25   5   5   5   5   5
-regrid_thresholds = 0.3 0.3 0.3 0.3 0.3 0.3 0.3
+# Level Regridding:   0   1   2   3   4   5
+regrid_interval   =  50  25   5   5   5   5
+regrid_thresholds = 0.3 0.3 0.3 0.3 0.3 0.3
 
 # Max box sizes
 max_grid_size = 16

--- a/Examples/ScalarField/Main_ScalarField.cpp
+++ b/Examples/ScalarField/Main_ScalarField.cpp
@@ -23,6 +23,9 @@ int runGRChombo(int argc, char *argv[])
     GRParmParse pp(argc - 2, argv + 2, NULL, in_file);
     SimulationParameters sim_params(pp);
 
+    if (sim_params.just_check_params)
+        return 0;
+
     // The line below selects the problem that is simulated
     // (To simulate a different problem, define a new child of AMRLevel
     // and an associated LevelFactory)

--- a/Examples/ScalarField/SimulationParameters.hpp
+++ b/Examples/ScalarField/SimulationParameters.hpp
@@ -23,6 +23,7 @@ class SimulationParameters : public SimulationParametersBase
     {
         // read the problem specific params
         read_params(pp);
+        check_params();
     }
 
     void read_params(GRParmParse &pp)
@@ -30,10 +31,11 @@ class SimulationParameters : public SimulationParametersBase
         // Initial scalar field data
         initial_params.center =
             center; // already read in SimulationParametersBase
-        pp.load("G_Newton", G_Newton, 1.0);
-        pp.load("scalar_amplitude", initial_params.amplitude);
-        pp.load("scalar_width", initial_params.width);
-        pp.load("scalar_mass", potential_params.scalar_mass);
+        pp.load("G_Newton", G_Newton,
+                0.0); // for now the example neglects backreaction
+        pp.load("scalar_amplitude", initial_params.amplitude, 0.1);
+        pp.load("scalar_width", initial_params.width, 1.0);
+        pp.load("scalar_mass", potential_params.scalar_mass, 0.1);
 
         // Initial Kerr data
         pp.load("kerr_mass", kerr_params.mass, 1.0);
@@ -43,6 +45,14 @@ class SimulationParameters : public SimulationParametersBase
 
     void check_params()
     {
+        warn_parameter("scalar_mass", potential_params.scalar_mass,
+                       potential_params.scalar_mass <
+                           0.2 / coarsest_dx / dt_multiplier,
+                       "oscillations of scalar field do not appear to be "
+                       "resolved on coarsest level");
+        warn_parameter("scalar_width", initial_params.width,
+                       initial_params.width < 0.5 * L,
+                       "is greater than half the domain size");
         warn_parameter("kerr_mass", kerr_params.mass, kerr_params.mass >= 0.0,
                        "should be >= 0.0");
         check_parameter("kerr_spin", kerr_params.spin,

--- a/Examples/ScalarField/SimulationParameters.hpp
+++ b/Examples/ScalarField/SimulationParameters.hpp
@@ -22,10 +22,10 @@ class SimulationParameters : public SimulationParametersBase
     SimulationParameters(GRParmParse &pp) : SimulationParametersBase(pp)
     {
         // read the problem specific params
-        readParams(pp);
+        read_params(pp);
     }
 
-    void readParams(GRParmParse &pp)
+    void read_params(GRParmParse &pp)
     {
         // Initial scalar field data
         initial_params.center =
@@ -39,6 +39,25 @@ class SimulationParameters : public SimulationParametersBase
         pp.load("kerr_mass", kerr_params.mass, 1.0);
         pp.load("kerr_spin", kerr_params.spin, 0.0);
         pp.load("kerr_center", kerr_params.center, center);
+    }
+
+    void check_params()
+    {
+        warn_parameter("kerr_mass", kerr_params.mass, kerr_params.mass >= 0.0,
+                       "should be >= 0.0");
+        check_parameter("kerr_spin", kerr_params.spin,
+                        std::abs(kerr_params.spin) <= kerr_params.mass,
+                        "must satisfy |a| <= M = " +
+                            std::to_string(kerr_params.mass));
+        FOR1(idir)
+        {
+            std::string name = "kerr_center[" + std::to_string(idir) + "]";
+            warn_parameter(
+                name, kerr_params.center[idir],
+                (kerr_params.center[idir] >= 0) &&
+                    (kerr_params.center[idir] <= (ivN[idir] + 1) * coarsest_dx),
+                "should be within the computational domain");
+        }
     }
 
     // Initial data for matter and potential and BH

--- a/Examples/ScalarField/params.txt
+++ b/Examples/ScalarField/params.txt
@@ -22,9 +22,9 @@ tag_buffer_size = 0
 # Maximum number of times you can regrid above coarsest level
 max_level = 6 # There are (max_level+1) grids, so min is zero
 # Frequency of regridding at each level
-# Need one for each level, ie max_level+1 items
-# in this example turn off regridding
-regrid_interval = 0 0 0 0 0 0 0
+# Need one for each level except the top one, ie max_level items
+# in this example turn off regridding on all levels
+regrid_interval = 0 0 0 0 0 0
 # Max and min box size - for load balancing
 max_box_size = 16
 min_box_size = 16

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -219,6 +219,21 @@ class ChomboParameters
         dx.fill(coarsest_dx);
         origin.fill(coarsest_dx / 2.0);
 
+        // These aren't parameters but used in parameter checks
+        FOR1(idir)
+        {
+            reflective_domain_lo[idir] = ((boundary_params.lo_boundary[idir] ==
+                                           BoundaryConditions::REFLECTIVE_BC)
+                                              ? -1.0
+                                              : 0.0) *
+                                         (ivN[idir] + 1) * coarsest_dx;
+            reflective_domain_hi[idir] = ((boundary_params.hi_boundary[idir] ==
+                                           BoundaryConditions::REFLECTIVE_BC)
+                                              ? 2.0
+                                              : 1.0) *
+                                         (ivN[idir] + 1) * coarsest_dx;
+        }
+
         // Grid center
         // now that L is surely set, get center
 #if CH_SPACEDIM == 3
@@ -360,8 +375,13 @@ class ChomboParameters
     // GRAMR (or child) object
     bool just_check_params = false;
 
-    // use this error function instead of MayDay::error as this will only print
-    // from rank 0
+  protected:
+    // the low and high corners of the domain taking into account reflective BCs
+    // only used in parameter checks hence protected
+    std::array<double, CH_SPACEDIM> reflective_domain_lo, reflective_domain_hi;
+
+    // use this error function instead of MayDay::error as this will only
+    // print from rank 0
     void error(const std::string &a_error_message)
     {
         if (procID() == 0)

--- a/Source/GRChomboCore/SimulationParametersBase.hpp
+++ b/Source/GRChomboCore/SimulationParametersBase.hpp
@@ -196,21 +196,6 @@ class SimulationParametersBase : public ChomboParameters
                        abs(ccz4_params.lapse_coeff - 2.0) <
                            std::numeric_limits<double>::epsilon(),
                        "set to 2.0 for 1+log slicing");
-        std::array<double, CH_SPACEDIM> reflective_box_lo, reflective_box_hi;
-
-        FOR1(idir)
-        {
-            reflective_box_lo[idir] = ((boundary_params.lo_boundary[idir] ==
-                                        BoundaryConditions::REFLECTIVE_BC)
-                                           ? -1.0
-                                           : 0.0) *
-                                      (ivN[idir] + 1) * coarsest_dx;
-            reflective_box_hi[idir] = ((boundary_params.hi_boundary[idir] ==
-                                        BoundaryConditions::REFLECTIVE_BC)
-                                           ? 2.0
-                                           : 1.0) *
-                                      (ivN[idir] + 1) * coarsest_dx;
-        }
 
         // Now extraction parameters
         FOR1(idir)
@@ -219,8 +204,8 @@ class SimulationParametersBase : public ChomboParameters
                 "extraction_center[" + std::to_string(idir) + "]";
             double center_in_dir = extraction_params.center[idir];
             check_parameter(center_name, center_in_dir,
-                            (center_in_dir >= reflective_box_lo[idir]) &&
-                                (center_in_dir <= reflective_box_hi[idir]),
+                            (center_in_dir >= reflective_domain_lo[idir]) &&
+                                (center_in_dir <= reflective_domain_hi[idir]),
                             "must be in the computational domain after "
                             "applying reflective symmetry");
             for (int iradius = 0;
@@ -234,8 +219,8 @@ class SimulationParametersBase : public ChomboParameters
                                     "must be >= 0.0");
                 check_parameter(
                     radius_name, radius,
-                    (center_in_dir - radius >= reflective_box_lo[idir]) &&
-                        (center_in_dir + radius <= reflective_box_hi[idir]),
+                    (center_in_dir - radius >= reflective_domain_lo[idir]) &&
+                        (center_in_dir + radius <= reflective_domain_hi[idir]),
                     "extraction sphere must lie within the computational "
                     "domain after applying reflective symmetry");
             }

--- a/Source/GRChomboCore/SimulationParametersBase.hpp
+++ b/Source/GRChomboCore/SimulationParametersBase.hpp
@@ -121,10 +121,15 @@ class SimulationParametersBase : public ChomboParameters
 
     void check_params()
     {
-        warn_parameter(
-            "sigma", sigma, (sigma >= 0.0) && (sigma <= 2.0 / dt_multiplier),
-            "should be >= 0.0 and <= 2 / dt_multiplier for stability "
-            "(see Alcubierre p344)");
+        check_parameter("dt_multiplier", dt_multiplier, dt_multiplier < 1.0,
+                        "must be < 1.0 for stability");
+        warn_parameter("dt_multiplier", dt_multiplier, dt_multiplier <= 0.5,
+                       "is unlikely to be stable for > 0.5");
+
+        check_parameter("sigma", sigma,
+                        (sigma >= 0.0) && (sigma <= 2.0 / dt_multiplier),
+                        "must be >= 0.0 and <= 2 / dt_multiplier for stability "
+                        "(see Alcubierre p344)");
         warn_parameter("nan_check", nan_check, nan_check,
                        "should not normally be disabled");
         // not sure these are necessary hence commented out
@@ -144,21 +149,24 @@ class SimulationParametersBase : public ChomboParameters
             warn_parameter("kappa2", ccz4_params.kappa2,
                            ccz4_params.kappa2 > -1.0,
                            "should be greater than -1.0 to damp constraints "
-                           "(see arXiv:1106.2254).");
+                           "(see arXiv:1106.2254)");
         }
         else if (formulation == CCZ4::USE_BSSN)
         {
             // maybe we should just set these to zero and print a warning
             // in the BSSN case
-            check_parameter("kappa1", ccz4_params.kappa1,
-                            ccz4_params.kappa1 == 0.0,
-                            "must equal zero for BSSN.");
-            check_parameter("kappa2", ccz4_params.kappa2,
-                            ccz4_params.kappa2 == 0.0,
-                            "must equal zero for BSSN.");
-            check_parameter("kappa3", ccz4_params.kappa3,
-                            ccz4_params.kappa3 == 0.0,
-                            "must equal zero for BSSN.");
+            warn_parameter("kappa1", ccz4_params.kappa1,
+                           ccz4_params.kappa1 == 0.0,
+                           "setting to 0.0 as required for BSSN");
+            warn_parameter("kappa2", ccz4_params.kappa2,
+                           ccz4_params.kappa2 == 0.0,
+                           "setting to 0.0 as required for BSSN");
+            warn_parameter("kappa3", ccz4_params.kappa3,
+                           ccz4_params.kappa3 == 0.0,
+                           "setting to 0.0 as required for BSSN");
+            ccz4_params.kappa1 = 0.0;
+            ccz4_params.kappa2 = 0.0;
+            ccz4_params.kappa3 = 0.0;
         }
 
         // only warn for gauge parameters as there are legitimate cases you may

--- a/Source/InitialConditions/BlackHoles/KerrBH.hpp
+++ b/Source/InitialConditions/BlackHoles/KerrBH.hpp
@@ -29,7 +29,7 @@ class KerrBH
     {
         double mass;                            //!<< The mass of the Kerr BH
         std::array<double, CH_SPACEDIM> center; //!< The center of the Kerr BH
-        double spin; //!< The spin param a = J/M, so 0 < a < 1
+        double spin; //!< The spin param a = J/M, so 0 <= |a| <= M
     };
 
   protected:
@@ -41,10 +41,9 @@ class KerrBH
 
     {
         // check this spin param is sensible
-        if ((m_params.spin > 1.0) || (m_params.spin < 0.0))
+        if (std::abs(m_params.spin) > m_params.mass)
         {
-            MayDay::Error(
-                "The spin parameter must be in the range 0 < a < 1.0");
+            MayDay::Error("The spin parameter must satisfy |a| <= M");
         }
     }
 

--- a/Source/utils/ArrayTools.hpp
+++ b/Source/utils/ArrayTools.hpp
@@ -8,6 +8,7 @@
 
 #include <algorithm>
 #include <array>
+#include <string>
 
 /// A place for tools that operate on std::arrays
 namespace ArrayTools
@@ -22,6 +23,31 @@ std::array<T, N + M> concatenate(const std::array<T, N> &first,
     std::array<T, N + M> out;
     std::copy(first.cbegin(), first.cend(), out.begin());
     std::copy(second.cbegin(), second.cend(), out.begin() + N);
+    return out;
+}
+
+template <typename T, size_t N,
+          std::enable_if_t<std::is_arithmetic<T>::value, bool> = true>
+T norm2(const std::array<T, N> &a_array)
+{
+    T out = 0;
+    for (auto &elem : a_array)
+    {
+        out += elem * elem;
+    }
+    return out;
+}
+
+template <typename T, size_t N,
+          std::enable_if_t<std::is_arithmetic<T>::value, bool> = true>
+std::string to_string(const std::array<T, N> a_array)
+{
+    std::string out;
+    for (int i = 0; i < N - 1; ++i)
+    {
+        out += std::to_string(a_array[i]) + " ";
+    }
+    out += std::to_string(a_array[N - 1]);
     return out;
 }
 } // namespace ArrayTools


### PR DESCRIPTION
This resolves #100 by implementing checking of parameters after they are loaded and aborts the whole code if a check fails. Additionally, the parameter loading and checking can be done without running the whole simulation by passing the `-check_params` flag e.g.
```mpiexec /path/to/exec.ex /path/to/params.txt -check_params```
for the provided examples (user examples will need to be updated acoordingly). Note that a warning function has also been added which will not abort the code but just print a message to stderr under the provided conditions. The checking of parameters has also been added to the BinaryBH and KerrBH examples (not the ScalarField one as this is changing in #140).

Note that this also fixes #136.

There is some amount of arbitrariness whether to warn or enforce by checking a condition on parameters that won't necessarily make the code crash immediately but will either give nonsensical results or will make the simulation blow up pretty quickly (e.g. setting `sigma` too large) but I guess we can decide here.