### PR TITLE
Add grid_buffer_size parameter

### DIFF
--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -37,7 +37,7 @@ class ChomboParameters
         // Grid setup
         pp.load("num_ghosts", num_ghosts, 3);
         pp.load("tag_buffer_size", tag_buffer_size, 3);
-        pp.load("additional_grid_buffer", additional_grid_buffer, 3);
+        pp.load("grid_buffer_size", grid_buffer_size, 8);
         pp.load("dt_multiplier", dt_multiplier, 0.25);
         pp.load("fill_ratio", fill_ratio, 0.7);
 
@@ -280,9 +280,11 @@ class ChomboParameters
                         "must be >= 3 and <= block_factor/min_box_size");
         check_parameter("tag_buffer_size", tag_buffer_size,
                         tag_buffer_size >= 0, "must be >= 0");
-        check_parameter("additional_grid_buffer", additional_grid_buffer,
-                        additional_grid_buffer >= 0,
-                        "must be >= 0 for proper nesting");
+        // assume ref_ratio is always 2
+        check_parameter(
+            "grid_buffer_size", grid_buffer_size,
+            grid_buffer_size >= ceil(num_ghosts / 2.0),
+            "must be >= ceil(num_ghosts/max_ref_ratio) for proper nesting");
         check_parameter("dt_multiplier", dt_multiplier, dt_multiplier > 0.0,
                         "must be > 0.0");
         check_parameter("max_grid_size/max_box_size", max_grid_size,
@@ -350,14 +352,13 @@ class ChomboParameters
     int verbosity;
     double L;                               // Physical sidelength of the grid
     std::array<double, CH_SPACEDIM> center; // grid center
-    IntVect ivN;                // The number of grid cells in each dimension
-    double coarsest_dx;         // The coarsest resolution
-    int max_level;              // the max number of regriddings to do
-    int num_ghosts;             // must be at least 3 for KO dissipation
-    int tag_buffer_size;        // Amount the tagged region is grown by
-    int additional_grid_buffer; // Number of additional cells (above the minimum
-                                // required for proper nesting) between level
-    Vector<int> ref_ratios;     // ref ratios between levels
+    IntVect ivN;            // The number of grid cells in each dimension
+    double coarsest_dx;     // The coarsest resolution
+    int max_level;          // the max number of regriddings to do
+    int num_ghosts;         // must be at least 3 for KO dissipation
+    int tag_buffer_size;    // Amount the tagged region is grown by
+    int grid_buffer_size;   // Number of cells between level
+    Vector<int> ref_ratios; // ref ratios between levels
     // boundaries.
     Vector<int> regrid_interval; // steps between regrid at each level
     int max_steps;

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -37,6 +37,7 @@ class ChomboParameters
         // Grid setup
         pp.load("num_ghosts", num_ghosts, 3);
         pp.load("tag_buffer_size", tag_buffer_size, 3);
+        pp.load("additional_grid_buffer", additional_grid_buffer, 3);
         pp.load("dt_multiplier", dt_multiplier, 0.25);
         pp.load("fill_ratio", fill_ratio, 0.7);
 
@@ -279,6 +280,9 @@ class ChomboParameters
                         "must be >= 3 and <= block_factor/min_box_size");
         check_parameter("tag_buffer_size", tag_buffer_size,
                         tag_buffer_size >= 0, "must be >= 0");
+        check_parameter("additional_grid_buffer", additional_grid_buffer,
+                        additional_grid_buffer >= 0,
+                        "must be >= 0 for proper nesting");
         check_parameter("dt_multiplier", dt_multiplier, dt_multiplier > 0.0,
                         "must be > 0.0");
         check_parameter("max_grid_size/max_box_size", max_grid_size,
@@ -346,12 +350,15 @@ class ChomboParameters
     int verbosity;
     double L;                               // Physical sidelength of the grid
     std::array<double, CH_SPACEDIM> center; // grid center
-    IntVect ivN;                 // The number of grid cells in each dimension
-    double coarsest_dx;          // The coarsest resolution
-    int max_level;               // the max number of regriddings to do
-    int num_ghosts;              // must be at least 3 for KO dissipation
-    int tag_buffer_size;         // Amount the tagged region is grown by
-    Vector<int> ref_ratios;      // ref ratios between levels
+    IntVect ivN;                // The number of grid cells in each dimension
+    double coarsest_dx;         // The coarsest resolution
+    int max_level;              // the max number of regriddings to do
+    int num_ghosts;             // must be at least 3 for KO dissipation
+    int tag_buffer_size;        // Amount the tagged region is grown by
+    int additional_grid_buffer; // Number of additional cells (above the minimum
+                                // required for proper nesting) between level
+    Vector<int> ref_ratios;     // ref ratios between levels
+    // boundaries.
     Vector<int> regrid_interval; // steps between regrid at each level
     int max_steps;
     bool ignore_checkpoint_name_mismatch;   // ignore mismatch of variable names

--- a/Source/GRChomboCore/SetupFunctions.hpp
+++ b/Source/GRChomboCore/SetupFunctions.hpp
@@ -129,10 +129,9 @@ void setupAMRObject(GRAMR &gr_amr, AMRLevelFactory &a_factory)
     // and defines the minimum number of level l cells there have to be
     // between level l+1 and level l-1
     const int max_ref_ratio = 2;
-    const int additional_grid_buffer = 3;
     int grid_buffer_size =
         std::ceil(((double)chombo_params.num_ghosts) / (double)max_ref_ratio) +
-        additional_grid_buffer;
+        chombo_params.additional_grid_buffer;
     gr_amr.gridBufferSize(grid_buffer_size);
 
     // set checkpoint and plot intervals and prefixes

--- a/Source/GRChomboCore/SetupFunctions.hpp
+++ b/Source/GRChomboCore/SetupFunctions.hpp
@@ -123,16 +123,10 @@ void setupAMRObject(GRAMR &gr_amr, AMRLevelFactory &a_factory)
     gr_amr.define(chombo_params.max_level, chombo_params.ref_ratios, physdomain,
                   &a_factory);
 
-    // To preserve proper nesting we need to know the maximum ref_ratio, this
-    // is now hard coded to 2 in the base params
-    // The buffer is width of ghost cells + additional_grid_buffer
-    // and defines the minimum number of level l cells there have to be
+    // The buffer defines the minimum number of level l cells there have to be
     // between level l+1 and level l-1
-    const int max_ref_ratio = 2;
-    int grid_buffer_size =
-        std::ceil(((double)chombo_params.num_ghosts) / (double)max_ref_ratio) +
-        chombo_params.additional_grid_buffer;
-    gr_amr.gridBufferSize(grid_buffer_size);
+    // It needs to be at least ceil(num_ghosts/max_ref_ratio) for proper nesting
+    gr_amr.gridBufferSize(chombo_params.grid_buffer_size);
 
     // set checkpoint and plot intervals and prefixes
     gr_amr.checkpointInterval(chombo_params.checkpoint_interval);


### PR DESCRIPTION
This controls the number of cells between the boundary of level l and the boundary of level l-1. It is 'additional' because `ceil(num_ghosts/ref_ratio)` is already added to it to define `grid_buffer` and this is what is passed to the `MeshRefine` object.

I have found this parameter very useful in my recent BBH simulations in order to ensure the refinement boundaries are not too close to each other as this causes problems with reflections of noise.