### PR TITLE
Separate Out Gauge

### DIFF
--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -7,7 +7,7 @@
 #include "AMRReductions.hpp"
 #include "BinaryBH.hpp"
 #include "BoxLoops.hpp"
-#include "CCZ4.hpp"
+#include "CCZ4RHS.hpp"
 #include "ChiExtractionTaggingCriterion.hpp"
 #include "ChiPunctureExtractionTaggingCriterion.hpp"
 #include "ComputePack.hpp"
@@ -60,7 +60,8 @@ void BinaryBHLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
                    a_soln, a_soln, INCLUDE_GHOST_CELLS);
 
     // Calculate CCZ4 right hand side
-    BoxLoops::loop(CCZ4(m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation),
+    BoxLoops::loop(CCZ4RHS<MovingPuncturePlusGauge, FourthOrderDerivatives>(
+                       m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation),
                    a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
 }
 

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -60,7 +60,7 @@ void BinaryBHLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
                    a_soln, a_soln, INCLUDE_GHOST_CELLS);
 
     // Calculate CCZ4 right hand side
-    BoxLoops::loop(CCZ4RHS<MovingPuncturePlusGauge, FourthOrderDerivatives>(
+    BoxLoops::loop(CCZ4RHS<MovingPunctureGauge, FourthOrderDerivatives>(
                        m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation),
                    a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
 }

--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -11,8 +11,8 @@
 #include "ChiExtractionTaggingCriterion.hpp"
 #include "ChiPunctureExtractionTaggingCriterion.hpp"
 #include "ComputePack.hpp"
-#include "Constraints.hpp"
 #include "NanCheck.hpp"
+#include "NewConstraints.hpp"
 #include "PositiveChiAndAlpha.hpp"
 #include "PunctureTracker.hpp"
 #include "SetValue.hpp"
@@ -147,8 +147,8 @@ void BinaryBHLevel::specificPostTimeStep()
     if (m_p.calculate_constraint_norms)
     {
         fillAllGhosts();
-        BoxLoops::loop(Constraints(m_dx), m_state_new, m_state_diagnostics,
-                       EXCLUDE_GHOST_CELLS);
+        BoxLoops::loop(Constraints(m_dx, c_Ham, Interval(c_Mom1, c_Mom3)),
+                       m_state_new, m_state_diagnostics, EXCLUDE_GHOST_CELLS);
         if (m_level == 0)
         {
             AMRReductions<VariableType::diagnostic> amr_reductions(m_gr_amr);
@@ -178,15 +178,17 @@ void BinaryBHLevel::specificPostTimeStep()
     }
 }
 
+#ifdef CH_USE_HDF5
 // Things to do before a plot level - need to calculate the Weyl scalars
 void BinaryBHLevel::prePlotLevel()
 {
     fillAllGhosts();
     if (m_p.activate_extraction == 1)
     {
-        BoxLoops::loop(
-            make_compute_pack(Weyl4(m_p.extraction_params.center, m_dx),
-                              Constraints(m_dx)),
-            m_state_new, m_state_diagnostics, EXCLUDE_GHOST_CELLS);
+        BoxLoops::loop(make_compute_pack(
+                           Weyl4(m_p.extraction_params.center, m_dx),
+                           Constraints(m_dx, c_Ham, Interval(c_Mom1, c_Mom3))),
+                       m_state_new, m_state_diagnostics, EXCLUDE_GHOST_CELLS);
     }
 }
+#endif /* CH_USE_HDF5 */

--- a/Examples/BinaryBH/BinaryBHLevel.hpp
+++ b/Examples/BinaryBH/BinaryBHLevel.hpp
@@ -45,8 +45,10 @@ class BinaryBHLevel : public GRAMRLevel
     // to do post each time step on every level
     virtual void specificPostTimeStep() override;
 
+#ifdef CH_USE_HDF5
     /// Any actions that should happen just before plot files output
     virtual void prePlotLevel() override;
+#endif /* CH_USE_HDF5 */
 };
 
 #endif /* BINARYBHLEVEL_HPP_ */

--- a/Examples/BinaryBH/params.txt
+++ b/Examples/BinaryBH/params.txt
@@ -97,7 +97,7 @@ eta = 1.0
 kappa1 = 0.1
 kappa2 = 0
 kappa3 = 1.0
-covariantZ4 = 1 # 0: default. 1: dampk1 -> dampk1/lapse
+covariantZ4 = 1 # 0: keep kappa1; 1 [default]: replace kappa1 -> kappa1/lapse
 
 # coefficient for KO numerical dissipation
 sigma = 1.0

--- a/Examples/BinaryBH/params_expensive.txt
+++ b/Examples/BinaryBH/params_expensive.txt
@@ -59,7 +59,7 @@ eta = 1.82
 kappa1 = 0.1
 kappa2 = 0
 kappa3 = 1.
-covariantZ4 = 1 # 0: default. 1: dampk1 -> dampk1/lapse
+covariantZ4 = 1 # 0: keep kappa1; 1 [default]: replace kappa1 -> kappa1/lapse
 
 #coefficient for KO numerical dissipation
 sigma = 0.3

--- a/Examples/BinaryBH/params_very_cheap.txt
+++ b/Examples/BinaryBH/params_very_cheap.txt
@@ -55,7 +55,7 @@ eta = 1.82
 kappa1 = 0.1
 kappa2 = 0
 kappa3 = 1.
-covariantZ4 = 1 # 0: default. 1: dampk1 -> dampk1/lapse
+covariantZ4 = 1 # 0: keep kappa1; 1 [default]: replace kappa1 -> kappa1/lapse
 
 #coefficient for KO numerical dissipation
 sigma = 0.3

--- a/Examples/KerrBH/KerrBHLevel.cpp
+++ b/Examples/KerrBH/KerrBHLevel.cpp
@@ -5,7 +5,7 @@
 
 #include "KerrBHLevel.hpp"
 #include "BoxLoops.hpp"
-#include "CCZ4.hpp"
+#include "CCZ4RHS.hpp"
 #include "ChiTaggingCriterion.hpp"
 #include "ComputePack.hpp"
 #include "Constraints.hpp"
@@ -64,7 +64,8 @@ void KerrBHLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
                    a_soln, a_soln, INCLUDE_GHOST_CELLS);
 
     // Calculate CCZ4 right hand side
-    BoxLoops::loop(CCZ4(m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation),
+    BoxLoops::loop(CCZ4RHS<MovingPuncturePlusGauge, FourthOrderDerivatives>(
+                       m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation),
                    a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
 }
 

--- a/Examples/KerrBH/KerrBHLevel.cpp
+++ b/Examples/KerrBH/KerrBHLevel.cpp
@@ -66,7 +66,7 @@ void KerrBHLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
                    a_soln, a_soln, INCLUDE_GHOST_CELLS);
 
     // Calculate CCZ4 right hand side
-    BoxLoops::loop(CCZ4RHS<MovingPuncturePlusGauge, FourthOrderDerivatives>(
+    BoxLoops::loop(CCZ4RHS<MovingPunctureGauge, FourthOrderDerivatives>(
                        m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation),
                    a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
 }

--- a/Examples/KerrBH/KerrBHLevel.cpp
+++ b/Examples/KerrBH/KerrBHLevel.cpp
@@ -8,9 +8,9 @@
 #include "CCZ4RHS.hpp"
 #include "ChiTaggingCriterion.hpp"
 #include "ComputePack.hpp"
-#include "Constraints.hpp"
 #include "KerrBHLevel.hpp"
 #include "NanCheck.hpp"
+#include "NewConstraints.hpp"
 #include "PositiveChiAndAlpha.hpp"
 #include "SetValue.hpp"
 #include "TraceARemoval.hpp"
@@ -49,12 +49,14 @@ void KerrBHLevel::initialData()
                    EXCLUDE_GHOST_CELLS);
 }
 
+#ifdef CH_USE_HDF5
 void KerrBHLevel::prePlotLevel()
 {
     fillAllGhosts();
-    BoxLoops::loop(Constraints(m_dx), m_state_new, m_state_diagnostics,
-                   EXCLUDE_GHOST_CELLS);
+    BoxLoops::loop(Constraints(m_dx, c_Ham, Interval(c_Mom1, c_Mom3)),
+                   m_state_new, m_state_diagnostics, EXCLUDE_GHOST_CELLS);
 }
+#endif /* CH_USE_HDF5 */
 
 void KerrBHLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
                                   const double a_time)

--- a/Examples/KerrBH/KerrBHLevel.hpp
+++ b/Examples/KerrBH/KerrBHLevel.hpp
@@ -22,8 +22,10 @@ class KerrBHLevel : public GRAMRLevel
     /// Initial data calculation
     virtual void initialData() override;
 
+#ifdef CH_USE_HDF5
     /// Things to do before writing a plot file
     virtual void prePlotLevel() override;
+#endif /* CH_USE_HDF5 */
 
     /// Calculation of the right hand side for the time stepping
     virtual void specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,

--- a/Examples/KerrBH/SimulationParameters.hpp
+++ b/Examples/KerrBH/SimulationParameters.hpp
@@ -11,7 +11,6 @@
 #include "SimulationParametersBase.hpp"
 
 // Problem specific includes:
-#include "CCZ4.hpp"
 #include "KerrBH.hpp"
 
 class SimulationParameters : public SimulationParametersBase

--- a/Examples/KerrBH/params.txt
+++ b/Examples/KerrBH/params.txt
@@ -95,7 +95,7 @@ formulation = 1  # 1 for BSSN, 0 for CCZ4
 kappa1 = 0
 kappa2 = 0
 kappa3 = 0
-covariantZ4 = 0 # 0: default. 1: dampk1 -> dampk1/lapse
+covariantZ4 = 1 # 0: keep kappa1; 1 [default]: replace kappa1 -> kappa1/lapse
 
 # coefficient for KO numerical dissipation
 sigma = 0.3

--- a/Examples/KerrBH/params_cheap.txt
+++ b/Examples/KerrBH/params_cheap.txt
@@ -96,7 +96,7 @@ formulation = 1  # 1 for BSSN, 0 for CCZ4
 kappa1 = 0
 kappa2 = 0
 kappa3 = 0
-covariantZ4 = 0 # 0: default. 1: dampk1 -> dampk1/lapse
+covariantZ4 = 1 # 0: keep kappa1; 1 [default]: replace kappa1 -> kappa1/lapse
 
 # coefficient for KO numerical dissipation
 # NB must be less than 0.5 for stability

--- a/Examples/ScalarField/InitialScalarData.hpp
+++ b/Examples/ScalarField/InitialScalarData.hpp
@@ -8,7 +8,7 @@
 
 #include "Cell.hpp"
 #include "Coordinates.hpp"
-#include "MatterCCZ4.hpp"
+#include "MatterCCZ4RHS.hpp"
 #include "ScalarField.hpp"
 #include "Tensor.hpp"
 #include "UserVariables.hpp" //This files needs NUM_VARS - total no. components

--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -89,7 +89,7 @@ void ScalarFieldLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
     // Calculate MatterCCZ4 right hand side with matter_t = ScalarField
     Potential potential(m_p.potential_params);
     ScalarFieldWithPotential scalar_field(potential);
-    MatterCCZ4RHS<ScalarFieldWithPotential, MovingPuncturePlusGauge,
+    MatterCCZ4RHS<ScalarFieldWithPotential, MovingPunctureGauge,
                   FourthOrderDerivatives>
         my_ccz4_matter(scalar_field, m_p.ccz4_params, m_dx, m_p.sigma,
                        m_p.formulation, m_p.G_Newton);

--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -11,7 +11,7 @@
 #include "TraceARemoval.hpp"
 
 // For RHS update
-#include "MatterCCZ4.hpp"
+#include "MatterCCZ4RHS.hpp"
 
 // For constraints calculation
 #include "NewMatterConstraints.hpp"
@@ -87,9 +87,10 @@ void ScalarFieldLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
     // Calculate MatterCCZ4 right hand side with matter_t = ScalarField
     Potential potential(m_p.potential_params);
     ScalarFieldWithPotential scalar_field(potential);
-    MatterCCZ4<ScalarFieldWithPotential> my_ccz4_matter(
-        scalar_field, m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation,
-        m_p.G_Newton);
+    MatterCCZ4RHS<ScalarFieldWithPotential, MovingPuncturePlusGauge,
+                  FourthOrderDerivatives>
+        my_ccz4_matter(scalar_field, m_p.ccz4_params, m_dx, m_p.sigma,
+                       m_p.formulation, m_p.G_Newton);
     BoxLoops::loop(my_ccz4_matter, a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
 }
 

--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -62,6 +62,7 @@ void ScalarFieldLevel::initialData()
                    EXCLUDE_GHOST_CELLS);
 }
 
+#ifdef CH_USE_HDF5
 // Things to do before outputting a checkpoint file
 void ScalarFieldLevel::prePlotLevel()
 {
@@ -73,6 +74,7 @@ void ScalarFieldLevel::prePlotLevel()
             scalar_field, m_dx, m_p.G_Newton, c_Ham, Interval(c_Mom, c_Mom)),
         m_state_new, m_state_diagnostics, EXCLUDE_GHOST_CELLS);
 }
+#endif
 
 // Things to do in RHS update, at each RK4 step
 void ScalarFieldLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,

--- a/Examples/ScalarField/ScalarFieldLevel.hpp
+++ b/Examples/ScalarField/ScalarFieldLevel.hpp
@@ -36,8 +36,10 @@ class ScalarFieldLevel : public GRAMRLevel
     //! Initialize data for the field and metric variables
     virtual void initialData();
 
+#ifdef CH_USE_HDF5
     //! routines to do before outputting plot file
     virtual void prePlotLevel();
+#endif
 
     //! RHS routines used at each RK4 step
     virtual void specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,

--- a/Examples/ScalarField/SimulationParameters.hpp
+++ b/Examples/ScalarField/SimulationParameters.hpp
@@ -11,7 +11,6 @@
 #include "SimulationParametersBase.hpp"
 
 // Problem specific includes:
-#include "CCZ4.hpp"
 #include "InitialScalarData.hpp"
 #include "KerrBH.hpp"
 #include "Potential.hpp"

--- a/Examples/ScalarField/params.txt
+++ b/Examples/ScalarField/params.txt
@@ -89,7 +89,7 @@ formulation = 1  # 1 for BSSN, 0 for CCZ4
 kappa1 = 0
 kappa2 = 0
 kappa3 = 0
-covariantZ4 = 0 # 0: default. 1: dampk1 -> dampk1/lapse
+covariantZ4 = 1 # 0: keep kappa1; 1 [default]: replace kappa1 -> kappa1/lapse
 
 # coefficient for KO numerical dissipation
 sigma = 0.3

--- a/Source/CCZ4/CCZ4.hpp
+++ b/Source/CCZ4/CCZ4.hpp
@@ -1,0 +1,1 @@
+CCZ4RHS.hpp

--- a/Source/CCZ4/CCZ4RHS.hpp
+++ b/Source/CCZ4/CCZ4RHS.hpp
@@ -19,13 +19,33 @@
 
 #include <array>
 
+/// Base parameter struct for CCZ4
+/** This struct collects the gauge independent CCZ4 parameters i.e. the damping
+ * ones
+ */
+struct CCZ4_base_params_t
+{
+    double kappa1; //!< Damping parameter kappa1 as in arXiv:1106.2254
+    double kappa2; //!< Damping parameter kappa2 as in arXiv:1106.2254
+    double kappa3; //!< Damping parameter kappa3 as in arXiv:1106.2254
+};
+
+/// Parameter struct for CCZ4
+/** This struct collects all parameters that are necessary for CCZ4 such as
+ * gauge and damping parameters. It inherits from CCZ4_base_params_t and
+ * gauge_t::params_t
+ */
+template <class gauge_t = MovingPuncturePlusGauge>
+struct CCZ4_params_t : public CCZ4_base_params_t, public gauge_t::params_t
+{
+};
+
 /// Compute class to calculate the CCZ4 right hand side
 /**
  * This compute class implements the CCZ4 right hand side equations. Use it by
- *handing it to a loop in the BoxLoops namespace. CCZ4RHS includes two classes
+ *handing it to a loop in the BoxLoops namespace. CCZ4RHS includes a struct
  *in its scope: CCZ4RHS::Vars (the CCZ4 variables like conformal factor,
- *conformal metric, extrinsic curvature, etc) and CCZ4RHS::Params (parameters
- *necessary for CCZ4 like gauge and damping parameters).
+ *conformal metric, extrinsic curvature, etc).
  **/
 template <class gauge_t = MovingPuncturePlusGauge,
           class deriv_t = FourthOrderDerivatives>
@@ -38,23 +58,14 @@ class CCZ4RHS
         USE_BSSN
     };
 
+    using params_t = CCZ4_params_t<gauge_t>;
+
     /// CCZ4 variables
     template <class data_t> using Vars = CCZ4Vars::VarsWithGauge<data_t>;
 
     /// CCZ4 variables
     template <class data_t>
     using Diff2Vars = CCZ4Vars::Diff2VarsWithGauge<data_t>;
-
-    /// Parameters for CCZ4
-    /** This struct collects all parameters that are necessary for CCZ4 such as
-     * gauge and damping parameters. It inherits from the gauge params_t struct
-     */
-    struct params_t : public gauge_t::params_t
-    {
-        double kappa1; //!< Damping parameter kappa1 as in arXiv:1106.2254
-        double kappa2; //!< Damping parameter kappa2 as in arXiv:1106.2254
-        double kappa3; //!< Damping parameter kappa3 as in arXiv:1106.2254
-    };
 
   protected:
     const params_t m_params; //!< CCZ4 parameters

--- a/Source/CCZ4/CCZ4RHS.hpp
+++ b/Source/CCZ4/CCZ4RHS.hpp
@@ -10,7 +10,7 @@
 #include "CCZ4Vars.hpp"
 #include "Cell.hpp"
 #include "FourthOrderDerivatives.hpp"
-#include "MovingPuncturePlusGauge.hpp"
+#include "MovingPunctureGauge.hpp"
 #include "Tensor.hpp"
 #include "TensorAlgebra.hpp"
 #include "simd.hpp"
@@ -35,7 +35,7 @@ struct CCZ4_base_params_t
  * gauge and damping parameters. It inherits from CCZ4_base_params_t and
  * gauge_t::params_t
  */
-template <class gauge_t = MovingPuncturePlusGauge>
+template <class gauge_t = MovingPunctureGauge>
 struct CCZ4_params_t : public CCZ4_base_params_t, public gauge_t::params_t
 {
 };
@@ -47,7 +47,7 @@ struct CCZ4_params_t : public CCZ4_base_params_t, public gauge_t::params_t
  *in its scope: CCZ4RHS::Vars (the CCZ4 variables like conformal factor,
  *conformal metric, extrinsic curvature, etc).
  **/
-template <class gauge_t = MovingPuncturePlusGauge,
+template <class gauge_t = MovingPunctureGauge,
           class deriv_t = FourthOrderDerivatives>
 class CCZ4RHS
 {

--- a/Source/CCZ4/CCZ4RHS.hpp
+++ b/Source/CCZ4/CCZ4RHS.hpp
@@ -120,6 +120,11 @@ class CCZ4RHS
 
 // This is here for backwards compatibility though the CCZ4RHS class should be
 // used in future hence mark as deprecated
+#ifdef __INTEL_COMPILER
+// Intel compiler bug means a spurious warning is printed (tinyurl.com/y9vfgj9j)
+// Supress the warning with this pragma
+#pragma warning(disable : 2651)
+#endif
 using CCZ4 [[deprecated("Use CCZ4RHS instead")]] = CCZ4RHS<>;
 
 #endif /* CCZ4RHS_HPP_ */

--- a/Source/CCZ4/CCZ4RHS.hpp
+++ b/Source/CCZ4/CCZ4RHS.hpp
@@ -22,12 +22,14 @@
 /// Compute class to calculate the CCZ4 right hand side
 /**
  * This compute class implements the CCZ4 right hand side equations. Use it by
- *handing it to a loop in the BoxLoops namespace. CCZ4 includes two classes in
- *its scope: CCZ4::Vars (the CCZ4 variables like conformal factor, conformal
- *metric, extrinsic curvature, etc) and CCZ4::Params (parameters necessary for
- *CCZ4 like gauge and damping parameters).
+ *handing it to a loop in the BoxLoops namespace. CCZ4RHS includes two classes
+ *in its scope: CCZ4RHS::Vars (the CCZ4 variables like conformal factor,
+ *conformal metric, extrinsic curvature, etc) and CCZ4RHS::Params (parameters
+ *necessary for CCZ4 like gauge and damping parameters).
  **/
-template <class gauge_t, class deriv_t = FourthOrderDerivatives> class CCZ4RHS
+template <class gauge_t = MovingPuncturePlusGauge,
+          class deriv_t = FourthOrderDerivatives>
+class CCZ4RHS
 {
   public:
     enum
@@ -45,7 +47,8 @@ template <class gauge_t, class deriv_t = FourthOrderDerivatives> class CCZ4RHS
 
     /// Parameters for CCZ4
     /** This struct collects all parameters that are necessary for CCZ4 such as
-     * gauge and damping parameters. It inherits from the gauge parameters  */
+     * gauge and damping parameters. It inherits from the gauge params_t struct
+     */
     struct params_t : public gauge_t::params_t
     {
         double kappa1; //!< Damping parameter kappa1 as in arXiv:1106.2254
@@ -80,10 +83,10 @@ template <class gauge_t, class deriv_t = FourthOrderDerivatives> class CCZ4RHS
 
   protected:
     /// Calculates the rhs for CCZ4
-    /** Calculates the right hand side for CCZ4 with slicing \f$- n \alpha^m (K
-     *- 2\Theta)\f$ and Gamma-Driver shift condition. The variables (the
-     *template argument vars_t) must contain at least the members: chi,
-     *h[i][j], Gamma[i], A[i][j], Theta, lapse and shift[i].
+    /** Calculates the right hand side for CCZ4 and calls rhs_gauge for the
+     *gauge conditions The variables (the template argument vars_t) must contain
+     *at least the members: chi, h[i][j], Gamma[i], A[i][j], Theta, lapse and
+     *shift[i].
      **/
     template <class data_t, template <typename> class vars_t,
               template <typename> class diff2_vars_t>
@@ -103,7 +106,7 @@ template <class gauge_t, class deriv_t = FourthOrderDerivatives> class CCZ4RHS
 #include "CCZ4RHS.impl.hpp"
 
 // This is here for backwards compatibility though the CCZ4RHS class should be
-// used in future
-using CCZ4 = CCZ4RHS<MovingPuncturePlusGauge, FourthOrderDerivatives>;
+// used in future hence mark as deprecated
+using CCZ4 [[deprecated("Use CCZ4RHS instead")]] = CCZ4RHS<>;
 
 #endif /* CCZ4RHS_HPP_ */

--- a/Source/CCZ4/CCZ4RHS.hpp
+++ b/Source/CCZ4/CCZ4RHS.hpp
@@ -25,9 +25,11 @@
  */
 struct CCZ4_base_params_t
 {
-    double kappa1; //!< Damping parameter kappa1 as in arXiv:1106.2254
-    double kappa2; //!< Damping parameter kappa2 as in arXiv:1106.2254
-    double kappa3; //!< Damping parameter kappa3 as in arXiv:1106.2254
+    double kappa1;    //!< Damping parameter kappa1 as in arXiv:1106.2254
+    double kappa2;    //!< Damping parameter kappa2 as in arXiv:1106.2254
+    double kappa3;    //!< Damping parameter kappa3 as in arXiv:1106.2254
+    bool covariantZ4; //!< if true, replace kappa1->kappa1/lapse as in
+                      //!<  arXiv:1307.7391 eq. 27
 };
 
 /// Parameter struct for CCZ4
@@ -35,8 +37,8 @@ struct CCZ4_base_params_t
  * gauge and damping parameters. It inherits from CCZ4_base_params_t and
  * gauge_t::params_t
  */
-template <class gauge_t = MovingPunctureGauge>
-struct CCZ4_params_t : public CCZ4_base_params_t, public gauge_t::params_t
+template <class gauge_params_t = MovingPunctureGauge::params_t>
+struct CCZ4_params_t : public CCZ4_base_params_t, public gauge_params_t
 {
 };
 
@@ -58,7 +60,7 @@ class CCZ4RHS
         USE_BSSN
     };
 
-    using params_t = CCZ4_params_t<gauge_t>;
+    using params_t = CCZ4_params_t<typename gauge_t::params_t>;
 
     /// CCZ4 variables
     template <class data_t> using Vars = CCZ4Vars::VarsWithGauge<data_t>;

--- a/Source/CCZ4/CCZ4RHS.impl.hpp
+++ b/Source/CCZ4/CCZ4RHS.impl.hpp
@@ -16,8 +16,9 @@
 #include "VarsTools.hpp"
 
 template <class gauge_t, class deriv_t>
-inline CCZ4RHS<gauge_t, deriv_t>::CCZ4RHS(params_t a_params, double a_dx,
-                                          double a_sigma, int a_formulation,
+inline CCZ4RHS<gauge_t, deriv_t>::CCZ4RHS(CCZ4_params_t<gauge_t> a_params,
+                                          double a_dx, double a_sigma,
+                                          int a_formulation,
                                           double a_cosmological_constant)
     : m_params(a_params), m_gauge(a_params), m_sigma(a_sigma),
       m_formulation(a_formulation),

--- a/Source/CCZ4/CCZ4RHS.impl.hpp
+++ b/Source/CCZ4/CCZ4RHS.impl.hpp
@@ -3,28 +3,31 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-#if !defined(CCZ4_HPP_)
-#error "This file should only be included through CCZ4.hpp"
+#if !defined(CCZ4RHS_HPP_)
+#error "This file should only be included through CCZ4RHS.hpp"
 #endif
 
-#ifndef CCZ4_IMPL_HPP_
-#define CCZ4_IMPL_HPP_
+#ifndef CCZ4RHS_IMPL_HPP_
+#define CCZ4RHS_IMPL_HPP_
 
 #define COVARIANTZ4
 #include "DimensionDefinitions.hpp"
 #include "GRInterval.hpp"
 #include "VarsTools.hpp"
 
-inline CCZ4::CCZ4(params_t params, double dx, double sigma, int formulation,
-                  double cosmological_constant)
-    : m_params(params), m_sigma(sigma), m_formulation(formulation),
-      m_cosmological_constant(cosmological_constant), m_deriv(dx)
+template <class gauge_t, class deriv_t>
+inline CCZ4RHS<gauge_t, deriv_t>::CCZ4RHS(params_t a_params, double a_dx,
+                                          double a_sigma, int a_formulation,
+                                          double a_cosmological_constant)
+    : m_params(a_params), m_gauge(a_params), m_sigma(a_sigma),
+      m_formulation(a_formulation),
+      m_cosmological_constant(a_cosmological_constant), m_deriv(a_dx)
 {
     // A user who wants to use BSSN should also have damping paramters = 0
     if (m_formulation == USE_BSSN)
     {
-        if ((m_params.kappa1 != 0.) || (params.kappa2 != 0.) ||
-            (params.kappa3 != 0.))
+        if ((m_params.kappa1 != 0.) || (m_params.kappa2 != 0.) ||
+            (m_params.kappa3 != 0.))
         {
             MayDay::Error("BSSN formulation is selected - CCZ4 kappa values "
                           "should be set to zero in params");
@@ -34,7 +37,9 @@ inline CCZ4::CCZ4(params_t params, double dx, double sigma, int formulation,
         MayDay::Error("The requested formulation is not supported");
 }
 
-template <class data_t> void CCZ4::compute(Cell<data_t> current_cell) const
+template <class gauge_t, class deriv_t>
+template <class data_t>
+void CCZ4RHS<gauge_t, deriv_t>::compute(Cell<data_t> current_cell) const
 {
     const auto vars = current_cell.template load_vars<Vars>();
     const auto d1 = m_deriv.template diff1<Vars>(current_cell);
@@ -50,12 +55,14 @@ template <class data_t> void CCZ4::compute(Cell<data_t> current_cell) const
     current_cell.store_vars(rhs); // Write the rhs into the output FArrayBox
 }
 
+template <class gauge_t, class deriv_t>
 template <class data_t, template <typename> class vars_t,
           template <typename> class diff2_vars_t>
-void CCZ4::rhs_equation(vars_t<data_t> &rhs, const vars_t<data_t> &vars,
-                        const vars_t<Tensor<1, data_t>> &d1,
-                        const diff2_vars_t<Tensor<2, data_t>> &d2,
-                        const vars_t<data_t> &advec) const
+void CCZ4RHS<gauge_t, deriv_t>::rhs_equation(
+    vars_t<data_t> &rhs, const vars_t<data_t> &vars,
+    const vars_t<Tensor<1, data_t>> &d1,
+    const diff2_vars_t<Tensor<2, data_t>> &d2,
+    const vars_t<data_t> &advec) const
 {
     using namespace TensorAlgebra;
 
@@ -216,19 +223,7 @@ void CCZ4::rhs_equation(vars_t<data_t> &rhs, const vars_t<data_t> &vars,
 
     FOR1(i) { rhs.Gamma[i] = advec.Gamma[i] + Gammadot[i]; }
 
-    const data_t etaDecay = 1.;
-
-    rhs.lapse = m_params.lapse_advec_coeff * advec.lapse -
-                m_params.lapse_coeff * pow(vars.lapse, m_params.lapse_power) *
-                    (vars.K - 2 * vars.Theta);
-    FOR1(i)
-    {
-        rhs.shift[i] = m_params.shift_advec_coeff * advec.shift[i] +
-                       m_params.shift_Gamma_coeff * vars.B[i];
-        rhs.B[i] = m_params.shift_advec_coeff * advec.B[i] +
-                   (1 - m_params.shift_advec_coeff) * advec.Gamma[i] +
-                   Gammadot[i] - m_params.eta * etaDecay * vars.B[i];
-    }
+    m_gauge.rhs_gauge(rhs, vars, d1, d2, advec);
 }
 
-#endif /* CCZ4_IMPL_HPP_ */
+#endif /* CCZ4RHS_IMPL_HPP_ */

--- a/Source/CCZ4/Constraints.hpp
+++ b/Source/CCZ4/Constraints.hpp
@@ -18,7 +18,8 @@
 
 #include <array>
 
-class Constraints
+class [
+    [deprecated("Use new Constraints class in NewConstraints.hpp")]] Constraints
 {
   public:
     /// CCZ4 variables
@@ -54,10 +55,10 @@ class Constraints
 
     template <class data_t, template <typename> class vars_t,
               template <typename> class diff2_vars_t>
-    Vars<data_t>
-    constraint_equations(const vars_t<data_t> &vars,
-                         const vars_t<Tensor<1, data_t>> &d1,
-                         const diff2_vars_t<Tensor<2, data_t>> &d2) const;
+    Vars<data_t> constraint_equations(const vars_t<data_t> &vars,
+                                      const vars_t<Tensor<1, data_t>> &d1,
+                                      const diff2_vars_t<Tensor<2, data_t>> &d2)
+        const;
 };
 
 #include "Constraints.impl.hpp"

--- a/Source/CCZ4/IntegratedMovingPunctureGauge.hpp
+++ b/Source/CCZ4/IntegratedMovingPunctureGauge.hpp
@@ -1,0 +1,96 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef INTEGRATEDMOVINGPUNCTUREGAUGE_HPP_
+#define INTEGRATEDMOVINGPUNCTUREGAUGE_HPP_
+
+#include "CCZ4Vars.hpp"
+#include "Cell.hpp"
+#include "DimensionDefinitions.hpp"
+#include "MovingPunctureGauge.hpp"
+#include "Tensor.hpp"
+
+/// This is an example of a gauge class that can be used in the CCZ4RHS compute
+/// class
+/**
+ * This class implements a slightly more generic version of the moving puncture
+ * gauge. In particular it uses a Bona-Masso slicing condition of the form
+ * f(lapse) = -c*lapse^(p-2)
+ * and an Integrated version of the Gamma-driver shift condition
+ * (see details in arXiv:gr-qc/0605030)
+ **/
+class IntegratedMovingPunctureGauge
+{
+  public:
+    using params_t = MovingPunctureGauge::params_t;
+
+  protected:
+    params_t m_params;
+
+    /// Vars needed internally in 'compute'
+    template <class data_t> struct Vars
+    {
+        Tensor<1, data_t> shift;
+        Tensor<1, data_t> Gamma; //!< Conformal connection functions
+
+        /// Defines the mapping between members of Vars and Chombo grid
+        /// variables (enum in User_Variables)
+        template <typename mapping_function_t>
+        void enum_mapping(mapping_function_t mapping_function)
+        {
+            VarsTools::define_enum_mapping(
+                mapping_function, GRInterval<c_shift1, c_shift3>(), shift);
+            VarsTools::define_enum_mapping(
+                mapping_function, GRInterval<c_Gamma1, c_Gamma3>(), Gamma);
+        }
+    };
+
+  public:
+    IntegratedMovingPunctureGauge(const params_t &a_params) : m_params(a_params)
+    {
+    }
+
+    // set the initial B^i to the initial condition equivalent to:
+    // \partial_t shift - advec_coeff * advec.shift = 0
+    // Include in your Example in GRAMRLevel::initial_data as:
+    // fillAllGhosts();
+    // BoxLoops::loop(IntegratedMovingPunctureGauge(m_p.ccz4_params),
+    // m_state_new, m_state_new, EXCLUDE_GHOST_CELLS);
+    template <class data_t> void compute(Cell<data_t> current_cell) const
+    {
+        const auto vars = current_cell.template load_vars<Vars>();
+
+        Tensor<1, data_t> B;
+        FOR1(i)
+        {
+            B[i] = m_params.shift_Gamma_coeff * vars.Gamma[i] -
+                   m_params.eta * vars.shift[i];
+        }
+
+        current_cell.store_vars(B, GRInterval<c_B1, c_B3>());
+    }
+
+    template <class data_t, template <typename> class vars_t,
+              template <typename> class diff2_vars_t>
+    inline void rhs_gauge(vars_t<data_t> &rhs, const vars_t<data_t> &vars,
+                          const vars_t<Tensor<1, data_t>> &d1,
+                          const diff2_vars_t<Tensor<2, data_t>> &d2,
+                          const vars_t<data_t> &advec) const
+    {
+        rhs.lapse = m_params.lapse_advec_coeff * advec.lapse -
+                    m_params.lapse_coeff *
+                        pow(vars.lapse, m_params.lapse_power) *
+                        (vars.K - 2 * vars.Theta);
+        FOR1(i)
+        {
+            rhs.shift[i] = m_params.shift_advec_coeff * advec.shift[i] +
+                           m_params.shift_Gamma_coeff * vars.Gamma[i] -
+                           m_params.eta * vars.shift[i] - vars.B[i];
+            rhs.B[i] = 0.; // static, stays the same to save initial condition
+        }
+    }
+};
+
+#endif /* INTEGRATEDMOVINGPUNCTUREGAUGE_HPP_ */

--- a/Source/CCZ4/MovingPunctureGauge.hpp
+++ b/Source/CCZ4/MovingPunctureGauge.hpp
@@ -3,8 +3,8 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-#ifndef MOVINGPUNCTUREPLUSGAUGE_HPP_
-#define MOVINGPUNCTUREPLUSGAUGE_HPP_
+#ifndef MOVINGPUNCTUREGAUGE_HPP_
+#define MOVINGPUNCTUREGAUGE_HPP_
 
 #include "DimensionDefinitions.hpp"
 #include "Tensor.hpp"
@@ -17,7 +17,7 @@
  * f(lapse) = -c*lapse^(p-2)
  * and a Gamma-driver shift condition
  **/
-class MovingPuncturePlusGauge
+class MovingPunctureGauge
 {
   public:
     struct params_t
@@ -40,7 +40,7 @@ class MovingPuncturePlusGauge
     params_t m_params;
 
   public:
-    MovingPuncturePlusGauge(const params_t &a_params) : m_params(a_params) {}
+    MovingPunctureGauge(const params_t &a_params) : m_params(a_params) {}
 
     template <class data_t, template <typename> class vars_t,
               template <typename> class diff2_vars_t>
@@ -64,4 +64,4 @@ class MovingPuncturePlusGauge
     }
 };
 
-#endif /* MOVINGPUNCTUREPLUSGAUGE_HPP_ */
+#endif /* MOVINGPUNCTUREGAUGE_HPP_ */

--- a/Source/CCZ4/MovingPunctureGauge.hpp
+++ b/Source/CCZ4/MovingPunctureGauge.hpp
@@ -22,18 +22,20 @@ class MovingPunctureGauge
   public:
     struct params_t
     {
-        double shift_Gamma_coeff = 0.75; //!< Gives the F in \f$\partial_t
-                                         //!  \beta^i =  F B^i\f$
-        double lapse_advec_coeff = 0.;   //!< Switches advection terms in
-                                         //! the lapse condition on/off
-        double shift_advec_coeff = 0.;   //!< Switches advection terms in the
-                                         //! shift condition on/off
-        double eta = 1.; //!< The eta in \f$\partial_t B^i = \partial_t \tilde
-                         //!\Gamma - \eta B^i\f$
+        // lapse params:
+        double lapse_advec_coeff = 0.; //!< Switches advection terms in
+                                       //! the lapse condition on/off
         double lapse_power = 1.; //!< The power p in \f$\partial_t \alpha = - c
                                  //!\alpha^p(K-2\Theta)\f$
         double lapse_coeff = 2.; //!< The coefficient c in \f$\partial_t \alpha
                                  //!= -c \alpha^p(K-2\Theta)\f$
+        // shift params:
+        double shift_Gamma_coeff = 0.75; //!< Gives the F in \f$\partial_t
+                                         //!  \beta^i =  F B^i\f$
+        double shift_advec_coeff = 0.;   //!< Switches advection terms in the
+                                         //! shift condition on/off
+        double eta = 1.; //!< The eta in \f$\partial_t B^i = \partial_t \tilde
+                         //!\Gamma - \eta B^i\f$
     };
 
   protected:

--- a/Source/CCZ4/MovingPuncturePlusGauge.hpp
+++ b/Source/CCZ4/MovingPuncturePlusGauge.hpp
@@ -1,0 +1,67 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef MOVINGPUNCTUREPLUSGAUGE_HPP_
+#define MOVINGPUNCTUREPLUSGAUGE_HPP_
+
+#include "DimensionDefinitions.hpp"
+#include "Tensor.hpp"
+
+/// This is an example of a gauge class that can be used in the CCZ4RHS compute
+/// class
+/**
+ * This class implements a slightly more generic version of the moving puncture
+ * gauge. In particular it uses a Bona-Masso slicing condition of the form
+ * f(lapse) = -c*lapse^(p-2)
+ * and a Gamma-driver shift condition
+ **/
+class MovingPuncturePlusGauge
+{
+  public:
+    struct params_t
+    {
+        double shift_Gamma_coeff = 0.75; //!< Gives the F in \f$\partial_t
+                                         //!  \beta^i =  F B^i\f$
+        double lapse_advec_coeff = 0.;   //!< Switches advection terms in
+                                         //! the lapse condition on/off
+        double shift_advec_coeff = 0.;   //!< Switches advection terms in the
+                                         //! shift condition on/off
+        double eta = 1.; //!< The eta in \f$\partial_t B^i = \partial_t \tilde
+                         //!\Gamma - \eta B^i\f$
+        double lapse_power = 1.; //!< The power p in \f$\partial_t \alpha = - c
+                                 //!\alpha^p(K-2\Theta)\f$
+        double lapse_coeff = 2.; //!< The coefficient c in \f$\partial_t \alpha
+                                 //!= -c \alpha^p(K-2\Theta)\f$
+    };
+
+  protected:
+    params_t m_params;
+
+  public:
+    MovingPuncturePlusGauge(const params_t &a_params) : m_params(a_params) {}
+
+    template <class data_t, template <typename> class vars_t,
+              template <typename> class diff2_vars_t>
+    inline void rhs_gauge(vars_t<data_t> &rhs, const vars_t<data_t> &vars,
+                          const vars_t<Tensor<1, data_t>> &d1,
+                          const diff2_vars_t<Tensor<2, data_t>> &d2,
+                          const vars_t<data_t> &advec) const
+    {
+        rhs.lapse = m_params.lapse_advec_coeff * advec.lapse -
+                    m_params.lapse_coeff *
+                        pow(vars.lapse, m_params.lapse_power) *
+                        (vars.K - 2 * vars.Theta);
+        FOR1(i)
+        {
+            rhs.shift[i] = m_params.shift_advec_coeff * advec.shift[i] +
+                           m_params.shift_Gamma_coeff * vars.B[i];
+            rhs.B[i] = m_params.shift_advec_coeff * advec.B[i] -
+                       m_params.shift_advec_coeff * advec.Gamma[i] +
+                       rhs.Gamma[i] - m_params.eta * vars.B[i];
+        }
+    }
+};
+
+#endif /* MOVINGPUNCTUREPLUSGAUGE_HPP_ */

--- a/Source/GRChomboCore/SimulationParametersBase.hpp
+++ b/Source/GRChomboCore/SimulationParametersBase.hpp
@@ -256,7 +256,7 @@ class SimulationParametersBase : public ChomboParameters
     int formulation; // Whether to use BSSN or CCZ4
 
     // Collection of parameters necessary for the CCZ4 RHS and extraction
-    // Note the gauge parameters are specific to MovingPuncturePlusGauge
+    // Note the gauge parameters are specific to MovingPunctureGauge
     // If you are using a different gauge, you need to load your parameters
     // in your own SimulationParameters class.
     CCZ4_params_t<> ccz4_params;

--- a/Source/GRChomboCore/SimulationParametersBase.hpp
+++ b/Source/GRChomboCore/SimulationParametersBase.hpp
@@ -44,9 +44,11 @@ class SimulationParametersBase : public ChomboParameters
         pp.load("kappa1", ccz4_base_params.kappa1, 0.1);
         pp.load("kappa2", ccz4_base_params.kappa2, 0.0);
         pp.load("kappa3", ccz4_base_params.kappa3, 1.0);
+        pp.load("covariantZ4", ccz4_base_params.covariantZ4, true);
         ccz4_params.kappa1 = ccz4_base_params.kappa1;
         ccz4_params.kappa2 = ccz4_base_params.kappa2;
         ccz4_params.kappa3 = ccz4_base_params.kappa3;
+        ccz4_params.covariantZ4 = ccz4_base_params.covariantZ4;
 
         // Dissipation
         pp.load("sigma", sigma, 0.1);
@@ -167,6 +169,7 @@ class SimulationParametersBase : public ChomboParameters
             warn_parameter("kappa3", ccz4_params.kappa3,
                            ccz4_params.kappa3 == 0.0,
                            "setting to 0.0 as required for BSSN");
+            // no warning necessary for ccz4_params.covariantZ4
             ccz4_params.kappa1 = 0.0;
             ccz4_params.kappa2 = 0.0;
             ccz4_params.kappa3 = 0.0;
@@ -174,23 +177,11 @@ class SimulationParametersBase : public ChomboParameters
 
         // only warn for gauge parameters as there are legitimate cases you may
         // want to deviate from the norm
-        warn_parameter("shift_Gamma_coeff", ccz4_params.shift_Gamma_coeff,
-                       abs(ccz4_params.shift_Gamma_coeff - 0.75) <
-                           std::numeric_limits<double>::epsilon(),
-                       "usually set to 0.75");
         warn_parameter("lapse_advec_coeff", ccz4_params.lapse_advec_coeff,
                        min(abs(ccz4_params.lapse_advec_coeff),
                            abs(ccz4_params.lapse_advec_coeff - 1.0)) <
                            std::numeric_limits<double>::epsilon(),
                        "usually set to 0.0 or 1.0");
-        warn_parameter("shift_advec_coeff", ccz4_params.shift_advec_coeff,
-                       min(abs(ccz4_params.shift_advec_coeff),
-                           abs(ccz4_params.shift_advec_coeff - 1.0)) <
-                           std::numeric_limits<double>::epsilon(),
-                       "usually set to 0.0 or 1.0");
-        warn_parameter("eta", ccz4_params.eta,
-                       ccz4_params.eta > 0.1 && ccz4_params.eta < 10,
-                       "usually O(1/M_ADM) so typically O(1) in code units");
         warn_parameter("lapse_power", ccz4_params.lapse_power,
                        abs(ccz4_params.lapse_power - 1.0) <
                            std::numeric_limits<double>::epsilon(),
@@ -199,6 +190,18 @@ class SimulationParametersBase : public ChomboParameters
                        abs(ccz4_params.lapse_coeff - 2.0) <
                            std::numeric_limits<double>::epsilon(),
                        "set to 2.0 for 1+log slicing");
+        warn_parameter("shift_Gamma_coeff", ccz4_params.shift_Gamma_coeff,
+                       abs(ccz4_params.shift_Gamma_coeff - 0.75) <
+                           std::numeric_limits<double>::epsilon(),
+                       "usually set to 0.75");
+        warn_parameter("shift_advec_coeff", ccz4_params.shift_advec_coeff,
+                       min(abs(ccz4_params.shift_advec_coeff),
+                           abs(ccz4_params.shift_advec_coeff - 1.0)) <
+                           std::numeric_limits<double>::epsilon(),
+                       "usually set to 0.0 or 1.0");
+        warn_parameter("eta", ccz4_params.eta,
+                       ccz4_params.eta > 0.1 && ccz4_params.eta < 10,
+                       "usually O(1/M_ADM) so typically O(1) in code units");
 
         // Now extraction parameters
         FOR1(idir)

--- a/Source/GRChomboCore/SimulationParametersBase.hpp
+++ b/Source/GRChomboCore/SimulationParametersBase.hpp
@@ -41,9 +41,12 @@ class SimulationParametersBase : public ChomboParameters
 
         // CCZ4 parameters
         pp.load("formulation", formulation, 0);
-        pp.load("kappa1", ccz4_params.kappa1, 0.1);
-        pp.load("kappa2", ccz4_params.kappa2, 0.0);
-        pp.load("kappa3", ccz4_params.kappa3, 1.0);
+        pp.load("kappa1", ccz4_base_params.kappa1, 0.1);
+        pp.load("kappa2", ccz4_base_params.kappa2, 0.0);
+        pp.load("kappa3", ccz4_base_params.kappa3, 1.0);
+        ccz4_params.kappa1 = ccz4_base_params.kappa1;
+        ccz4_params.kappa2 = ccz4_base_params.kappa2;
+        ccz4_params.kappa3 = ccz4_base_params.kappa3;
 
         // Dissipation
         pp.load("sigma", sigma, 0.1);
@@ -238,6 +241,11 @@ class SimulationParametersBase : public ChomboParameters
         }
     }
 
+  protected:
+    // This is just the CCZ4 damping parameters in case you want to use
+    // a different gauge (with different parameters)
+    CCZ4_base_params_t ccz4_base_params;
+
   public:
     double sigma; // Kreiss-Oliger dissipation parameter
 
@@ -249,7 +257,9 @@ class SimulationParametersBase : public ChomboParameters
 
     // Collection of parameters necessary for the CCZ4 RHS and extraction
     // Note the gauge parameters are specific to MovingPuncturePlusGauge
-    CCZ4RHS<>::params_t ccz4_params;
+    // If you are using a different gauge, you need to load your parameters
+    // in your own SimulationParameters class.
+    CCZ4_params_t<> ccz4_params;
     SphericalExtraction::params_t extraction_params;
 };
 

--- a/Source/GRChomboCore/SimulationParametersBase.hpp
+++ b/Source/GRChomboCore/SimulationParametersBase.hpp
@@ -8,7 +8,7 @@
 
 // General includes
 #include "BoundaryConditions.hpp"
-#include "CCZ4.hpp"
+#include "CCZ4RHS.hpp"
 #include "ChomboParameters.hpp"
 #include "GRParmParse.hpp"
 #include "SphericalExtraction.hpp"
@@ -248,6 +248,7 @@ class SimulationParametersBase : public ChomboParameters
     int formulation; // Whether to use BSSN or CCZ4
 
     // Collection of parameters necessary for the CCZ4 RHS and extraction
+    // Note the gauge parameters are specific to MovingPuncturePlusGauge
     CCZ4::params_t ccz4_params;
     SphericalExtraction::params_t extraction_params;
 };

--- a/Source/GRChomboCore/SimulationParametersBase.hpp
+++ b/Source/GRChomboCore/SimulationParametersBase.hpp
@@ -137,10 +137,10 @@ class SimulationParametersBase : public ChomboParameters
         // 0.0"); check_parameter("min_lapse", min_lapse, (min_lapse >= 0.0)
         // "must be >= 0.0");
         check_parameter("formulation", formulation,
-                        (formulation == CCZ4::USE_CCZ4) ||
-                            (formulation == CCZ4::USE_BSSN),
+                        (formulation == CCZ4RHS<>::USE_CCZ4) ||
+                            (formulation == CCZ4RHS<>::USE_BSSN),
                         "must be 0 or 1");
-        if (formulation == CCZ4::USE_CCZ4)
+        if (formulation == CCZ4RHS<>::USE_CCZ4)
         {
             warn_parameter(
                 "kappa1", ccz4_params.kappa1, ccz4_params.kappa1 > 0.0,
@@ -151,7 +151,7 @@ class SimulationParametersBase : public ChomboParameters
                            "should be greater than -1.0 to damp constraints "
                            "(see arXiv:1106.2254)");
         }
-        else if (formulation == CCZ4::USE_BSSN)
+        else if (formulation == CCZ4RHS<>::USE_BSSN)
         {
             // maybe we should just set these to zero and print a warning
             // in the BSSN case
@@ -249,7 +249,7 @@ class SimulationParametersBase : public ChomboParameters
 
     // Collection of parameters necessary for the CCZ4 RHS and extraction
     // Note the gauge parameters are specific to MovingPuncturePlusGauge
-    CCZ4::params_t ccz4_params;
+    CCZ4RHS<>::params_t ccz4_params;
     SphericalExtraction::params_t extraction_params;
 };
 

--- a/Source/InitialConditions/ScalarFields/ScalarBubble.hpp
+++ b/Source/InitialConditions/ScalarFields/ScalarBubble.hpp
@@ -8,7 +8,7 @@
 
 #include "Cell.hpp"
 #include "Coordinates.hpp"
-#include "MatterCCZ4.hpp"
+#include "MatterCCZ4RHS.hpp"
 #include "ScalarField.hpp"
 #include "Tensor.hpp"
 #include "UserVariables.hpp" //This files needs NUM_VARS - total no. components

--- a/Source/InitialConditions/ScalarFields/ScalarBubble.impl.hpp
+++ b/Source/InitialConditions/ScalarFields/ScalarBubble.impl.hpp
@@ -19,7 +19,7 @@ inline ScalarBubble::ScalarBubble(params_t a_params, double a_dx)
 template <class data_t>
 void ScalarBubble::compute(Cell<data_t> current_cell) const
 {
-    MatterCCZ4<ScalarField<>>::Vars<data_t> vars;
+    MatterCCZ4RHS<ScalarField<>>::Vars<data_t> vars;
     VarsTools::assign(vars, 0.); // Set only the non-zero components below
     Coordinates<data_t> coords(current_cell, m_dx, m_params.centerSF);
 

--- a/Source/Matter/ChiRelaxation.hpp
+++ b/Source/Matter/ChiRelaxation.hpp
@@ -9,7 +9,7 @@
 #include "CCZ4Geometry.hpp"
 #include "Cell.hpp"
 #include "FourthOrderDerivatives.hpp"
-#include "MatterCCZ4.hpp"
+#include "MatterCCZ4RHS.hpp"
 #include "Tensor.hpp"
 #include "TensorAlgebra.hpp"
 #include "UserVariables.hpp" //This files needs NUM_VARS - total number of components

--- a/Source/Matter/ChiRelaxation.hpp
+++ b/Source/Matter/ChiRelaxation.hpp
@@ -37,10 +37,11 @@ template <class matter_t> class ChiRelaxation
 
     // Use the variable definitions in MatterCCZ4
     template <class data_t>
-    using Vars = typename MatterCCZ4<matter_t>::template Vars<data_t>;
+    using Vars = typename MatterCCZ4RHS<matter_t>::template Vars<data_t>;
 
     template <class data_t>
-    using Diff2Vars = typename MatterCCZ4<matter_t>::template Diff2Vars<data_t>;
+    using Diff2Vars =
+        typename MatterCCZ4RHS<matter_t>::template Diff2Vars<data_t>;
 
   public:
     //! Constructor of class ChiRelaxation

--- a/Source/Matter/MatterCCZ4.hpp
+++ b/Source/Matter/MatterCCZ4.hpp
@@ -1,0 +1,1 @@
+MatterCCZ4RHS.hpp

--- a/Source/Matter/MatterCCZ4RHS.hpp
+++ b/Source/Matter/MatterCCZ4RHS.hpp
@@ -10,7 +10,7 @@
 #include "CCZ4RHS.hpp"
 #include "Cell.hpp"
 #include "FourthOrderDerivatives.hpp"
-#include "MovingPuncturePlusGauge.hpp"
+#include "MovingPunctureGauge.hpp"
 #include "Tensor.hpp"
 #include "TensorAlgebra.hpp"
 #include "UserVariables.hpp" //This files needs NUM_VARS - total number of components
@@ -29,7 +29,7 @@
    an example of a matter_t. \sa CCZ4RHS(), ScalarField()
 */
 
-template <class matter_t, class gauge_t = MovingPuncturePlusGauge,
+template <class matter_t, class gauge_t = MovingPunctureGauge,
           class deriv_t = FourthOrderDerivatives>
 class MatterCCZ4RHS : public CCZ4RHS<gauge_t, deriv_t>
 {

--- a/Source/Matter/MatterCCZ4RHS.hpp
+++ b/Source/Matter/MatterCCZ4RHS.hpp
@@ -114,7 +114,9 @@ class MatterCCZ4RHS : public CCZ4RHS<gauge_t, deriv_t>
 #include "MatterCCZ4RHS.impl.hpp"
 
 // This is here for backwards compatibility though the MatterCCZ4RHS
-// class should be used in future
-template <class matter_t> using MatterCCZ4 = MatterCCZ4RHS<matter_t>;
+// class should be used in future hence mark as deprecated
+template <class matter_t>
+using MatterCCZ4 [[deprecated("Use MatterCCZ4RHS instead")]] =
+    MatterCCZ4RHS<matter_t>;
 
 #endif /* MATTERCCZ4RHS_HPP_ */

--- a/Source/Matter/MatterCCZ4RHS.hpp
+++ b/Source/Matter/MatterCCZ4RHS.hpp
@@ -34,7 +34,10 @@ template <class matter_t, class gauge_t = MovingPuncturePlusGauge,
 class MatterCCZ4RHS : public CCZ4RHS<gauge_t, deriv_t>
 {
   public:
-    using params_t = typename CCZ4RHS<gauge_t, deriv_t>::params_t;
+    // Use this alias for the same template instantiation as this class
+    using CCZ4 = CCZ4RHS<gauge_t, deriv_t>;
+
+    using params_t = typename CCZ4::params_t;
 
     template <class data_t>
     using MatterVars = typename matter_t::template Vars<data_t>;
@@ -42,24 +45,27 @@ class MatterCCZ4RHS : public CCZ4RHS<gauge_t, deriv_t>
     template <class data_t>
     using MatterDiff2Vars = typename matter_t::template Diff2Vars<data_t>;
 
+    template <class data_t> using CCZ4Vars = typename CCZ4::Vars<data_t>;
+
+    template <class data_t>
+    using CCZ4Diff2Vars = typename CCZ4::Diff2Vars<data_t>;
+
     // Inherit the variable definitions from CCZ4RHS + matter_t
     template <class data_t>
-    struct Vars : public CCZ4RHS<gauge_t, deriv_t>::Vars<data_t>,
-                  public MatterVars<data_t>
+    struct Vars : public CCZ4Vars<data_t>, public MatterVars<data_t>
     {
         /// Defines the mapping between members of Vars and Chombo grid
         /// variables (enum in User_Variables)
         template <typename mapping_function_t>
         void enum_mapping(mapping_function_t mapping_function)
         {
-            using CCZ4Vars = typename CCZ4RHS<gauge_t, deriv_t>::Vars<data_t>;
-            CCZ4Vars::enum_mapping(mapping_function);
+            CCZ4Vars<data_t>::enum_mapping(mapping_function);
             MatterVars<data_t>::enum_mapping(mapping_function);
         }
     };
 
     template <class data_t>
-    struct Diff2Vars : public CCZ4RHS<gauge_t, deriv_t>::Diff2Vars<data_t>,
+    struct Diff2Vars : public CCZ4Diff2Vars<data_t>,
                        public MatterDiff2Vars<data_t>
     {
         /// Defines the mapping between members of Vars and Chombo grid
@@ -67,9 +73,7 @@ class MatterCCZ4RHS : public CCZ4RHS<gauge_t, deriv_t>
         template <typename mapping_function_t>
         void enum_mapping(mapping_function_t mapping_function)
         {
-            using CCZ4Diff2Vars =
-                typename CCZ4RHS<gauge_t, deriv_t>::Diff2Vars<data_t>;
-            CCZ4Diff2Vars::enum_mapping(mapping_function);
+            CCZ4Diff2Vars<data_t>::enum_mapping(mapping_function);
             MatterDiff2Vars<data_t>::enum_mapping(mapping_function);
         }
     };

--- a/Source/Matter/MatterCCZ4RHS.hpp
+++ b/Source/Matter/MatterCCZ4RHS.hpp
@@ -3,13 +3,14 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-#ifndef MATTERCCZ4_HPP_
-#define MATTERCCZ4_HPP_
+#ifndef MATTERCCZ4RHS_HPP_
+#define MATTERCCZ4RHS_HPP_
 
-#include "CCZ4.hpp"
 #include "CCZ4Geometry.hpp"
+#include "CCZ4RHS.hpp"
 #include "Cell.hpp"
 #include "FourthOrderDerivatives.hpp"
+#include "MovingPuncturePlusGauge.hpp"
 #include "Tensor.hpp"
 #include "TensorAlgebra.hpp"
 #include "UserVariables.hpp" //This files needs NUM_VARS - total number of components
@@ -20,39 +21,45 @@
 //!  evolution
 /*!
      The class calculates the RHS evolution for all the variables. It inherits
-   from the CCZ4 class, which it uses to do the non matter evolution of
+   from the CCZ4RHS class, which it uses to do the non matter evolution of
    variables. It then adds in the additional matter terms to the CCZ4 evolution
    (those including the stress energy tensor), and calculates the evolution of
    the matter variables. It does not assume a specific form of matter but is
    templated over a matter class matter_t. Please see the class ScalarField as
-   an example of a matter_t. \sa CCZ4(), ScalarField()
+   an example of a matter_t. \sa CCZ4RHS(), ScalarField()
 */
 
-template <class matter_t> class MatterCCZ4 : public CCZ4
+template <class matter_t, class gauge_t = MovingPuncturePlusGauge,
+          class deriv_t = FourthOrderDerivatives>
+class MatterCCZ4RHS : public CCZ4RHS<gauge_t, deriv_t>
 {
   public:
+    using params_t = typename CCZ4RHS<gauge_t, deriv_t>::params_t;
+
     template <class data_t>
     using MatterVars = typename matter_t::template Vars<data_t>;
 
     template <class data_t>
     using MatterDiff2Vars = typename matter_t::template Diff2Vars<data_t>;
 
-    // Inherit the variable definitions from CCZ4 + matter_t
+    // Inherit the variable definitions from CCZ4RHS + matter_t
     template <class data_t>
-    struct Vars : public CCZ4::Vars<data_t>, public MatterVars<data_t>
+    struct Vars : public CCZ4RHS<gauge_t, deriv_t>::Vars<data_t>,
+                  public MatterVars<data_t>
     {
         /// Defines the mapping between members of Vars and Chombo grid
         /// variables (enum in User_Variables)
         template <typename mapping_function_t>
         void enum_mapping(mapping_function_t mapping_function)
         {
-            CCZ4::Vars<data_t>::enum_mapping(mapping_function);
+            using CCZ4Vars = typename CCZ4RHS<gauge_t, deriv_t>::Vars<data_t>;
+            CCZ4Vars::enum_mapping(mapping_function);
             MatterVars<data_t>::enum_mapping(mapping_function);
         }
     };
 
     template <class data_t>
-    struct Diff2Vars : public CCZ4::Diff2Vars<data_t>,
+    struct Diff2Vars : public CCZ4RHS<gauge_t, deriv_t>::Diff2Vars<data_t>,
                        public MatterDiff2Vars<data_t>
     {
         /// Defines the mapping between members of Vars and Chombo grid
@@ -60,7 +67,9 @@ template <class matter_t> class MatterCCZ4 : public CCZ4
         template <typename mapping_function_t>
         void enum_mapping(mapping_function_t mapping_function)
         {
-            CCZ4::Diff2Vars<data_t>::enum_mapping(mapping_function);
+            using CCZ4Diff2Vars =
+                typename CCZ4RHS<gauge_t, deriv_t>::Diff2Vars<data_t>;
+            CCZ4Diff2Vars::enum_mapping(mapping_function);
             MatterDiff2Vars<data_t>::enum_mapping(mapping_function);
         }
     };
@@ -73,8 +82,9 @@ template <class matter_t> class MatterCCZ4 : public CCZ4
        It allows the user to set the value of Newton's constant, which is set to
        one by default.
     */
-    MatterCCZ4(matter_t a_matter, params_t params, double dx, double sigma,
-               int formulation = CCZ4::USE_CCZ4, double G_Newton = 1.0);
+    MatterCCZ4RHS(matter_t a_matter, params_t a_params, double a_dx,
+                  double a_sigma, int a_formulation = CCZ4::USE_CCZ4,
+                  double a_G_Newton = 1.0);
 
     //!  The compute member which calculates the RHS at each point in the box
     //!  \sa matter_rhs_equation()
@@ -97,6 +107,10 @@ template <class matter_t> class MatterCCZ4 : public CCZ4
     const double m_G_Newton; //!< Newton's constant, set to one by default.
 };
 
-#include "MatterCCZ4.impl.hpp"
+#include "MatterCCZ4RHS.impl.hpp"
 
-#endif /* MATTERCCZ4_HPP_ */
+// This is here for backwards compatibility though the MatterCCZ4RHS
+// class should be used in future
+template <class matter_t> using MatterCCZ4 = MatterCCZ4RHS<matter_t>;
+
+#endif /* MATTERCCZ4RHS_HPP_ */

--- a/Source/Matter/MatterCCZ4RHS.hpp
+++ b/Source/Matter/MatterCCZ4RHS.hpp
@@ -37,7 +37,7 @@ class MatterCCZ4RHS : public CCZ4RHS<gauge_t, deriv_t>
     // Use this alias for the same template instantiation as this class
     using CCZ4 = CCZ4RHS<gauge_t, deriv_t>;
 
-    using params_t = CCZ4_params_t<gauge_t>;
+    using params_t = CCZ4_params_t<typename gauge_t::params_t>;
 
     template <class data_t>
     using MatterVars = typename matter_t::template Vars<data_t>;
@@ -45,10 +45,11 @@ class MatterCCZ4RHS : public CCZ4RHS<gauge_t, deriv_t>
     template <class data_t>
     using MatterDiff2Vars = typename matter_t::template Diff2Vars<data_t>;
 
-    template <class data_t> using CCZ4Vars = typename CCZ4::Vars<data_t>;
+    template <class data_t>
+    using CCZ4Vars = typename CCZ4::template Vars<data_t>;
 
     template <class data_t>
-    using CCZ4Diff2Vars = typename CCZ4::Diff2Vars<data_t>;
+    using CCZ4Diff2Vars = typename CCZ4::template Diff2Vars<data_t>;
 
     // Inherit the variable definitions from CCZ4RHS + matter_t
     template <class data_t>

--- a/Source/Matter/MatterCCZ4RHS.hpp
+++ b/Source/Matter/MatterCCZ4RHS.hpp
@@ -37,7 +37,7 @@ class MatterCCZ4RHS : public CCZ4RHS<gauge_t, deriv_t>
     // Use this alias for the same template instantiation as this class
     using CCZ4 = CCZ4RHS<gauge_t, deriv_t>;
 
-    using params_t = typename CCZ4::params_t;
+    using params_t = CCZ4_params_t<gauge_t>;
 
     template <class data_t>
     using MatterVars = typename matter_t::template Vars<data_t>;

--- a/Source/Matter/MatterCCZ4RHS.impl.hpp
+++ b/Source/Matter/MatterCCZ4RHS.impl.hpp
@@ -13,8 +13,8 @@
 
 template <class matter_t, class gauge_t, class deriv_t>
 MatterCCZ4RHS<matter_t, gauge_t, deriv_t>::MatterCCZ4RHS(
-    matter_t a_matter, params_t a_params, double a_dx, double a_sigma,
-    int a_formulation, double a_G_Newton)
+    matter_t a_matter, CCZ4_params_t<gauge_t> a_params, double a_dx,
+    double a_sigma, int a_formulation, double a_G_Newton)
     : CCZ4RHS<gauge_t, deriv_t>(a_params, a_dx, a_sigma, a_formulation,
                                 0.0 /*No cosmological constant*/),
       my_matter(a_matter), m_G_Newton(a_G_Newton)

--- a/Source/Matter/MatterCCZ4RHS.impl.hpp
+++ b/Source/Matter/MatterCCZ4RHS.impl.hpp
@@ -3,36 +3,39 @@
  * Please refer to LICENSE in GRChombo's root directory.
  */
 
-#if !defined(MATTERCCZ4_HPP_)
-#error "This file should only be included through MatterCCZ4.hpp"
+#if !defined(MATTERCCZ4RHS_HPP_)
+#error "This file should only be included through MatterCCZ4RHS.hpp"
 #endif
 
-#ifndef MATTERCCZ4_IMPL_HPP_
-#define MATTERCCZ4_IMPL_HPP_
+#ifndef MATTERCCZ4RHS_IMPL_HPP_
+#define MATTERCCZ4RHS_IMPL_HPP_
 #include "DimensionDefinitions.hpp"
 
-template <class matter_t>
-MatterCCZ4<matter_t>::MatterCCZ4(matter_t a_matter, params_t params, double dx,
-                                 double sigma, int formulation, double G_Newton)
-    : CCZ4(params, dx, sigma, formulation, 0.0 /*No cosmological constant*/),
-      my_matter(a_matter), m_G_Newton(G_Newton)
+template <class matter_t, class gauge_t, class deriv_t>
+MatterCCZ4RHS<matter_t, gauge_t, deriv_t>::MatterCCZ4RHS(
+    matter_t a_matter, params_t a_params, double a_dx, double a_sigma,
+    int a_formulation, double a_G_Newton)
+    : CCZ4RHS<gauge_t, deriv_t>(a_params, a_dx, a_sigma, a_formulation,
+                                0.0 /*No cosmological constant*/),
+      my_matter(a_matter), m_G_Newton(a_G_Newton)
 {
 }
 
-template <class matter_t>
+template <class matter_t, class gauge_t, class deriv_t>
 template <class data_t>
-void MatterCCZ4<matter_t>::compute(Cell<data_t> current_cell) const
+void MatterCCZ4RHS<matter_t, gauge_t, deriv_t>::compute(
+    Cell<data_t> current_cell) const
 {
     // copy data from chombo gridpoint into local variables
     const auto matter_vars = current_cell.template load_vars<Vars>();
-    const auto d1 = m_deriv.template diff1<Vars>(current_cell);
-    const auto d2 = m_deriv.template diff2<Diff2Vars>(current_cell);
+    const auto d1 = this->m_deriv.template diff1<Vars>(current_cell);
+    const auto d2 = this->m_deriv.template diff2<Diff2Vars>(current_cell);
     const auto advec =
-        m_deriv.template advection<Vars>(current_cell, matter_vars.shift);
+        this->m_deriv.template advection<Vars>(current_cell, matter_vars.shift);
 
     // Call CCZ4 RHS - work out RHS without matter, no dissipation
     Vars<data_t> matter_rhs;
-    rhs_equation(matter_rhs, matter_vars, d1, d2, advec);
+    this->rhs_equation(matter_rhs, matter_vars, d1, d2, advec);
 
     // add RHS matter terms from EM Tensor
     add_emtensor_rhs(matter_rhs, matter_vars, d1);
@@ -41,16 +44,16 @@ void MatterCCZ4<matter_t>::compute(Cell<data_t> current_cell) const
     my_matter.add_matter_rhs(matter_rhs, matter_vars, d1, d2, advec);
 
     // Add dissipation to all terms
-    m_deriv.add_dissipation(matter_rhs, current_cell, m_sigma);
+    this->m_deriv.add_dissipation(matter_rhs, current_cell, this->m_sigma);
 
     // Write the rhs into the output FArrayBox
     current_cell.store_vars(matter_rhs);
 }
 
 // Function to add in EM Tensor matter terms to CCZ4 rhs
-template <class matter_t>
+template <class matter_t, class gauge_t, class deriv_t>
 template <class data_t>
-void MatterCCZ4<matter_t>::add_emtensor_rhs(
+void MatterCCZ4RHS<matter_t, gauge_t, deriv_t>::add_emtensor_rhs(
     Vars<data_t> &matter_rhs, const Vars<data_t> &matter_vars,
     const Vars<Tensor<1, data_t>> &d1) const
 {
@@ -64,7 +67,7 @@ void MatterCCZ4<matter_t>::add_emtensor_rhs(
         my_matter.compute_emtensor(matter_vars, d1, h_UU, chris.ULL);
 
     // Update RHS for K and Theta depending on formulation
-    if (m_formulation == USE_BSSN)
+    if (this->m_formulation == CCZ4::USE_BSSN)
     {
         matter_rhs.K += 4.0 * M_PI * m_G_Newton * matter_vars.lapse *
                         (emtensor.S + emtensor.rho);
@@ -102,4 +105,4 @@ void MatterCCZ4<matter_t>::add_emtensor_rhs(
     }
 }
 
-#endif /* MATTERCCZ4_IMPL_HPP_ */
+#endif /* MATTERCCZ4RHS_IMPL_HPP_ */

--- a/Source/Matter/MatterCCZ4RHS.impl.hpp
+++ b/Source/Matter/MatterCCZ4RHS.impl.hpp
@@ -67,7 +67,7 @@ void MatterCCZ4RHS<matter_t, gauge_t, deriv_t>::add_emtensor_rhs(
         my_matter.compute_emtensor(matter_vars, d1, h_UU, chris.ULL);
 
     // Update RHS for K and Theta depending on formulation
-    if (this->m_formulation == CCZ4::USE_BSSN)
+    if (this->m_formulation == CCZ4RHS<>::USE_BSSN)
     {
         matter_rhs.K += 4.0 * M_PI * m_G_Newton * matter_vars.lapse *
                         (emtensor.S + emtensor.rho);

--- a/Source/Matter/MatterCCZ4RHS.impl.hpp
+++ b/Source/Matter/MatterCCZ4RHS.impl.hpp
@@ -13,8 +13,8 @@
 
 template <class matter_t, class gauge_t, class deriv_t>
 MatterCCZ4RHS<matter_t, gauge_t, deriv_t>::MatterCCZ4RHS(
-    matter_t a_matter, CCZ4_params_t<gauge_t> a_params, double a_dx,
-    double a_sigma, int a_formulation, double a_G_Newton)
+    matter_t a_matter, CCZ4_params_t<typename gauge_t::params_t> a_params,
+    double a_dx, double a_sigma, int a_formulation, double a_G_Newton)
     : CCZ4RHS<gauge_t, deriv_t>(a_params, a_dx, a_sigma, a_formulation,
                                 0.0 /*No cosmological constant*/),
       my_matter(a_matter), m_G_Newton(a_G_Newton)

--- a/Source/Matter/MatterConstraints.hpp
+++ b/Source/Matter/MatterConstraints.hpp
@@ -24,7 +24,10 @@
    For an example of a matter_t class see ScalarField. \sa Constraints(),
    ScalarField()
 */
-template <class matter_t> class MatterConstraints : public Constraints
+template <class matter_t>
+class [[deprecated("Use new MatterConstraints class in "
+                   "NewMatterConstraints.hpp")]] MatterConstraints
+    : public Constraints
 {
   public:
     template <class data_t>

--- a/Tests/CppChFComparison/CCZ4Test.cpp
+++ b/Tests/CppChFComparison/CCZ4Test.cpp
@@ -199,7 +199,7 @@ int main()
         }
     }
 
-    CCZ4_params_t<MovingPunctureGauge> params;
+    CCZ4_params_t<MovingPunctureGauge::params_t> params;
     params.kappa1 = 0.1;
     params.kappa2 = 0;
     params.kappa3 = 1;

--- a/Tests/CppChFComparison/CCZ4Test.cpp
+++ b/Tests/CppChFComparison/CCZ4Test.cpp
@@ -199,7 +199,7 @@ int main()
         }
     }
 
-    CCZ4_params_t<MovingPuncturePlusGauge> params;
+    CCZ4_params_t<MovingPunctureGauge> params;
     params.kappa1 = 0.1;
     params.kappa2 = 0;
     params.kappa3 = 1;
@@ -213,9 +213,9 @@ int main()
     struct timeval begin, end;
     gettimeofday(&begin, NULL);
 
-    BoxLoops::loop(CCZ4RHS<MovingPuncturePlusGauge, FourthOrderDerivatives>(
-                       params, dx, sigma),
-                   in_fab, out_fab);
+    BoxLoops::loop(
+        CCZ4RHS<MovingPunctureGauge, FourthOrderDerivatives>(params, dx, sigma),
+        in_fab, out_fab);
 
     gettimeofday(&end, NULL);
 

--- a/Tests/CppChFComparison/CCZ4Test.cpp
+++ b/Tests/CppChFComparison/CCZ4Test.cpp
@@ -213,7 +213,9 @@ int main()
     struct timeval begin, end;
     gettimeofday(&begin, NULL);
 
-    BoxLoops::loop(CCZ4(params, dx, sigma), in_fab, out_fab);
+    BoxLoops::loop(CCZ4RHS<MovingPuncturePlusGauge, FourthOrderDerivatives>(
+                       params, dx, sigma),
+                   in_fab, out_fab);
 
     gettimeofday(&end, NULL);
 

--- a/Tests/CppChFComparison/CCZ4Test.cpp
+++ b/Tests/CppChFComparison/CCZ4Test.cpp
@@ -17,7 +17,7 @@
 
 // Our includes
 #include "BoxLoops.hpp"
-#include "CCZ4.hpp"
+#include "CCZ4RHS.hpp"
 #include "GRBSSNChomboF_F.H"
 
 // Chombo namespace

--- a/Tests/CppChFComparison/CCZ4Test.cpp
+++ b/Tests/CppChFComparison/CCZ4Test.cpp
@@ -199,7 +199,7 @@ int main()
         }
     }
 
-    CCZ4::params_t params;
+    CCZ4_params_t<MovingPuncturePlusGauge> params;
     params.kappa1 = 0.1;
     params.kappa2 = 0;
     params.kappa3 = 1;

--- a/Tests/KclBssnTests/BSSNTest.cpp
+++ b/Tests/KclBssnTests/BSSNTest.cpp
@@ -216,7 +216,7 @@ int main()
         }
     }
 
-    CCZ4::params_t params;
+    CCZ4_params_t<MovingPuncturePlusGauge> params;
     params.kappa1 = 0.0;
     params.kappa2 = 0.0;
     params.kappa3 = 0.0;

--- a/Tests/KclBssnTests/BSSNTest.cpp
+++ b/Tests/KclBssnTests/BSSNTest.cpp
@@ -241,10 +241,11 @@ int main()
     typedef ScalarField<Potential> ScalarFieldWithPotential;
     Potential my_potential(potential_params);
     ScalarFieldWithPotential my_scalar_field(my_potential);
-    BoxLoops::loop(MatterCCZ4<ScalarFieldWithPotential>(my_scalar_field, params,
-                                                        dx, sigma, formulation,
-                                                        G_Newton),
-                   in_fab, out_fab);
+    BoxLoops::loop(
+        MatterCCZ4RHS<ScalarFieldWithPotential, MovingPuncturePlusGauge,
+                      FourthOrderDerivatives>(my_scalar_field, params, dx,
+                                              sigma, formulation, G_Newton),
+        in_fab, out_fab);
     BoxLoops::loop(MatterConstraints<ScalarFieldWithPotential>(my_scalar_field,
                                                                dx, G_Newton),
                    in_fab, out_fab);

--- a/Tests/KclBssnTests/BSSNTest.cpp
+++ b/Tests/KclBssnTests/BSSNTest.cpp
@@ -216,7 +216,7 @@ int main()
         }
     }
 
-    CCZ4_params_t<MovingPunctureGauge> params;
+    CCZ4_params_t<MovingPunctureGauge::params_t> params;
     params.kappa1 = 0.0;
     params.kappa2 = 0.0;
     params.kappa3 = 0.0;

--- a/Tests/KclBssnTests/BSSNTest.cpp
+++ b/Tests/KclBssnTests/BSSNTest.cpp
@@ -14,7 +14,7 @@
 #endif
 
 #include "BoxLoops.hpp"
-#include "MatterCCZ4.hpp"
+#include "MatterCCZ4RHS.hpp"
 #include "MatterConstraints.hpp"
 #include "Potential.hpp"
 #include "ScalarField.hpp"

--- a/Tests/KclBssnTests/BSSNTest.cpp
+++ b/Tests/KclBssnTests/BSSNTest.cpp
@@ -216,7 +216,7 @@ int main()
         }
     }
 
-    CCZ4_params_t<MovingPuncturePlusGauge> params;
+    CCZ4_params_t<MovingPunctureGauge> params;
     params.kappa1 = 0.0;
     params.kappa2 = 0.0;
     params.kappa3 = 0.0;
@@ -241,11 +241,11 @@ int main()
     typedef ScalarField<Potential> ScalarFieldWithPotential;
     Potential my_potential(potential_params);
     ScalarFieldWithPotential my_scalar_field(my_potential);
-    BoxLoops::loop(
-        MatterCCZ4RHS<ScalarFieldWithPotential, MovingPuncturePlusGauge,
-                      FourthOrderDerivatives>(my_scalar_field, params, dx,
-                                              sigma, formulation, G_Newton),
-        in_fab, out_fab);
+    BoxLoops::loop(MatterCCZ4RHS<ScalarFieldWithPotential, MovingPunctureGauge,
+                                 FourthOrderDerivatives>(my_scalar_field,
+                                                         params, dx, sigma,
+                                                         formulation, G_Newton),
+                   in_fab, out_fab);
     BoxLoops::loop(
         MatterConstraints<ScalarFieldWithPotential>(
             my_scalar_field, dx, G_Newton, c_Ham, Interval(c_Mom1, c_Mom3)),

--- a/Tests/KclBssnTests/BSSNTest.cpp
+++ b/Tests/KclBssnTests/BSSNTest.cpp
@@ -15,7 +15,7 @@
 
 #include "BoxLoops.hpp"
 #include "MatterCCZ4RHS.hpp"
-#include "MatterConstraints.hpp"
+#include "NewMatterConstraints.hpp"
 #include "Potential.hpp"
 #include "ScalarField.hpp"
 #include "SetValue.hpp"
@@ -246,10 +246,12 @@ int main()
                       FourthOrderDerivatives>(my_scalar_field, params, dx,
                                               sigma, formulation, G_Newton),
         in_fab, out_fab);
-    BoxLoops::loop(MatterConstraints<ScalarFieldWithPotential>(my_scalar_field,
-                                                               dx, G_Newton),
-                   in_fab, out_fab);
-    BoxLoops::loop(Constraints(dx), in_fab, out_fab_ccz4constraints);
+    BoxLoops::loop(
+        MatterConstraints<ScalarFieldWithPotential>(
+            my_scalar_field, dx, G_Newton, c_Ham, Interval(c_Mom1, c_Mom3)),
+        in_fab, out_fab);
+    BoxLoops::loop(Constraints(dx, c_Ham, Interval(c_Mom1, c_Mom3)), in_fab,
+                   out_fab_ccz4constraints);
     out_fab -= out_fab_ccz4constraints; // so as to test only matter additions
 
     gettimeofday(&end, NULL);

--- a/Tests/KclWeyl4Test/Weyl4Test.cpp
+++ b/Tests/KclWeyl4Test/Weyl4Test.cpp
@@ -202,17 +202,6 @@ int main()
         }
     }
 
-    CCZ4::params_t params;
-    params.kappa1 = 00.0;
-    params.kappa2 = 00.0;
-    params.kappa3 = 00.0;
-    params.shift_Gamma_coeff = 0.75;
-    params.lapse_advec_coeff = 1.0;
-    params.lapse_power = 1.0;
-    params.lapse_coeff = 2.0;
-    params.shift_advec_coeff = 0.0;
-    params.eta = 1.0;
-
     Real null = 0;
 
     std::array<double, CH_SPACEDIM> centerGW = {0, 0, 0};

--- a/Tests/KclWeyl4Test/Weyl4Test.cpp
+++ b/Tests/KclWeyl4Test/Weyl4Test.cpp
@@ -14,7 +14,7 @@
 #include <sys/time.h>
 
 #include "BoxLoops.hpp"
-#include "CCZ4.hpp"
+#include "CCZ4RHS.hpp"
 #include "GravWavDecF_F.H"
 #include "SetValue.hpp"
 #include "UserVariables.hpp"


### PR DESCRIPTION
This resolves #146 by templating the `CCZ4RHS` (formerly called `CCZ4`) class over a `gauge_t` template parameter. Additionally in anticipation of sixth order derivatives, this class is also templated over a `deriv_t` type defaulted to `FourthOrderDerivatives`. The `MatterCCZ4RHS` is templated similarly (in addition to its existing `matter_t` template).  The existing gauge conditions have been moved to a new `MovingPuncturePlusGauge` class which is the default for the `gauge_t` template parameter.

For backwards compatibility, the old `CCZ4` and `MatterCCZ4` classes are defined using an alias but they are marked as `deprecated` (so, if used, the compiler will issue a warning but compilation won't break). 

In order to make the CCZ4 parameter struct not depend on the `deriv_t` template, its definition has moved from `CCZ4::params_t` to `CCZ4_params_t` struct defined outside of the `CCZ4RHS` class. This is also templated over a `gauge_t` template parameter and inherits from `gauge_t::params_t` and `CCZ4_base_params_t` (which has the damping parameters). Note that since these gauge parameters are loaded in `SimulationParametersBase`, if you want to define your own gauge with different parameters, these will need to be loaded elsewhere.

Note that the changes to the evolution equations in this PR are tested by the BSSN Test and the CCZ4 Test (at least for the parameters in the test).