### PR TITLE
Add TwoPunctures integration

### DIFF
--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -18,6 +18,7 @@
 #include "SetValue.hpp"
 #include "SmallDataIO.hpp"
 #include "TraceARemoval.hpp"
+#include "TwoPuncturesInitialData.hpp"
 #include "Weyl4.hpp"
 #include "WeylExtraction.hpp"
 
@@ -41,7 +42,13 @@ void BinaryBHLevel::initialData()
     CH_TIME("BinaryBHLevel::initialData");
     if (m_verbosity)
         pout() << "BinaryBHLevel::initialData " << m_level << endl;
-
+#ifdef USE_TWOPUNCTURES
+    TwoPuncturesInitialData two_punctures_initial_data(
+        m_dx, m_p.center, m_tp_amr.m_two_punctures);
+    // Can't use simd with this initial data
+    BoxLoops::loop(two_punctures_initial_data, m_state_new, m_state_new,
+                   INCLUDE_GHOST_CELLS, disable_simd());
+#else
     // Set up the compute class for the BinaryBH initial data
     BinaryBH binary(m_p.bh1_params, m_p.bh2_params, m_dx);
 
@@ -49,6 +56,7 @@ void BinaryBHLevel::initialData()
     // then calculate initial data
     BoxLoops::loop(make_compute_pack(SetValue(0.), binary), m_state_new,
                    m_state_new, INCLUDE_GHOST_CELLS);
+#endif
 }
 
 // Calculate RHS during RK4 substeps
@@ -84,8 +92,14 @@ void BinaryBHLevel::computeTaggingCriterion(FArrayBox &tagging_criterion,
 {
     if (m_p.track_punctures)
     {
-        const vector<double> puncture_masses = {m_p.bh1_params.mass,
-                                                m_p.bh2_params.mass};
+        std::vector<double> puncture_masses;
+#ifdef USE_TWOPUNCTURES
+        // use calculated bare masses from TwoPunctures
+        puncture_masses = {m_tp_amr.m_two_punctures.mm,
+                           m_tp_amr.m_two_punctures.mp};
+#else
+        puncture_masses = {m_p.bh1_params.mass, m_p.bh2_params.mass};
+#endif /* USE_TWOPUNCTURES */
         auto puncture_coords =
             m_bh_amr.m_puncture_tracker.get_puncture_coords();
         BoxLoops::loop(ChiPunctureExtractionTaggingCriterion(

--- a/Examples/BinaryBH/BinaryBHLevel.hpp
+++ b/Examples/BinaryBH/BinaryBHLevel.hpp
@@ -6,9 +6,9 @@
 #ifndef BINARYBHLEVEL_HPP_
 #define BINARYBHLEVEL_HPP_
 
-#include "BHAMR.hpp"
 #include "DefaultLevelFactory.hpp"
 #include "GRAMRLevel.hpp"
+#include "TPAMR.hpp"
 
 class BinaryBHLevel : public GRAMRLevel
 {
@@ -17,6 +17,9 @@ class BinaryBHLevel : public GRAMRLevel
     using GRAMRLevel::GRAMRLevel;
 
     BHAMR &m_bh_amr = dynamic_cast<BHAMR &>(m_gr_amr);
+#ifdef USE_TWOPUNCTURES
+    TPAMR &m_tp_amr = dynamic_cast<TPAMR &>(m_gr_amr);
+#endif /* USE_TWOPUNCTURES */
 
     /// Things to do at every full timestep
     ///(might include several substeps, e.g. in RK4)

--- a/Examples/BinaryBH/BinaryBHLevel.hpp
+++ b/Examples/BinaryBH/BinaryBHLevel.hpp
@@ -8,6 +8,7 @@
 
 #include "DefaultLevelFactory.hpp"
 #include "GRAMRLevel.hpp"
+// TPAMR.hpp includes BHAMR.hpp
 #include "TPAMR.hpp"
 
 class BinaryBHLevel : public GRAMRLevel

--- a/Examples/BinaryBH/GNUmakefile
+++ b/Examples/BinaryBH/GNUmakefile
@@ -6,6 +6,21 @@
 # Included makefiles need an absolute path to the Chombo installation
 # CHOMBO_HOME := Please set the CHOMBO_HOME locally (e.g. export CHOMBO_HOME=... in bash)
 
+# Figure out whether to build with Two Punctures
+ifdef TWOPUNCTURES_SOURCE
+ifneq (,$(wildcard $(TWOPUNCTURES_SOURCE)/TwoPunctures.hpp))
+  $(info ================== Using TwoPunctures ==================)
+  USE_TWOPUNCTURES := TRUE
+  # Note this code requires linking with the GNU Scientific Library
+  # In addition to the line below, the include paths to the relevant header
+  # files might also need to be passed to the preprocessor/compiler
+  XTRALIBFLAGS = -lgsl
+  cxxcppflags = -DUSE_TWOPUNCTURES
+else
+  $(error TWOPUNCTURES_SOURCE not set correctly)
+endif
+endif
+
 GRCHOMBO_SOURCE = ../../Source
 
 ebase := Main_BinaryBH
@@ -21,5 +36,9 @@ src_dirs := $(GRCHOMBO_SOURCE)/utils \
             $(GRCHOMBO_SOURCE)/TaggingCriteria  \
             $(GRCHOMBO_SOURCE)/InitialConditions/BlackHoles \
             $(GRCHOMBO_SOURCE)/BlackHoles
+
+ifeq ($(USE_TWOPUNCTURES),TRUE)
+  src_dirs += $(TWOPUNCTURES_SOURCE)
+endif
 
 include $(CHOMBO_HOME)/mk/Make.test

--- a/Examples/BinaryBH/Main_BinaryBH.cpp
+++ b/Examples/BinaryBH/Main_BinaryBH.cpp
@@ -12,12 +12,12 @@
 #include <iostream>
 
 // Our includes
-#include "BHAMR.hpp"
 #include "DefaultLevelFactory.hpp"
 #include "GRParmParse.hpp"
 #include "MultiLevelTask.hpp"
 #include "SetupFunctions.hpp"
 #include "SimulationParameters.hpp"
+#include "TPAMR.hpp" // TPAMR code conditional compiled on USE_TWOPUNCTURES
 
 // Problem specific includes:
 #include "BinaryBHLevel.hpp"
@@ -36,7 +36,15 @@ int runGRChombo(int argc, char *argv[])
     if (sim_params.just_check_params)
         return 0;
 
+#ifdef USE_TWOPUNCTURES
+    TPAMR bh_amr;
+    bh_amr.set_two_punctures_parameters(sim_params.tp_params);
+    // Run TwoPunctures solver
+    bh_amr.m_two_punctures.Run();
+#else
     BHAMR bh_amr;
+#endif
+
     // must be before 'setupAMRObject' to define punctures for tagging criteria
     if (sim_params.track_punctures)
     {

--- a/Examples/BinaryBH/Main_BinaryBH.cpp
+++ b/Examples/BinaryBH/Main_BinaryBH.cpp
@@ -17,6 +17,7 @@
 #include "MultiLevelTask.hpp"
 #include "SetupFunctions.hpp"
 #include "SimulationParameters.hpp"
+// TPAMR.hpp includes BHAMR.hpp
 #include "TPAMR.hpp" // TPAMR code conditional compiled on USE_TWOPUNCTURES
 
 // Problem specific includes:

--- a/Examples/BinaryBH/README.md
+++ b/Examples/BinaryBH/README.md
@@ -1,0 +1,25 @@
+# Using TwoPunctures initial data with this example
+
+To build this example with [TwoPunctures](https://github.com/GRChombo/TwoPunctures)
+initial data, set the environment variable `TWOPUNCTURES_SOURCE` to the Source
+subdirectory of the local clone of the [TwoPunctures repository](https://github.com/GRChombo/TwoPunctures)
+e.g.
+```bash
+export TWOPUNCTURES_SOURCE=/path/to/TwoPunctures/Source
+```
+Then, simply build as normal e.g.
+```bash
+make all -j 4
+```
+To stop using TwoPunctures, undefine the `TWOPUNCTURES_SOURCE` environment variable:
+```bash
+unset TWOPUNCTURES_SOURCE
+```
+Alternatively, you can avoid defining an environment variable by defining it in
+the make command:
+```bash
+make all -j 4 TWOPUNCTURES_SOURCE=/path/to/TwoPunctures/Source
+```
+Note that the parameter names for TwoPunctures initial data differ to that of
+the vanilla example: see [params_two_punctures.txt](./params_two_punctures.txt)
+for the parameter names.

--- a/Examples/BinaryBH/SimulationParameters.hpp
+++ b/Examples/BinaryBH/SimulationParameters.hpp
@@ -13,18 +13,178 @@
 // Problem specific includes:
 #include "ArrayTools.hpp"
 #include "BoostedBH.hpp"
+#ifdef USE_TWOPUNCTURES
+#include "TP_Parameters.hpp"
+#endif
 
 class SimulationParameters : public SimulationParametersBase
 {
   public:
     SimulationParameters(GRParmParse &pp) : SimulationParametersBase(pp)
     {
-        read_params(pp);
+        read_shared_params(pp);
+#ifdef USE_TWOPUNCTURES
+        read_tp_params(pp);
+#else
+        read_bh_params(pp);
+#endif
         check_params();
     }
 
-    /// Read parameters from the parameter file
-    void read_params(GRParmParse &pp)
+    /// Read shared parameters
+    void read_shared_params(GRParmParse &pp)
+    {
+        // Do we want Weyl extraction, puncture tracking and constraint norm
+        // calculation?
+        pp.load("activate_extraction", activate_extraction, false);
+        pp.load("track_punctures", track_punctures, false);
+        pp.load("puncture_tracking_level", puncture_tracking_level, max_level);
+        pp.load("calculate_constraint_norms", calculate_constraint_norms,
+                false);
+    }
+
+#ifdef USE_TWOPUNCTURES
+    void read_tp_params(GRParmParse &pp)
+    {
+        tp_params.verbose = (verbosity > 0);
+        // check whether to calculate the target ADM masses or use provided bare
+        // masses
+        bool calculate_target_masses;
+        pp.load("TP_calculate_target_masses", calculate_target_masses, false);
+        tp_params.give_bare_mass = !calculate_target_masses;
+
+        // masses
+        if (calculate_target_masses)
+        {
+            pp.load("TP_target_mass_plus", tp_params.target_M_plus);
+            pp.load("TP_target_mass_minus", tp_params.target_M_minus);
+            pp.load("TP_adm_tol", tp_params.adm_tol, 1e-10);
+            pout() << "The black holes have target ADM masses of "
+                   << tp_params.target_M_plus << " and "
+                   << tp_params.target_M_minus << "\n";
+            bh1_params.mass = tp_params.target_M_minus;
+            bh2_params.mass = tp_params.target_M_plus;
+        }
+        else
+        {
+            pp.load("TP_mass_plus", tp_params.par_m_plus);
+            pp.load("TP_mass_minus", tp_params.par_m_minus);
+            bh1_params.mass = tp_params.par_m_plus;
+            bh2_params.mass = tp_params.par_m_minus;
+            pout() << "The black holes have bare masses of "
+                   << std::setprecision(16) << tp_params.par_m_plus << " and "
+                   << tp_params.par_m_minus << "\n";
+            // reset precision
+            pout() << std::setprecision(6);
+        }
+
+        // BH spin and momenta
+        std::array<double, CH_SPACEDIM> spin_minus, spin_plus;
+        pp.load("TP_momentum_minus", bh1_params.momentum);
+        pp.load("TP_momentum_plus", bh2_params.momentum);
+        pp.load("TP_spin_plus", spin_plus);
+        pp.load("TP_spin_minus", spin_minus);
+        FOR1(i)
+        {
+            tp_params.par_P_minus[i] = bh1_params.momentum[i];
+            tp_params.par_P_plus[i] = bh2_params.momentum[i];
+            tp_params.par_S_minus[i] = spin_minus[i];
+            tp_params.par_S_plus[i] = spin_plus[i];
+        }
+
+        pout() << "The corresponding momenta are:";
+        pout() << "\nP_plus = ";
+        FOR1(i) { pout() << tp_params.par_P_plus[i] << " "; }
+        pout() << "\nP_minus = ";
+        FOR1(i) { pout() << tp_params.par_P_minus[i] << " "; }
+
+        pout() << "\nThe corresponding spins are:";
+        pout() << "\nS_plus = ";
+        FOR1(i) { pout() << tp_params.par_S_plus[i] << " "; }
+        pout() << "\nS_minus = ";
+        FOR1(i) { pout() << tp_params.par_S_minus[i] << " "; }
+        pout() << "\n";
+
+        // interpolation type
+        bool use_spectral_interpolation;
+        pp.load("TP_use_spectral_interpolation", use_spectral_interpolation,
+                false);
+        tp_params.grid_setup_method =
+            (use_spectral_interpolation) ? "evaluation" : "Taylor expansion";
+
+        // initial_lapse (default to psi^n)
+        pp.load("TP_initial_lapse", tp_params.initial_lapse,
+                std::string("psi^n"));
+        if (tp_params.initial_lapse != "twopunctures-antisymmetric" &&
+            tp_params.initial_lapse != "twopunctures-averaged" &&
+            tp_params.initial_lapse != "psi^n" &&
+            tp_params.initial_lapse != "brownsville")
+        {
+            std::string message = "Parameter: TP_initial_lapse: ";
+            message += tp_params.initial_lapse;
+            message += " invalid";
+            MayDay::Error(message.c_str());
+        }
+        if (tp_params.initial_lapse == "psi^n")
+        {
+            pp.load("TP_initial_lapse_psi_exponent",
+                    tp_params.initial_lapse_psi_exponent, -2.0);
+        }
+
+        // Spectral grid parameters
+        pp.load("TP_npoints_A", tp_params.npoints_A, 30);
+        pp.load("TP_npoints_B", tp_params.npoints_B, 30);
+        pp.load("TP_npoints_phi", tp_params.npoints_phi, 16);
+        if (tp_params.npoints_phi % 4 != 0)
+        {
+            MayDay::Error("TP_npoints_phi must be a multiple of 4");
+        }
+
+        // Solver parameters and tolerances
+        pp.load("TP_Newton_tol", tp_params.Newton_tol, 1e-10);
+        pp.load("TP_Newton_maxit", tp_params.Newton_maxit, 5);
+        pp.load("TP_epsilon", tp_params.TP_epsilon, 1e-6);
+        pp.load("TP_Tiny", tp_params.TP_Tiny, 0.0);
+        pp.load("TP_Extend_Radius", tp_params.TP_Extend_Radius, 0.0);
+
+        // BH positions
+        pp.load("TP_offset_minus", tp_offset_minus);
+        pp.load("TP_offset_plus", tp_offset_plus);
+        bh1_params.center = center;
+        bh2_params.center = center;
+        bh1_params.center[0] += tp_offset_minus;
+        bh2_params.center[0] += tp_offset_plus;
+        double center_offset_x = 0.5 * (tp_offset_plus + tp_offset_minus);
+        tp_params.center_offset[0] = center_offset_x;
+        // par_b is half the distance between BH_minus and BH_plus
+        tp_params.par_b = 0.5 * (tp_offset_plus - tp_offset_minus);
+        pp.load("TP_swap_xz", tp_params.swap_xz, false);
+
+        // Debug output
+        pp.load("TP_do_residuum_debug_output",
+                tp_params.do_residuum_debug_output, false);
+        pp.load("TP_do_initial_debug_output", tp_params.do_initial_debug_output,
+                false);
+
+        // Irrelevant parameters set to default value
+        tp_params.keep_u_around = false;
+        tp_params.use_sources = false;
+        tp_params.rescale_sources = true;
+        tp_params.use_external_initial_guess = false;
+        tp_params.multiply_old_lapse = false;
+        tp_params.schedule_in_ADMBase_InitialData = true;
+        tp_params.solve_momentum_constraint = false;
+        tp_params.metric_type = "something else";
+        tp_params.conformal_storage = "not conformal at all";
+        tp_params.conformal_state = 0;
+        tp_params.mp = 0;
+        tp_params.mm = 0;
+        tp_params.mp_adm = 0;
+        tp_params.mm_adm = 0;
+    }
+#else
+    /// Read BH parameters if not using two punctures
+    void read_bh_params(GRParmParse &pp)
     {
         // Initial data
         pp.load("massA", bh1_params.mass);
@@ -46,18 +206,61 @@ class SimulationParameters : public SimulationParametersBase
             bh1_params.center[idir] = centerA[idir] + offsetA[idir];
             bh2_params.center[idir] = centerB[idir] + offsetB[idir];
         }
-
-        // Do we want Weyl extraction, puncture tracking and constraint norm
-        // calculation?
-        pp.load("activate_extraction", activate_extraction, false);
-        pp.load("track_punctures", track_punctures, false);
-        pp.load("puncture_tracking_level", puncture_tracking_level, max_level);
-        pp.load("calculate_constraint_norms", calculate_constraint_norms,
-                false);
     }
+#endif /* USE_TWOPUNCTURES */
 
     void check_params()
     {
+#ifdef USE_TWOPUNCTURES
+        // These checks are mostly taken from the Einstein Toolkit thorn
+        // documentation:
+        // https://einsteintoolkit.org/thornguide/EinsteinInitialData/TwoPunctures/documentation.html
+        std::string mass_plus_name, mass_minus_name;
+        if (tp_params.give_bare_mass)
+        {
+            mass_minus_name = "TP_mass_minus";
+            mass_plus_name = "TP_mass_plus";
+        }
+        else
+        {
+            mass_minus_name = "TP_target_mass_minus";
+            mass_plus_name = "TP_target_mass_plus";
+            check_parameter("TP_adm_tol", tp_params.adm_tol,
+                            tp_params.adm_tol > 0., "must be > 0.0");
+        }
+        check_parameter(mass_minus_name, bh1_params.mass, bh1_params.mass >= 0.,
+                        "mustd be >= 0.0");
+        check_parameter(mass_plus_name, bh2_params.mass, bh2_params.mass >= 0.,
+                        "must be >= 0.0");
+
+        int offset_dir = (!tp_params.swap_xz) ? 0 : 2;
+        warn_parameter("TP_offset_minus", tp_offset_minus,
+                       tp_offset_minus < (ivN[offset_dir] + 1) * coarsest_dx -
+                                             center[offset_dir],
+                       "should be within the computational domain");
+        warn_parameter("TP_offset_plus", tp_offset_plus,
+                       tp_offset_plus < (ivN[offset_dir] + 1) * coarsest_dx -
+                                            center[offset_dir],
+                       "should be within the computational domain");
+        check_parameter("TP_npoints_A", tp_params.npoints_A,
+                        tp_params.npoints_A >= 4, "must be >= 4");
+        check_parameter("TP_npoints_B", tp_params.npoints_B,
+                        tp_params.npoints_B >= 4, "must be >= 4");
+        check_parameter("TP_npoints_phi", tp_params.npoints_phi,
+                        tp_params.npoints_phi >= 4 &&
+                            tp_params.npoints_phi % 2 == 0,
+                        "must be >= 4 and divisible by 2");
+        check_parameter("TP_Newton_maxit", tp_params.Newton_maxit,
+                        tp_params.Newton_maxit >= 0, "must be >= 0");
+        check_parameter("TP_Newton_tol", tp_params.Newton_tol,
+                        tp_params.Newton_tol >= 0., "must be >= 0.0");
+        check_parameter("TP_epsilon", tp_params.TP_epsilon,
+                        tp_params.TP_epsilon >= 0., "must be >= 0.0");
+        check_parameter("TP_Tiny", tp_params.TP_Tiny, tp_params.TP_Tiny >= 0.,
+                        "must be >= 0.0");
+        check_parameter("TP_Extend_Radius", tp_params.TP_Extend_Radius,
+                        tp_params.TP_Extend_Radius >= 0., "must be >= 0.0");
+#else
         warn_parameter("massA", bh1_params.mass, bh1_params.mass >= 0,
                        "should be >= 0");
         warn_parameter("massB", bh2_params.mass, bh2_params.mass >= 0,
@@ -87,6 +290,7 @@ class SimulationParameters : public SimulationParametersBase
                                (center_B_dir <= (ivN[idir] + 1) * coarsest_dx),
                            "should be within the computational domain");
         }
+#endif /* USE_TWOPUNCTURES */
         check_parameter("puncture_tracking_level", puncture_tracking_level,
                         (puncture_tracking_level >= 0) &&
                             (puncture_tracking_level <= max_level),
@@ -97,8 +301,15 @@ class SimulationParameters : public SimulationParametersBase
     bool activate_extraction, track_punctures, calculate_constraint_norms;
     int puncture_tracking_level;
     // Collection of parameters necessary for initial conditions
+    // Set these even in the case of TwoPunctures as they are used elsewhere
+    // e.g. for puncture tracking/tagging
     BoostedBH::params_t bh2_params;
     BoostedBH::params_t bh1_params;
+
+#ifdef USE_TWOPUNCTURES
+    double tp_offset_plus, tp_offset_minus;
+    TP::Parameters tp_params;
+#endif
 };
 
 #endif /* SIMULATIONPARAMETERS_HPP */

--- a/Examples/BinaryBH/TPAMR.hpp
+++ b/Examples/BinaryBH/TPAMR.hpp
@@ -1,0 +1,35 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef TPAMR_HPP_
+#define TPAMR_HPP_
+
+// Even if USE_TWOPUNCTURES is not defined, this file will include BHAMR.hpp
+#include "BHAMR.hpp"
+
+#ifdef USE_TWOPUNCTURES
+#include "TwoPunctures.hpp"
+
+/// A descendent of Chombo's AMR class to interface with tools which require
+/// access to the whole AMR hierarchy, and those of GRAMR
+/**
+ * This object inherits from BHAMR and adds members relevant to TwoPunctures
+ * initial data
+ */
+class TPAMR : public BHAMR
+{
+  public:
+    TP::TwoPunctures m_two_punctures;
+
+    void set_two_punctures_parameters(const TP::Parameters &params)
+    {
+        // explicitly invoke copy constructor of base Parameters class
+        m_two_punctures.Parameters::operator=(params);
+    }
+};
+
+#endif /* USE_TWOPUNCTURES */
+
+#endif /* TPAMR_HPP_ */

--- a/Examples/BinaryBH/params_two_punctures.txt
+++ b/Examples/BinaryBH/params_two_punctures.txt
@@ -128,8 +128,8 @@ TP_target_mass_minus = 0.5
 TP_offset_plus = 6.10679
 TP_offset_minus = -6.10679
 #TP_swap_xz = false
-TP_momentum_plus = -0.0841746 -0.000510846 0.0
-TP_momentum_minus = 0.0841746  0.000510846 0.0
+TP_momentum_plus = -0.000510846 0.0841746 0.0
+TP_momentum_minus = 0.000510846 -0.0841746 0.0
 TP_spin_plus = 0.0 0.0 0.0
 TP_spin_minus = 0.0 0.0 0.0
 

--- a/Examples/BinaryBH/params_two_punctures.txt
+++ b/Examples/BinaryBH/params_two_punctures.txt
@@ -1,0 +1,153 @@
+# See the wiki page for an explanation of the params!
+# https://github.com/GRChombo/GRChombo/wiki/Guide-to-parameters
+
+# location / naming of output files (must give full path)
+verbosity = 0
+chk_prefix = BinaryBHChk_
+plot_prefix = BinaryBHPlot_
+#restart_file = BinaryBHChk_000000.3d.hdf5
+
+# 'N' is the number of subdivisions in each direction of a cubic box
+# 'L' is the length of the longest side of the box, dx_coarsest = L/N
+# NB - If you use reflective BC and want to specify the subdivisions and side
+# of the box were there are no symmetries, specify 'N_full' and 'L_full' instead
+# NB - if you have a non-cubic grid, you can specify 'N1' or 'N1_full',
+# 'N2' or 'N2_full' and 'N3' or 'N3_full' ( then dx_coarsest = L/N(max) )
+# NB - the N values need to be multiples of the block_factor
+N_full = 64
+L_full = 512
+
+# Defaults to center of grid L/2
+# uncomment to change
+#center = 256.0 256.0 256.0
+
+# BH params, use puncture tracking to
+# ensure horizons resolved
+track_punctures = 1
+puncture_tracking_level = 5
+
+# regridding control, specify threshold (same on each level)
+regrid_threshold = 0.05
+max_level = 9
+# need max_level entries for regrid interval
+regrid_interval = 0 0 0 64 64 64 64 64 64
+
+# Max and min box sizes
+max_grid_size = 16
+block_factor = 16
+
+# Set up time steps
+# dt will be dx*dt_multiplier on each grid level
+# HDF5files are written every dt = L/N*dt_multiplier*checkpoint_interval
+checkpoint_interval = 100
+# set to zero to turn off plot files, comps defined in BinaryBHLevel.cpp
+plot_interval = 10
+num_plot_vars = 3
+plot_vars = chi Weyl4_Re Weyl4_Im
+dt_multiplier = 0.25
+stop_time = 2200.0
+
+# boundaries and periodicity of grid
+# Periodic directions - 0 = false, 1 = true
+isPeriodic = 0 0 0
+# if not periodic, then specify the boundary type
+# 0 = static, 1 = sommerfeld, 2 = reflective
+# (see BoundaryConditions.hpp for details)
+hi_boundary = 1 1 1
+lo_boundary = 1 1 2
+
+# if reflective boundaries selected, must set
+# parity of all vars (in order given by UserVariables.hpp)
+# 0 = even
+# 1,2,3 = odd x, y, z
+# 4,5,6 = odd xy, yz, xz
+# 7     = odd xyz
+vars_parity            = 0 0 4 6 0 5 0    #chi and hij
+                         0 0 4 6 0 5 0    #K and Aij
+                         0 1 2 3          #Theta and Gamma
+                         0 1 2 3 1 2 3    #lapse shift and B
+vars_parity_diagnostic = 0 1 2 3          #Ham and Mom
+                         0 7              #Weyl
+
+# if sommerfeld boundaries selected, must select
+# asymptotic values
+num_nonzero_asymptotic_vars = 5
+nonzero_asymptotic_vars = chi h11 h22 h33 lapse
+nonzero_asymptotic_values = 1.0 1.0 1.0 1.0 1.0
+
+# Lapse evolution
+lapse_advec_coeff = 1.0
+lapse_coeff = 2.0
+lapse_power = 1.0
+
+# Shift evolution
+shift_advec_coeff = 0.0
+shift_Gamma_coeff = 0.75
+eta = 1.0
+
+# CCZ4 parameters
+kappa1 = 0.1
+kappa2 = 0
+kappa3 = 1.0
+covariantZ4 = 1 # 0: default. 1: dampk1 -> dampk1/lapse
+
+# coefficient for KO numerical dissipation
+sigma = 1.0
+
+# extraction params
+# default of extraction_center is center, uncomment to change
+#extraction_center = 256 256 256
+activate_extraction = 1
+num_extraction_radii = 2
+extraction_radii = 50.0 100.0
+extraction_levels = 2 1
+num_points_phi = 24
+num_points_theta = 36
+num_modes = 8
+modes = 2 0 # l m for spherical harmonics
+        2 1
+        2 2
+        4 0
+        4 1
+        4 2
+        4 3
+        4 4
+
+
+### Two Punctures params
+
+# Main BH params
+# Either calculate target masses or set bare masses explicitly below
+TP_calculate_target_masses = true
+TP_target_mass_plus = 0.5
+TP_target_mass_minus = 0.5
+#TP_adm_tol = 1e-10
+#TP_mass_plus = 0.9773790195003562
+#TP_mass_minus = 0.4758625198306865
+# offset in x direction (or z if TP_swap_xz set true)
+TP_offset_plus = 6.10679
+TP_offset_minus = -6.10679
+#TP_swap_xz = false
+TP_momentum_plus = -0.0841746 -0.000510846 0.0
+TP_momentum_minus = 0.0841746  0.000510846 0.0
+TP_spin_plus = 0.0 0.0 0.0
+TP_spin_minus = 0.0 0.0 0.0
+
+# Solver params
+#TP_npoints_A = 30
+#TP_npoints_B = 30
+#TP_npoints_phi = 16;
+#TP_Newton_tol = 1e-10
+#TP_Newton_maxit = 5
+TP_epsilon = 1e-6
+#TP_Tiny = 0.0
+#TP_Extend_Radius = 0.0
+
+# Initial data params
+TP_use_spectral_interpolation = true
+TP_initial_lapse = psi^n
+TP_initial_lapse_psi_exponent = -2.0
+
+# Debug output
+#TP_do_residuum_debug_output = false
+#TP_do_initial_debug_output = false

--- a/Source/InitialConditions/BlackHoles/TwoPuncturesInitialData.hpp
+++ b/Source/InitialConditions/BlackHoles/TwoPuncturesInitialData.hpp
@@ -1,0 +1,55 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifdef USE_TWOPUNCTURES
+
+#ifndef TWOPUNCTURESINITIALDATA_HPP_
+#define TWOPUNCTURESINITIALDATA_HPP_
+
+#include "CCZ4Vars.hpp"
+#include "Cell.hpp"
+#include "Coordinates.hpp"
+#include "Tensor.hpp"
+#include "TensorAlgebra.hpp"
+#include "TwoPunctures.hpp"
+#include "UserVariables.hpp" //This files needs NUM_VARS - total number of components
+#include "VarsTools.hpp"
+#include "simd.hpp"
+#include <array>
+
+//! This compute class sets the initial data computed by TwoPunctures on the
+//! grid
+class TwoPuncturesInitialData
+{
+  protected:
+    double m_dx;
+    std::array<double, CH_SPACEDIM> m_center;
+    const TP::TwoPunctures &m_two_punctures;
+
+  public:
+    template <class data_t> using Vars = CCZ4Vars::VarsWithGauge<data_t>;
+
+    TwoPuncturesInitialData(const double a_dx,
+                            const std::array<double, CH_SPACEDIM> a_center,
+                            const TP::TwoPunctures &a_two_punctures)
+        : m_dx(a_dx), m_center(a_center), m_two_punctures(a_two_punctures)
+    {
+    }
+
+    void compute(Cell<double> current_cell) const;
+
+  protected:
+    void interpolate_tp_vars(const Coordinates<double> &coords,
+                             Tensor<2, double> &out_h_phys,
+                             Tensor<2, double> &out_extrinsic_K,
+                             double &out_lapse, Tensor<1, double> &out_shift,
+                             double &out_Theta,
+                             Tensor<1, double> &out_Z3) const;
+};
+
+#include "TwoPuncturesInitialData.impl.hpp"
+
+#endif /* TWOPUNCTURESINITIALDATA_HPP_ */
+#endif /* USE_TWOPUNCTURES */

--- a/Source/InitialConditions/BlackHoles/TwoPuncturesInitialData.impl.hpp
+++ b/Source/InitialConditions/BlackHoles/TwoPuncturesInitialData.impl.hpp
@@ -1,0 +1,88 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#if !defined(TWOPUNCTURESINITIALDATA_HPP_)
+#error "This file should only be included through TwoPuncturesInitialData.hpp"
+#endif
+
+#ifndef TWOPUNCTURESINITIALDATA_IMPL_HPP_
+#define TWOPUNCTURESINITIALDATA_IMPL_HPP_
+
+void TwoPuncturesInitialData::compute(Cell<double> current_cell) const
+{
+    Vars<double> vars;
+    // Set only the non-zero components explicitly below
+    VarsTools::assign(vars, 0.);
+
+    Coordinates<double> coords(current_cell, m_dx, m_center);
+    Tensor<2, double> h_phys, extrinsic_K;
+    Tensor<1, double> shift, Z3;
+    double lapse, Theta;
+
+    interpolate_tp_vars(coords, h_phys, extrinsic_K, lapse, shift, Theta, Z3);
+
+    // analytically set Bowen-York properties below (e.g. conformal flatness,
+    // tracefree K)
+
+    // metric variables
+    vars.chi = 1.0 / h_phys[0][0];
+    FOR1(i) { vars.h[i][i] = 1.0; }
+
+    // extrinsic curvature
+    FOR2(i, j) { vars.A[i][j] = vars.chi * extrinsic_K[i][j]; }
+    // conformal flatness means h_UU = h
+    TensorAlgebra::make_trace_free(vars.A, vars.h, vars.h);
+
+    // gauge
+    vars.lapse = lapse;
+
+    current_cell.store_vars(vars);
+}
+
+void TwoPuncturesInitialData::interpolate_tp_vars(
+    const Coordinates<double> &coords, Tensor<2, double> &out_h_phys,
+    Tensor<2, double> &out_extrinsic_K, double &out_lapse,
+    Tensor<1, double> &out_shift, double &out_Theta,
+    Tensor<1, double> &out_Z3) const
+{
+    double coords_array[CH_SPACEDIM];
+    coords_array[0] = coords.x;
+    coords_array[1] = coords.y;
+    coords_array[2] = coords.z;
+
+    using namespace TP::Z4VectorShortcuts;
+    double TP_state[Qlen];
+    m_two_punctures.Interpolate(coords_array, TP_state);
+
+    // metric
+    out_h_phys[0][0] = TP_state[g11];
+    out_h_phys[0][1] = out_h_phys[1][0] = TP_state[g12];
+    out_h_phys[0][2] = out_h_phys[2][0] = TP_state[g13];
+    out_h_phys[1][1] = TP_state[g22];
+    out_h_phys[1][2] = out_h_phys[2][1] = TP_state[g23];
+    out_h_phys[2][2] = TP_state[g33];
+
+    // extrinsic curvature
+    out_extrinsic_K[0][0] = TP_state[K11];
+    out_extrinsic_K[0][1] = out_extrinsic_K[1][0] = TP_state[K12];
+    out_extrinsic_K[0][2] = out_extrinsic_K[2][0] = TP_state[K13];
+    out_extrinsic_K[1][1] = TP_state[K22];
+    out_extrinsic_K[1][2] = out_extrinsic_K[2][1] = TP_state[K23];
+    out_extrinsic_K[2][2] = TP_state[K33];
+
+    // Z4 vector
+    out_Z3[0] = TP_state[Z1];
+    out_Z3[1] = TP_state[Z2];
+    out_Z3[2] = TP_state[Z3];
+    out_Theta = TP_state[Theta];
+
+    // gauge
+    out_lapse = TP_state[lapse];
+    out_shift[0] = TP_state[shift1];
+    out_shift[1] = TP_state[shift2];
+    out_shift[2] = TP_state[shift3];
+}
+
+#endif /* TWOPUNCTURESINITIALDATA_IMPL_HPP_ */


### PR DESCRIPTION
This adds the necessary changes to allow use of the TwoPunctures initial data in the BinaryBH example. Due to licensing incompatibilities, the TwoPunctures files are contained in a [separate repository](https://github.com/GRChombo/TwoPunctures).

There is a README in the BinaryBH example directory that explains how to build the example with TwoPunctures initial data (in addition to the [README](https://github.com/GRChombo/TwoPunctures/blob/main/README.md) in the base of the TwoPunctures directory) and I plan on adding more details to a new wiki page.

The params_two_punctures.txt is essentially a copy of the really nice initial data in params.txt but for the TwoPunctures version. For ease of use, I have tried to keep the names of the parameters as close to that of the original ETK TwoPunctures code as possible (see [the documentation](https://einsteintoolkit.org/thornguide/EinsteinInitialData/TwoPunctures/documentation.html)) but I have slightly modified some of them to make them more consistent with our naming conventions.

A nice bonus of this addition is that we can now have spinning BHs (which we didn't have before).