### PR TITLE
Add more flexibility when filling ghosts

### DIFF
--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -129,7 +129,12 @@ void BinaryBHLevel::specificPostTimeStep()
             {
                 CH_TIME("WeylExtraction");
                 // Now refresh the interpolator and do the interpolation
-                m_gr_amr.m_interpolator->refresh();
+                // fill ghosts manually to minimise communication
+                bool fill_ghosts = false;
+                m_gr_amr.m_interpolator->refresh(fill_ghosts);
+                m_gr_amr.fill_multilevel_ghosts(
+                    VariableType::diagnostic, Interval(c_Weyl4_Re, c_Weyl4_Im),
+                    min_level);
                 WeylExtraction my_extraction(m_p.extraction_params, m_dt,
                                              m_time, first_step,
                                              m_restart_time);

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -72,6 +72,12 @@ void BinaryBHLevel::specificUpdateODE(GRLevelData &a_soln,
     BoxLoops::loop(TraceARemoval(), a_soln, a_soln, INCLUDE_GHOST_CELLS);
 }
 
+void BinaryBHLevel::preTagCells()
+{
+    // We only use chi in the tagging criterion so only fill the ghosts for chi
+    fillAllGhosts(VariableType::evolution, Interval(c_chi, c_chi));
+}
+
 // specify the cells to tag
 void BinaryBHLevel::computeTaggingCriterion(FArrayBox &tagging_criterion,
                                             const FArrayBox &current_state)

--- a/Examples/BinaryBH/BinaryBHLevel.hpp
+++ b/Examples/BinaryBH/BinaryBHLevel.hpp
@@ -34,6 +34,9 @@ class BinaryBHLevel : public GRAMRLevel
                                    const GRLevelData &a_rhs,
                                    Real a_dt) override;
 
+    /// Things to do before tagging cells (i.e. filling ghosts)
+    virtual void preTagCells() override;
+
     /// Identify and tag the cells that need higher resolution
     virtual void
     computeTaggingCriterion(FArrayBox &tagging_criterion,

--- a/Examples/BinaryBH/Main_BinaryBH.cpp
+++ b/Examples/BinaryBH/Main_BinaryBH.cpp
@@ -40,9 +40,13 @@ int runGRChombo(int argc, char *argv[])
     // must be before 'setupAMRObject' to define punctures for tagging criteria
     if (sim_params.track_punctures)
     {
+        // the tagging criterion used in this example means that the punctures
+        // should be on the max level but let's fill ghosts on the level below
+        // too just in case
+        int puncture_tracker_min_level = sim_params.max_level - 1;
         bh_amr.m_puncture_tracker.initial_setup(
             {sim_params.bh1_params.center, sim_params.bh2_params.center},
-            sim_params.checkpoint_prefix);
+            sim_params.checkpoint_prefix, puncture_tracker_min_level);
     }
 
     // The line below selects the problem that is simulated

--- a/Examples/KerrBH/KerrBHLevel.cpp
+++ b/Examples/KerrBH/KerrBHLevel.cpp
@@ -75,6 +75,12 @@ void KerrBHLevel::specificUpdateODE(GRLevelData &a_soln,
     BoxLoops::loop(TraceARemoval(), a_soln, a_soln, INCLUDE_GHOST_CELLS);
 }
 
+void KerrBHLevel::preTagCells()
+{
+    // We only use chi in the tagging criterion so only fill the ghosts for chi
+    fillAllGhosts(VariableType::evolution, Interval(c_chi, c_chi));
+}
+
 void KerrBHLevel::computeTaggingCriterion(FArrayBox &tagging_criterion,
                                           const FArrayBox &current_state)
 {

--- a/Examples/KerrBH/KerrBHLevel.hpp
+++ b/Examples/KerrBH/KerrBHLevel.hpp
@@ -34,6 +34,9 @@ class KerrBHLevel : public GRAMRLevel
                                    const GRLevelData &a_rhs,
                                    Real a_dt) override;
 
+    /// Things to do before tagging cells (i.e. filling ghosts)
+    virtual void preTagCells() override;
+
     virtual void
     computeTaggingCriterion(FArrayBox &tagging_criterion,
                             const FArrayBox &current_state) override;

--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -101,6 +101,12 @@ void ScalarFieldLevel::specificUpdateODE(GRLevelData &a_soln,
     BoxLoops::loop(TraceARemoval(), a_soln, a_soln, INCLUDE_GHOST_CELLS);
 }
 
+void ScalarFieldLevel::preTagCells()
+{
+    // we don't need any ghosts filled for the fixed grids tagging criterion
+    // used here so don't fill any
+}
+
 void ScalarFieldLevel::computeTaggingCriterion(FArrayBox &tagging_criterion,
                                                const FArrayBox &current_state)
 {

--- a/Examples/ScalarField/ScalarFieldLevel.hpp
+++ b/Examples/ScalarField/ScalarFieldLevel.hpp
@@ -47,6 +47,9 @@ class ScalarFieldLevel : public GRAMRLevel
     virtual void specificUpdateODE(GRLevelData &a_soln,
                                    const GRLevelData &a_rhs, Real a_dt);
 
+    /// Things to do before tagging cells (i.e. filling ghosts)
+    virtual void preTagCells() override;
+
     //! Tell Chombo how to tag cells for regridding
     virtual void computeTaggingCriterion(FArrayBox &tagging_criterion,
                                          const FArrayBox &current_state);

--- a/Source/AMRInterpolator/AMRInterpolator.hpp
+++ b/Source/AMRInterpolator/AMRInterpolator.hpp
@@ -11,11 +11,11 @@
 #include <limits>
 
 // Chombo includes
-#include "AMR.H"
 #include "AMRLevel.H"
 
 // Our includes
 #include "BoundaryConditions.hpp"
+#include "GRAMR.hpp"
 #include "InterpSource.hpp"
 #include "InterpolationAlgorithm.hpp"
 #include "InterpolationLayout.hpp"
@@ -34,11 +34,11 @@ template <typename InterpAlgo> class AMRInterpolator
   public:
     // constructor for backward compatibility
     // (adds an artificial BC with only periodic BC)
-    AMRInterpolator(const AMR &amr,
+    AMRInterpolator(const GRAMR &amr,
                     const std::array<double, CH_SPACEDIM> &coarsest_origin,
                     const std::array<double, CH_SPACEDIM> &coarsest_dx,
                     int verbosity = 0);
-    AMRInterpolator(const AMR &amr,
+    AMRInterpolator(const GRAMR &amr,
                     const std::array<double, CH_SPACEDIM> &coarsest_origin,
                     const std::array<double, CH_SPACEDIM> &coarsest_dx,
                     const BoundaryConditions::params_t &a_bc_params,
@@ -47,7 +47,7 @@ template <typename InterpAlgo> class AMRInterpolator
     void refresh(const bool a_fill_ghosts = true);
 
     // if not filling ghosts in refresh, call this explicitly for required vars
-    void fill_ghosts(
+    void fill_multilevel_ghosts(
         const VariableType a_var_type,
         const Interval &a_comps = Interval(0, std::numeric_limits<int>::max()),
         const int a_min_level = 0,
@@ -79,7 +79,7 @@ template <typename InterpAlgo> class AMRInterpolator
     double apply_reflective_BC_on_coord(const InterpolationQuery &query,
                                         double dir, int point_idx) const;
 
-    const AMR &m_amr;
+    const GRAMR &m_gr_amr;
 
     // Coordinates of the point represented by IntVect::Zero in coarsest grid
     const std::array<double, CH_SPACEDIM> m_coarsest_origin;

--- a/Source/AMRInterpolator/AMRInterpolator.hpp
+++ b/Source/AMRInterpolator/AMRInterpolator.hpp
@@ -6,6 +6,10 @@
 #ifndef AMRINTERPOLATOR_HPP_
 #define AMRINTERPOLATOR_HPP_
 
+// system includes
+
+#include <limits>
+
 // Chombo includes
 #include "AMR.H"
 #include "AMRLevel.H"
@@ -39,7 +43,16 @@ template <typename InterpAlgo> class AMRInterpolator
                     const std::array<double, CH_SPACEDIM> &coarsest_dx,
                     const BoundaryConditions::params_t &a_bc_params,
                     int verbosity = 0);
-    void refresh();
+
+    void refresh(const bool a_fill_ghosts = true);
+
+    // if not filling ghosts in refresh, call this explicitly for required vars
+    void fill_ghosts(
+        const VariableType a_var_type,
+        const Interval &a_comps = Interval(0, std::numeric_limits<int>::max()),
+        const int a_min_level = 0,
+        const int a_max_level = std::numeric_limits<int>::max());
+
     void limit_num_levels(unsigned int num_levels);
     void interp(InterpolationQuery &query);
     const AMR &getAMR() const;

--- a/Source/AMRInterpolator/InterpSource.hpp
+++ b/Source/AMRInterpolator/InterpSource.hpp
@@ -24,10 +24,6 @@ class InterpSource
         const VariableType var_type = VariableType::evolution) const = 0;
     virtual bool
     contains(const std::array<double, CH_SPACEDIM> &point) const = 0;
-    virtual void
-    fillAllGhosts(const VariableType var_type = VariableType::evolution,
-                  const Interval &a_comps =
-                      Interval(0, std::numeric_limits<int>::max())) = 0;
 };
 
 #endif /* INTERPSOURCE_H_ */

--- a/Source/AMRInterpolator/InterpSource.hpp
+++ b/Source/AMRInterpolator/InterpSource.hpp
@@ -25,7 +25,9 @@ class InterpSource
     virtual bool
     contains(const std::array<double, CH_SPACEDIM> &point) const = 0;
     virtual void
-    fillAllGhosts(const VariableType var_type = VariableType::evolution) = 0;
+    fillAllGhosts(const VariableType var_type = VariableType::evolution,
+                  const Interval &a_comps =
+                      Interval(0, std::numeric_limits<int>::max())) = 0;
 };
 
 #endif /* INTERPSOURCE_H_ */

--- a/Source/BlackHoles/PunctureTracker.cpp
+++ b/Source/BlackHoles/PunctureTracker.cpp
@@ -182,8 +182,8 @@ void PunctureTracker::interp_shift()
     bool fill_ghosts = false;
     m_interpolator->refresh(fill_ghosts);
     // only fill the ghosts we need
-    m_interpolator->fill_ghosts(VariableType::evolution,
-                                Interval(c_shift1, c_shift3), m_min_level);
+    m_interpolator->fill_multilevel_ghosts(
+        VariableType::evolution, Interval(c_shift1, c_shift3), m_min_level);
 
     // set up shift and coordinate holders
     std::vector<double> interp_shift1(m_num_punctures);

--- a/Source/BlackHoles/PunctureTracker.cpp
+++ b/Source/BlackHoles/PunctureTracker.cpp
@@ -13,13 +13,15 @@
 //! Set punctures post restart
 void PunctureTracker::initial_setup(
     const std::vector<std::array<double, CH_SPACEDIM>> &initial_puncture_coords,
-    const std::string &a_checkpoint_prefix)
+    const std::string &a_checkpoint_prefix, const int a_min_level)
 {
     m_punctures_filename = a_checkpoint_prefix + "Punctures";
 
     // first set the puncture data
     // m_num_punctures is only set later
     m_puncture_coords = initial_puncture_coords;
+
+    m_min_level = a_min_level;
 }
 
 void PunctureTracker::restart_punctures()
@@ -177,7 +179,11 @@ void PunctureTracker::interp_shift()
     m_puncture_shift.resize(m_num_punctures);
 
     // refresh interpolator
-    m_interpolator->refresh();
+    bool fill_ghosts = false;
+    m_interpolator->refresh(fill_ghosts);
+    // only fill the ghosts we need
+    m_interpolator->fill_ghosts(VariableType::evolution,
+                                Interval(c_shift1, c_shift3), m_min_level);
 
     // set up shift and coordinate holders
     std::vector<double> interp_shift1(m_num_punctures);

--- a/Source/BlackHoles/PunctureTracker.hpp
+++ b/Source/BlackHoles/PunctureTracker.hpp
@@ -19,6 +19,8 @@ class PunctureTracker
     int m_num_punctures;
     std::vector<std::array<double, CH_SPACEDIM>> m_puncture_coords;
     std::vector<std::array<double, CH_SPACEDIM>> m_puncture_shift;
+    int m_min_level; //!< the min level on which punctures will be
+                     //!< (to fill ghosts)
 
     std::string m_punctures_filename;
 
@@ -34,7 +36,8 @@ class PunctureTracker
     //! if the puncture locations are required for Tagging Criteria
     void initial_setup(const std::vector<std::array<double, CH_SPACEDIM>>
                            &initial_puncture_coords,
-                       const std::string &a_checkpoint_prefix);
+                       const std::string &a_checkpoint_prefix,
+                       const int a_min_level = 0);
 
     //! set puncture locations on start (or restart)
     void restart_punctures();

--- a/Source/GRChomboCore/BoundaryConditions.cpp
+++ b/Source/GRChomboCore/BoundaryConditions.cpp
@@ -13,6 +13,7 @@
 #include <algorithm>
 #include <array>
 #include <map>
+#include <numeric>
 #include <string>
 
 // Chombo namespace

--- a/Source/GRChomboCore/GRAMR.cpp
+++ b/Source/GRChomboCore/GRAMR.cpp
@@ -39,3 +39,17 @@ std::vector<const GRAMRLevel *> GRAMR::get_gramrlevels() const
 
     return out;
 }
+
+void GRAMR::fill_multilevel_ghosts(const VariableType a_var_type,
+                                   const Interval &a_comps,
+                                   const int a_min_level,
+                                   const int a_max_level) const
+{
+    int max_level = std::min(m_finest_level, a_max_level);
+
+    for (int level_idx = a_min_level; level_idx <= max_level; ++level_idx)
+    {
+        GRAMRLevel &level = *GRAMRLevel::gr_cast(m_amrlevels[level_idx]);
+        level.fillAllGhosts(a_var_type, a_comps);
+    }
+}

--- a/Source/GRChomboCore/GRAMR.hpp
+++ b/Source/GRChomboCore/GRAMR.hpp
@@ -8,10 +8,11 @@
 
 // Chombo includes
 #include "AMR.H"
+#include "Interval.H"
 
 // Other includes
-#include "AMRInterpolator.hpp"
 #include "Lagrange.hpp"
+#include "VariableType.hpp"
 #include <algorithm>
 #include <chrono>
 #include <ratio>
@@ -29,6 +30,9 @@
 
 // Forward declaration for get_gramrlevels function declarations
 class GRAMRLevel;
+
+// Forward declaration for AMRInterpolator
+template <typename InterpAlgo> class AMRInterpolator;
 
 class GRAMR : public AMR
 {
@@ -60,6 +64,13 @@ class GRAMR : public AMR
 
     // const version of above
     std::vector<const GRAMRLevel *> get_gramrlevels() const;
+
+    // Fill ghosts on multiple levels
+    void fill_multilevel_ghosts(
+        const VariableType a_var_type,
+        const Interval &a_comps = Interval(0, std::numeric_limits<int>::max()),
+        const int a_min_level = 0,
+        const int a_max_level = std::numeric_limits<int>::max()) const;
 };
 
 #endif /* GRAMR_HPP_ */

--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -192,6 +192,14 @@ void GRAMRLevel::postTimeStep()
         pout() << "GRAMRLevel::postTimeStep " << m_level << " finished" << endl;
 }
 
+// things to do before tagging cells
+void GRAMRLevel::preTagCells()
+{
+    CH_TIME("GRAMRLevel::preTagCells");
+    fillAllEvolutionGhosts(); // We need filled ghost cells to calculate
+                              // gradients etc
+}
+
 // create tags
 void GRAMRLevel::tagCells(IntVectSet &a_tags)
 {
@@ -199,10 +207,8 @@ void GRAMRLevel::tagCells(IntVectSet &a_tags)
     if (m_verbosity)
         pout() << "GRAMRLevel::tagCells " << m_level << endl;
 
-    fillAllEvolutionGhosts(); // We need filled ghost cells to calculate
-                              // gradients etc
+    preTagCells();
 
-    // Create tags based on undivided gradient of phi
     IntVectSet local_tags;
 
     const DisjointBoxLayout &level_domain = m_state_new.disjointBoxLayout();

--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -994,15 +994,24 @@ bool GRAMRLevel::at_level_timestep_multiple(int a_level) const
     return (abs(time_remainder) < m_gr_amr.timeEps() * coarsest_dt);
 }
 
-void GRAMRLevel::fillAllGhosts(const VariableType var_type)
+void GRAMRLevel::fillAllGhosts(const VariableType var_type,
+                               const Interval &a_comps)
 {
     if (var_type == VariableType::evolution)
-        fillAllEvolutionGhosts();
+    {
+        Interval comps(a_comps.begin(),
+                       std::min<int>(NUM_VARS - 1, a_comps.end()));
+        fillAllEvolutionGhosts(comps);
+    }
     else if (var_type == VariableType::diagnostic)
-        fillAllDiagnosticsGhosts();
+    {
+        Interval comps(a_comps.begin(),
+                       std::min<int>(NUM_DIAGNOSTIC_VARS - 1, a_comps.end()));
+        fillAllDiagnosticsGhosts(comps);
+    }
 }
 
-void GRAMRLevel::fillAllEvolutionGhosts()
+void GRAMRLevel::fillAllEvolutionGhosts(const Interval &a_comps)
 {
     CH_TIME("GRAMRLevel::fillAllEvolutionGhosts()");
     if (m_verbosity)
@@ -1013,12 +1022,12 @@ void GRAMRLevel::fillAllEvolutionGhosts()
     {
         GRAMRLevel *coarser_gr_amr_level_ptr = gr_cast(m_coarser_level_ptr);
         m_patcher.fillInterp(m_state_new, coarser_gr_amr_level_ptr->m_state_new,
-                             0, 0, NUM_VARS);
+                             a_comps.begin(), a_comps.begin(), a_comps.size());
     }
-    fillIntralevelGhosts();
+    fillIntralevelGhosts(a_comps);
 }
 
-void GRAMRLevel::fillAllDiagnosticsGhosts()
+void GRAMRLevel::fillAllDiagnosticsGhosts(const Interval &a_comps)
 {
     CH_TIME("GRAMRLevel::fillAllDiagnosticsGhosts");
     if (m_verbosity)
@@ -1030,32 +1039,34 @@ void GRAMRLevel::fillAllDiagnosticsGhosts()
         GRAMRLevel *coarser_gr_amr_level_ptr = gr_cast(m_coarser_level_ptr);
         m_patcher_diagnostics.fillInterp(
             m_state_diagnostics, coarser_gr_amr_level_ptr->m_state_diagnostics,
-            0, 0, NUM_DIAGNOSTIC_VARS);
+            a_comps.begin(), a_comps.begin(), a_comps.size());
     }
-    m_state_diagnostics.exchange(m_exchange_copier);
+    m_state_diagnostics.exchange(a_comps, m_exchange_copier);
 
     // We should always fill the boundary ghosts to avoid nans
     // if we have non periodic directions
     if (m_p.boundary_params.nonperiodic_boundaries_exist)
     {
-        m_boundaries.fill_diagnostic_boundaries(Side::Hi, m_state_diagnostics);
-        m_boundaries.fill_diagnostic_boundaries(Side::Lo, m_state_diagnostics);
+        m_boundaries.fill_diagnostic_boundaries(Side::Hi, m_state_diagnostics,
+                                                a_comps);
+        m_boundaries.fill_diagnostic_boundaries(Side::Lo, m_state_diagnostics,
+                                                a_comps);
     }
 }
 
-void GRAMRLevel::fillIntralevelGhosts()
+void GRAMRLevel::fillIntralevelGhosts(const Interval &a_comps)
 {
-    m_state_new.exchange(m_exchange_copier);
+    m_state_new.exchange(a_comps, m_exchange_copier);
     fillBdyGhosts(m_state_new);
 }
 
-void GRAMRLevel::fillBdyGhosts(GRLevelData &a_state)
+void GRAMRLevel::fillBdyGhosts(GRLevelData &a_state, const Interval &a_comps)
 {
     // enforce solution BCs after filling ghosts
     if (m_p.boundary_params.boundary_solution_enforced)
     {
-        m_boundaries.fill_solution_boundaries(Side::Hi, a_state);
-        m_boundaries.fill_solution_boundaries(Side::Lo, a_state);
+        m_boundaries.fill_solution_boundaries(Side::Hi, a_state, a_comps);
+        m_boundaries.fill_solution_boundaries(Side::Lo, a_state, a_comps);
     }
 }
 

--- a/Source/GRChomboCore/GRAMRLevel.hpp
+++ b/Source/GRChomboCore/GRAMRLevel.hpp
@@ -22,6 +22,7 @@
 #include "SimulationParameters.hpp"
 #include "UserVariables.hpp" // need NUM_VARS
 #include <fstream>
+#include <limits>
 #include <sys/time.h>
 
 // Chombo namespace
@@ -170,23 +171,29 @@ class GRAMRLevel : public AMRLevel, public InterpSource
     bool at_level_timestep_multiple(int a_level) const;
 
     /// Fill all [either] evolution or diagnostic ghost cells
-    virtual void
-    fillAllGhosts(const VariableType var_type = VariableType::evolution);
+    virtual void fillAllGhosts(
+        const VariableType var_type = VariableType::evolution,
+        const Interval &a_comps = Interval(0, std::numeric_limits<int>::max()));
 
   protected:
     /// Fill all evolution ghosts cells (i.e. those in m_state_new)
-    virtual void fillAllEvolutionGhosts();
+    virtual void
+    fillAllEvolutionGhosts(const Interval &a_comps = Interval(0, NUM_VARS - 1));
 
     /// Fill all diagnostics ghost cells (i.e. those in m_state_diagnostics)
-    virtual void fillAllDiagnosticsGhosts();
+    virtual void fillAllDiagnosticsGhosts(
+        const Interval &a_comps = Interval(0, NUM_DIAGNOSTIC_VARS - 1));
 
     /// Fill ghosts cells from boxes on this level only. Do not interpolate
     /// between levels.
-    virtual void fillIntralevelGhosts();
+    virtual void
+    fillIntralevelGhosts(const Interval &a_comps = Interval(0, NUM_VARS - 1));
 
     /// This function is used to fill ghost cells outside the domain
     /// (for non-periodic boundary conditions, where values depend on state)
-    virtual void fillBdyGhosts(GRLevelData &a_state);
+    virtual void fillBdyGhosts(GRLevelData &a_state,
+                               const Interval &a_comps = Interval(0, NUM_VARS -
+                                                                         1));
 
     /// This function is used to copy ghost cells outside the domain
     /// (for non-periodic boundary conditions, where boundaries evolve via rhs)

--- a/Source/GRChomboCore/GRAMRLevel.hpp
+++ b/Source/GRChomboCore/GRAMRLevel.hpp
@@ -62,6 +62,9 @@ class GRAMRLevel : public AMRLevel, public InterpSource
     /// things to do after a timestep
     virtual void postTimeStep();
 
+    /// things to do before tagging cells (e.g. filling ghosts)
+    virtual void preTagCells();
+
     /// tag cells that need to be refined
     virtual void tagCells(IntVectSet &a_tags);
 

--- a/Source/TaggingCriteria/FixedGridsTaggingCriterion.hpp
+++ b/Source/TaggingCriteria/FixedGridsTaggingCriterion.hpp
@@ -9,7 +9,6 @@
 #include "Cell.hpp"
 #include "Coordinates.hpp"
 #include "DimensionDefinitions.hpp"
-#include "FourthOrderDerivatives.hpp"
 #include "Tensor.hpp"
 
 class FixedGridsTaggingCriterion
@@ -17,7 +16,6 @@ class FixedGridsTaggingCriterion
   protected:
     const double m_dx;
     const double m_L;
-    const FourthOrderDerivatives m_deriv;
     const int m_level;
     const std::array<double, CH_SPACEDIM> m_center;
 
@@ -25,8 +23,7 @@ class FixedGridsTaggingCriterion
     FixedGridsTaggingCriterion(const double dx, const int a_level,
                                const double a_L,
                                const std::array<double, CH_SPACEDIM> a_center)
-        : m_dx(dx), m_deriv(dx), m_level(a_level), m_L(a_L),
-          m_center(a_center){};
+        : m_dx(dx), m_level(a_level), m_L(a_L), m_center(a_center){};
 
     template <class data_t> void compute(Cell<data_t> current_cell) const
     {


### PR DESCRIPTION
This operation is expensive so allow restricting to an `Interval` of variables to fill ghosts for in order to save unnecessary communication. The filling of ghosts can also be disabled in `AMRInterpolator::refresh` and the user can manually fill the ghosts for an interval of variables and levels.

The puncture tracker has been sped up by only filling the ghosts for the shift variables and from a specifiable `min_level` to `max_level` (currently >95% of the time spent in the puncture tracker is just filling ghosts).

Finally users can manually specify which variables to fill ghosts for before tagging cells by overriding the `GRAMRLevel::preTagCells` (which defaults to the current behaviour of filling all the evolution ghosts).

