### PR TITLE
Add sixth order spatial derivatives

### DIFF
--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -16,6 +16,7 @@
 #include "PositiveChiAndAlpha.hpp"
 #include "PunctureTracker.hpp"
 #include "SetValue.hpp"
+#include "SixthOrderDerivatives.hpp"
 #include "SmallDataIO.hpp"
 #include "TraceARemoval.hpp"
 #include "Weyl4.hpp"
@@ -60,9 +61,18 @@ void BinaryBHLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
                    a_soln, a_soln, INCLUDE_GHOST_CELLS);
 
     // Calculate CCZ4 right hand side
-    BoxLoops::loop(CCZ4RHS<MovingPunctureGauge, FourthOrderDerivatives>(
-                       m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation),
-                   a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
+    if (m_p.max_spatial_derivative_order == 4)
+    {
+        BoxLoops::loop(CCZ4RHS<MovingPunctureGauge, FourthOrderDerivatives>(
+                           m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation),
+                       a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
+    }
+    else if (m_p.max_spatial_derivative_order == 6)
+    {
+        BoxLoops::loop(CCZ4RHS<MovingPunctureGauge, SixthOrderDerivatives>(
+                           m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation),
+                       a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
+    }
 }
 
 // enforce trace removal during RK4 substeps

--- a/Examples/BinaryBH/params.txt
+++ b/Examples/BinaryBH/params.txt
@@ -13,11 +13,14 @@ plot_prefix = BinaryBHPlot_
 # 'L' is the length of the longest side of the box, dx_coarsest = L/N
 # NB - If you use reflective BC and want to specify the subdivisions and side
 # of the box were there are no symmetries, specify 'N_full' and 'L_full' instead
-# NB - if you have a non-cubic grid, you can specify 'N1' or 'N1_full', 
+# NB - if you have a non-cubic grid, you can specify 'N1' or 'N1_full',
 # 'N2' or 'N2_full' and 'N3' or 'N3_full' ( then dx_coarsest = L/N(max) )
 # NB - the N values need to be multiples of the block_factor
 N_full = 64
 L_full = 512
+
+# Spatial derivative order (only affects CCZ4 RHS)
+max_spatial_derivative_order = 4 # can be 4 or 6
 
 # Defaults to center of grid L/2
 # uncomment to change

--- a/Examples/BinaryBH/params_expensive.txt
+++ b/Examples/BinaryBH/params_expensive.txt
@@ -11,6 +11,9 @@ N2 = 256
 N3 = 256
 L = 192
 
+# Spatial derivative order (only affects CCZ4 RHS)
+max_spatial_derivative_order = 4 # can be 4 or 6
+
 massA = 0.5
 offsetA = 3 0 0
 

--- a/Examples/BinaryBH/params_very_cheap.txt
+++ b/Examples/BinaryBH/params_very_cheap.txt
@@ -6,6 +6,9 @@ plot_prefix = BinaryBHPlot_
 # Set up grid spacings and regrid params
 # NB - the N values need to be multiples of block_factor
 
+# Spatial derivative order (only affects CCZ4 RHS)
+max_spatial_derivative_order = 4 # can be 4 or 6
+
 N_full = 32
 L_full = 16
 
@@ -103,4 +106,3 @@ num_modes = 3
 modes = 2 0 # l m for spherical harmonics
         2 1
         2 2
-

--- a/Examples/KerrBH/KerrBHLevel.cpp
+++ b/Examples/KerrBH/KerrBHLevel.cpp
@@ -13,6 +13,7 @@
 #include "NewConstraints.hpp"
 #include "PositiveChiAndAlpha.hpp"
 #include "SetValue.hpp"
+#include "SixthOrderDerivatives.hpp"
 #include "TraceARemoval.hpp"
 
 // Initial data
@@ -66,9 +67,18 @@ void KerrBHLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
                    a_soln, a_soln, INCLUDE_GHOST_CELLS);
 
     // Calculate CCZ4 right hand side
-    BoxLoops::loop(CCZ4RHS<MovingPunctureGauge, FourthOrderDerivatives>(
-                       m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation),
-                   a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
+    if (m_p.max_spatial_derivative_order == 4)
+    {
+        BoxLoops::loop(CCZ4RHS<MovingPunctureGauge, FourthOrderDerivatives>(
+                           m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation),
+                       a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
+    }
+    else if (m_p.max_spatial_derivative_order == 6)
+    {
+        BoxLoops::loop(CCZ4RHS<MovingPunctureGauge, SixthOrderDerivatives>(
+                           m_p.ccz4_params, m_dx, m_p.sigma, m_p.formulation),
+                       a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
+    }
 }
 
 void KerrBHLevel::specificUpdateODE(GRLevelData &a_soln,

--- a/Examples/KerrBH/params.txt
+++ b/Examples/KerrBH/params.txt
@@ -9,11 +9,14 @@ plot_prefix = KerrBHp_
 # 'L' is the length of the longest side of the box, dx_coarsest = L/N
 # NB - If you use reflective BC and want to specify the subdivisions and side
 # of the box were there are no symmetries, specify 'N_full' and 'L_full' instead
-# NB - if you have a non-cubic grid, you can specify 'N1' or 'N1_full', 
+# NB - if you have a non-cubic grid, you can specify 'N1' or 'N1_full',
 # 'N2' or 'N2_full' and 'N3' or 'N3_full' ( then dx_coarsest = L/N(max) )
 # NB - the N values need to be multiples of the block_factor
 N_full = 64
 L_full = 128
+
+# Spatial derivative order (only affects CCZ4 RHS)
+max_spatial_derivative_order = 4 # can be 4 or 6
 
 # Params for Kerr BH
 kerr_mass = 1.0
@@ -63,7 +66,7 @@ vars_parity            = 0 0 4 6 0 5 0    #chi and hij
                          0 1 2 3 1 2 3    #lapse shift and B
 vars_parity_diagnostic = 0 1 2 3          #Ham and Mom
 
-# if sommerfeld boundaries selected, must select 
+# if sommerfeld boundaries selected, must select
 # non zero asymptotic values
 num_nonzero_asymptotic_vars = 5
 nonzero_asymptotic_vars = chi h11 h22 h33 lapse

--- a/Examples/KerrBH/params_cheap.txt
+++ b/Examples/KerrBH/params_cheap.txt
@@ -9,11 +9,14 @@ plot_prefix = KerrBHp_
 # 'L' is the length of the longest side of the box, dx_coarsest = L/N
 # NB - If you use reflective BC and want to specify the subdivisions and side
 # of the box were there are no symmetries, specify 'N_full' and 'L_full' instead
-# NB - if you have a non-cubic grid, you can specify 'N1' or 'N1_full', 
+# NB - if you have a non-cubic grid, you can specify 'N1' or 'N1_full',
 # 'N2' or 'N2_full' and 'N3' or 'N3_full' ( then dx_coarsest = L/N(max) )
 # NB - the N values need to be multiples of the block_factor
 N_full = 64
 L_full = 128
+
+# Spatial derivative order (only affects CCZ4 RHS)
+max_spatial_derivative_order = 4 # can be 4 or 6
 
 # Params for Kerr BH
 kerr_mass = 1.0
@@ -63,7 +66,7 @@ vars_parity            = 0 0 4 6 0 5 0    #chi and hij
                          0 1 2 3 1 2 3    #lapse shift and B
 vars_parity_diagnostic = 0 1 2 3          #Ham and Mom
 
-# if sommerfeld boundaries selected, must select 
+# if sommerfeld boundaries selected, must select
 # asymptotic values (in order given by UserVariables.hpp)
 vars_asymptotic_values = 1.0 1.0 0.0 0.0 1.0 0.0 1.0 #chi and hij
                          0.0 0.0 0.0 0.0 0.0 0.0 0.0 #K and Aij
@@ -87,7 +90,7 @@ lapse_advec_coeff = 1 # 1 makes the lapse gauge 1+log slicing
 
 # Shift evolution coefficients
 shift_advec_coeff = 0 # Usually no advection for beta
-shift_Gamma_coeff = 0.75 # 
+shift_Gamma_coeff = 0.75 #
 eta = 1.0 # This is gamma driver, usually of order 1/M_ADM of spacetime
 
 # CCZ4 parameters

--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -8,6 +8,7 @@
 #include "BoxLoops.hpp"
 #include "NanCheck.hpp"
 #include "PositiveChiAndAlpha.hpp"
+#include "SixthOrderDerivatives.hpp"
 #include "TraceARemoval.hpp"
 
 // For RHS update
@@ -89,11 +90,22 @@ void ScalarFieldLevel::specificEvalRHS(GRLevelData &a_soln, GRLevelData &a_rhs,
     // Calculate MatterCCZ4 right hand side with matter_t = ScalarField
     Potential potential(m_p.potential_params);
     ScalarFieldWithPotential scalar_field(potential);
-    MatterCCZ4RHS<ScalarFieldWithPotential, MovingPunctureGauge,
-                  FourthOrderDerivatives>
-        my_ccz4_matter(scalar_field, m_p.ccz4_params, m_dx, m_p.sigma,
-                       m_p.formulation, m_p.G_Newton);
-    BoxLoops::loop(my_ccz4_matter, a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
+    if (m_p.max_spatial_derivative_order == 4)
+    {
+        MatterCCZ4RHS<ScalarFieldWithPotential, MovingPunctureGauge,
+                      FourthOrderDerivatives>
+            my_ccz4_matter(scalar_field, m_p.ccz4_params, m_dx, m_p.sigma,
+                           m_p.formulation, m_p.G_Newton);
+        BoxLoops::loop(my_ccz4_matter, a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
+    }
+    else if (m_p.max_spatial_derivative_order == 6)
+    {
+        MatterCCZ4RHS<ScalarFieldWithPotential, MovingPunctureGauge,
+                      SixthOrderDerivatives>
+            my_ccz4_matter(scalar_field, m_p.ccz4_params, m_dx, m_p.sigma,
+                           m_p.formulation, m_p.G_Newton);
+        BoxLoops::loop(my_ccz4_matter, a_soln, a_rhs, EXCLUDE_GHOST_CELLS);
+    }
 }
 
 // Things to do at ODE update, after soln + rhs

--- a/Examples/ScalarField/params.txt
+++ b/Examples/ScalarField/params.txt
@@ -9,11 +9,14 @@ plot_prefix = ScalarFieldp_
 # 'L' is the length of the longest side of the box, dx_coarsest = L/N
 # NB - If you use reflective BC and want to specify the subdivisions and side
 # of the box were there are no symmetries, specify 'N_full' and 'L_full' instead
-# NB - if you have a non-cubic grid, you can specify 'N1' or 'N1_full', 
+# NB - if you have a non-cubic grid, you can specify 'N1' or 'N1_full',
 # 'N2' or 'N2_full' and 'N3' or 'N3_full' ( then dx_coarsest = L/N(max) )
 # NB - the N values need to be multiples of the block_factor
 N_full = 128
 L_full = 256
+
+# Spatial derivative order (only affects CCZ4 RHS)
+max_spatial_derivative_order = 4 # can be 4 or 6
 
 # Regridding - in this example use a fixed grid
 tag_buffer_size = 0
@@ -97,7 +100,7 @@ sigma = 0.3
 # Change the gravitational constant of the Universe!
 # Default is 1.0, for standard geometric units
 # Here we decouple the evolution so the scalar evolved on the
-# metric background without backreaction (this avoids the need 
+# metric background without backreaction (this avoids the need
 # to solve the constaints)
 G_Newton = 0.0
 

--- a/Source/BoxUtils/SixthOrderDerivatives.hpp
+++ b/Source/BoxUtils/SixthOrderDerivatives.hpp
@@ -1,0 +1,484 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef SIXTHORDERDERIVATIVES_HPP_
+#define SIXTHORDERDERIVATIVES_HPP_
+
+#include "Cell.hpp"
+#include "DimensionDefinitions.hpp"
+#include "Tensor.hpp"
+#include "UserVariables.hpp"
+#include <array>
+
+class SixthOrderDerivatives
+{
+  public:
+    const double m_dx;
+
+  private:
+    const double m_one_over_dx;
+    const double m_one_over_dx2;
+
+  public:
+    SixthOrderDerivatives(double dx)
+        : m_dx(dx), m_one_over_dx(1 / dx), m_one_over_dx2(1 / (dx * dx))
+    {
+    }
+
+    template <class data_t>
+    ALWAYS_INLINE data_t diff1(const double *in_ptr, const int idx,
+                               const int stride) const
+    {
+        auto in = SIMDIFY<data_t>(in_ptr);
+
+        data_t weight_vfar = 1.66666666666666666667e-2;
+        data_t weight_far = 1.50000000000000000000e-1;
+        data_t weight_near = 7.50000000000000000000e-1;
+
+        // NOTE: if you have been sent here by the debugger because of
+        // EXC_BAD_ACCESS  or something similar you might be trying to take
+        // derivatives without ghost points.
+        return (-weight_vfar * in[idx - 3 * stride] +
+                weight_far * in[idx - 2 * stride] -
+                weight_near * in[idx - stride] +
+                weight_near * in[idx + stride] -
+                weight_far * in[idx + 2 * stride] +
+                weight_vfar * in[idx + 3 * stride]) *
+               m_one_over_dx;
+    }
+
+    // Writes directly into the vars object - use this wherever possible
+    template <class data_t, template <typename> class vars_t>
+    void diff1(vars_t<Tensor<1, data_t>> &d1, const Cell<data_t> &current_cell,
+               int direction) const
+    {
+        const int stride =
+            current_cell.get_box_pointers().m_in_stride[direction];
+        const int in_index = current_cell.get_in_index();
+        d1.enum_mapping([&](const int &ivar, Tensor<1, data_t> &var) {
+            var[direction] =
+                diff1<data_t>(current_cell.get_box_pointers().m_in_ptr[ivar],
+                              in_index, stride);
+        });
+    }
+
+    /// Calculates all first derivatives and returns as variable type specified
+    /// by the template parameter
+    template <template <typename> class vars_t, class data_t>
+    auto diff1(const Cell<data_t> &current_cell) const
+    {
+        const auto in_index = current_cell.get_in_index();
+        const auto strides = current_cell.get_box_pointers().m_in_stride;
+        vars_t<Tensor<1, data_t>> d1;
+        d1.enum_mapping([&](const int &ivar, Tensor<1, data_t> &var) {
+            FOR1(idir)
+            {
+                var[idir] = diff1<data_t>(
+                    current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
+                    strides[idir]);
+            }
+        });
+        return d1;
+    }
+
+    template <class data_t>
+    void diff1(Tensor<1, data_t> &diff_value, const Cell<data_t> &current_cell,
+               int direction, int ivar) const
+    {
+        const int stride =
+            current_cell.get_box_pointers().m_in_stride[direction];
+        const int in_index = current_cell.get_in_index();
+        diff_value[direction] = diff1<data_t>(
+            current_cell.get_box_pointers().m_in_ptr[ivar], in_index, stride);
+    }
+
+    template <class data_t, int num_vars>
+    void diff1(Tensor<1, data_t> (&diff_array)[num_vars],
+               const Cell<data_t> &current_cell, int direction,
+               int start_var = 0) const
+    {
+        const int stride =
+            current_cell.get_box_pointers().m_in_stride[direction];
+        const int in_index = current_cell.get_in_index();
+        for (int i = start_var; i < start_var + num_vars; ++i)
+        {
+            diff_array[i][direction] = diff1<data_t>(
+                current_cell.get_box_pointers().m_in_ptr[i], in_index, stride);
+        }
+    }
+
+    template <class data_t>
+    ALWAYS_INLINE data_t diff2(const double *in_ptr, const int idx,
+                               const int stride) const
+    {
+        auto in = SIMDIFY<data_t>(in_ptr);
+
+        data_t weight_vfar = 1.11111111111111111111e-2;
+        data_t weight_far = 1.50000000000000000000e-1;
+        data_t weight_near = 1.50000000000000000000e+0;
+        data_t weight_local = 2.72222222222222222222e+0;
+
+        return (weight_vfar * in[idx - 3 * stride] -
+                weight_far * in[idx - 2 * stride] +
+                weight_near * in[idx - stride] - weight_local * in[idx] +
+                weight_near * in[idx + stride] -
+                weight_far * in[idx + 2 * stride] +
+                weight_vfar * in[idx + 3 * stride]) *
+               m_one_over_dx2;
+    }
+
+    // Writes 2nd deriv directly into the vars object - use this wherever
+    // possible
+    template <class data_t, template <typename> class vars_t>
+    void diff2(vars_t<Tensor<2, data_t>> &d2, const Cell<data_t> &current_cell,
+               int direction) const
+    {
+        const int stride =
+            current_cell.get_box_pointers().m_in_stride[direction];
+        const int in_index = current_cell.get_in_index();
+        d2.enum_mapping([&](const int &ivar, Tensor<2, data_t> &var) {
+            var[direction][direction] =
+                diff2<data_t>(current_cell.get_box_pointers().m_in_ptr[ivar],
+                              in_index, stride);
+        });
+    }
+
+    template <class data_t>
+    void diff2(Tensor<2, data_t> (&diffArray)[NUM_VARS],
+               const Cell<data_t> &current_cell, int direction) const
+    {
+        const int stride =
+            current_cell.get_box_pointers().m_in_stride[direction];
+        const int in_index = current_cell.get_in_index();
+        for (int ivar = 0; ivar < NUM_VARS; ++ivar)
+        {
+            diffArray[ivar][direction][direction] =
+                diff2<data_t>(current_cell.get_box_pointers().m_in_ptr[ivar],
+                              in_index, stride);
+        }
+    }
+
+    template <class data_t>
+    ALWAYS_INLINE data_t mixed_diff2(const double *in_ptr, const int idx,
+                                     const int stride1, const int stride2) const
+    {
+        auto in = SIMDIFY<data_t>(in_ptr);
+
+        data_t weight_vfar_vfar = 2.77777777777777777778e-4;
+        data_t weight_vfar_far = 2.50000000000000000000e-3;
+        data_t weight_vfar_near = 1.25000000000000000000e-2;
+        data_t weight_far_far = 2.25000000000000000000e-2;
+        data_t weight_far_near = 1.12500000000000000000e-1;
+        data_t weight_near_near = 5.62500000000000000000e-1;
+
+        return (weight_vfar_vfar * in[idx - 3 * stride1 - 3 * stride2] -
+                weight_vfar_far * in[idx - 3 * stride1 - 2 * stride2] +
+                weight_vfar_near * in[idx - 3 * stride1 - stride2] -
+                weight_vfar_near * in[idx - 3 * stride1 + stride2] +
+                weight_vfar_far * in[idx - 3 * stride1 + 2 * stride2] -
+                weight_vfar_vfar * in[idx - 3 * stride1 + 3 * stride2]
+
+                - weight_vfar_far * in[idx - 2 * stride1 - 3 * stride2] +
+                weight_far_far * in[idx - 2 * stride1 - 2 * stride2] -
+                weight_far_near * in[idx - 2 * stride1 - stride2] +
+                weight_far_near * in[idx - 2 * stride1 + stride2] -
+                weight_far_far * in[idx - 2 * stride1 + 2 * stride2] +
+                weight_vfar_far * in[idx - 2 * stride1 + 3 * stride2]
+
+                + weight_vfar_near * in[idx - stride1 - 3 * stride2] -
+                weight_far_near * in[idx - stride1 - 2 * stride2] +
+                weight_near_near * in[idx - stride1 - stride2] -
+                weight_near_near * in[idx - stride1 + stride2] +
+                weight_far_near * in[idx - stride1 + 2 * stride2] -
+                weight_vfar_near * in[idx - stride1 + 3 * stride2]
+
+                - weight_vfar_near * in[idx + stride1 - 3 * stride2] +
+                weight_far_near * in[idx + stride1 - 2 * stride2] -
+                weight_near_near * in[idx + stride1 - stride2] +
+                weight_near_near * in[idx + stride1 + stride2] -
+                weight_far_near * in[idx + stride1 + 2 * stride2] +
+                weight_vfar_near * in[idx + stride1 + 3 * stride2]
+
+                + weight_vfar_far * in[idx + 2 * stride1 - 3 * stride2] -
+                weight_far_far * in[idx + 2 * stride1 - 2 * stride2] +
+                weight_far_near * in[idx + 2 * stride1 - stride2] -
+                weight_far_near * in[idx + 2 * stride1 + stride2] +
+                weight_far_far * in[idx + 2 * stride1 + 2 * stride2] -
+                weight_vfar_far * in[idx + 2 * stride1 + 3 * stride2]
+
+                - weight_vfar_vfar * in[idx + 3 * stride1 - 3 * stride2] +
+                weight_vfar_far * in[idx + 3 * stride1 - 2 * stride2] -
+                weight_vfar_near * in[idx + 3 * stride1 - stride2] +
+                weight_vfar_near * in[idx + 3 * stride1 + stride2] -
+                weight_vfar_far * in[idx + 3 * stride1 + 2 * stride2] +
+                weight_vfar_vfar * in[idx + 3 * stride1 + 3 * stride2]) *
+               m_one_over_dx2;
+    }
+
+    template <class data_t, template <typename> class vars_t>
+    void mixed_diff2(vars_t<Tensor<2, data_t>> &d2,
+                     const Cell<data_t> &current_cell, int direction1,
+                     int direction2) const
+    {
+        const int stride1 =
+            current_cell.get_box_pointers().m_in_stride[direction1];
+        const int stride2 =
+            current_cell.get_box_pointers().m_in_stride[direction2];
+        const int in_index = current_cell.get_in_index();
+        d2.enum_mapping([&](const int &ivar, Tensor<2, data_t> &var) {
+            auto tmp = mixed_diff2<data_t>(
+                current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
+                stride1, stride2);
+            var[direction1][direction2] = tmp;
+            var[direction2][direction1] = tmp;
+        });
+    }
+
+    template <class data_t>
+    void mixed_diff2(Tensor<2, data_t> (&diffArray)[NUM_VARS],
+                     const Cell<data_t> &current_cell, int direction1,
+                     int direction2) const
+    {
+        const int stride1 =
+            current_cell.get_box_pointers().m_in_stride[direction1];
+        const int stride2 =
+            current_cell.get_box_pointers().m_in_stride[direction2];
+        const int in_index = current_cell.get_in_index();
+        for (int ivar = 0; ivar < NUM_VARS; ++ivar)
+        {
+            data_t diff2_value = mixed_diff2<data_t>(
+                current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
+                stride1, stride2);
+            diffArray[ivar][direction1][direction2] = diff2_value;
+            diffArray[ivar][direction2][direction1] = diff2_value;
+        }
+    }
+
+    template <typename data_t> struct Detector;
+
+    /// Calculates all second derivatives and returns as variable type specified
+    /// by the template parameter
+    template <template <typename> class vars_t, class data_t>
+    auto diff2(const Cell<data_t> &current_cell) const
+    {
+        vars_t<Tensor<2, data_t>> d2;
+        const auto in_index = current_cell.get_in_index();
+        const auto strides = current_cell.get_box_pointers().m_in_stride;
+        d2.enum_mapping([&](const int &ivar, Tensor<2, data_t> &var) {
+            FOR1(dir1) // First calculate the repeated derivatives
+            {
+                var[dir1][dir1] = diff2<data_t>(
+                    current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
+                    strides[dir1]);
+                for (int dir2 = 0; dir2 < dir1; ++dir2)
+                {
+                    auto tmp = mixed_diff2<data_t>(
+                        current_cell.get_box_pointers().m_in_ptr[ivar],
+                        in_index, strides[dir1], strides[dir2]);
+                    var[dir1][dir2] = tmp;
+                    var[dir2][dir1] = tmp;
+                }
+            }
+        });
+        return d2;
+    }
+
+  protected: // Let's keep this protected ... we may want to change the
+             // advection calculation
+    template <class data_t, class mask_t>
+    ALWAYS_INLINE data_t advection_term(const double *in_ptr, const int idx,
+                                        const data_t &vec_comp,
+                                        const int stride,
+                                        const mask_t shift_positive) const
+    {
+        const auto in = SIMDIFY<data_t>(in_ptr);
+        const data_t in_left_far = in[idx - 2 * stride];
+        const data_t in_left = in[idx - stride];
+        const data_t in_centre = in[idx];
+        const data_t in_right = in[idx + stride];
+        const data_t in_right_far = in[idx + 2 * stride];
+
+        data_t weight_0 = +3.33333333333333333333e-2;
+        data_t weight_1 = -4.00000000000000000000e-1;
+        data_t weight_2 = -5.83333333333333333333e-1;
+        data_t weight_3 = +1.33333333333333333333e0;
+        data_t weight_4 = -5.00000000000000000000e-1;
+        data_t weight_5 = +1.33333333333333333333e-1;
+        data_t weight_6 = -1.66666666666666666667e-2;
+
+        data_t upwind;
+        upwind = vec_comp *
+                 (weight_0 * in_left_far + weight_1 * in_left +
+                  weight_2 * in_centre + weight_3 * in_right +
+                  weight_4 * in_right_far + weight_5 * in[idx + 3 * stride] +
+                  weight_6 * in[idx + 4 * stride]) *
+                 m_one_over_dx;
+
+        data_t downwind;
+        downwind = vec_comp *
+                   (-weight_6 * in[idx - 4 * stride] -
+                    weight_5 * in[idx - 3 * stride] - weight_4 * in_left_far -
+                    weight_3 * in_left - weight_2 * in_centre -
+                    weight_1 * in_right - weight_0 * in_right_far) *
+                   m_one_over_dx;
+
+        return simd_conditional(shift_positive, upwind, downwind);
+    }
+
+  public:
+    template <class data_t, template <typename> class vars_t>
+    void add_advection(vars_t<data_t> &vars, const Cell<data_t> &current_cell,
+                       const data_t &vec_comp, const int dir) const
+    {
+        const int stride = current_cell.get_box_pointers().m_in_stride[dir];
+        auto shift_positive = simd_compare_gt(vec_comp, 0.0);
+        const int in_index = current_cell.get_in_index();
+        vars.enum_mapping([&](const int &ivar, data_t &var) {
+            var +=
+                advection_term(current_cell.get_box_pointers().m_in_ptr[ivar],
+                               in_index, vec_comp, stride, shift_positive);
+        });
+    }
+
+    template <class data_t>
+    void add_advection(data_t (&out)[NUM_VARS],
+                       const Cell<data_t> &current_cell, const data_t &vec_comp,
+                       const int dir) const
+    {
+        const int stride = current_cell.get_box_pointers().m_in_stride[dir];
+        auto shift_positive = simd_compare_gt(vec_comp, 0.0);
+        const int in_index = current_cell.get_in_index();
+        for (int ivar = 0; ivar < NUM_VARS; ++ivar)
+        {
+            out[ivar] +=
+                advection_term(current_cell.get_box_pointers().m_in_ptr[ivar],
+                               in_index, vec_comp, stride, shift_positive);
+        }
+    }
+
+    /// Calculates all second derivatives and returns as variable type specified
+    /// by the template parameter
+    template <template <typename> class vars_t, class data_t>
+    auto advection(const Cell<data_t> &current_cell,
+                   const Tensor<1, data_t> &vector) const
+    {
+        const auto in_index = current_cell.get_in_index();
+        const auto strides = current_cell.get_box_pointers().m_in_stride;
+        vars_t<data_t> advec;
+        advec.enum_mapping([&](const int &ivar, data_t &var) {
+            var = 0.;
+            FOR1(dir)
+            {
+                const auto shift_positive = simd_compare_gt(vector[dir], 0.0);
+                var += advection_term(
+                    current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
+                    vector[dir], strides[dir], shift_positive);
+            }
+        });
+        return advec;
+    }
+
+    /*
+    // Eighth order dissipation: remember to change sign in front of factor in
+    // add_dissipation functions below if using this
+    template <class data_t>
+    ALWAYS_INLINE data_t dissipation_term(const double *in_ptr, const int idx,
+                                          const int stride) const
+    {
+        const auto in = SIMDIFY<data_t>(in_ptr);
+        data_t weight_vvfar = 3.906250e-3;
+        data_t weight_vfar = 3.125000e-2;
+        data_t weight_far = 1.093750e-1;
+        data_t weight_near = 2.187500e-1;
+        data_t weight_local = 2.734375e-1;
+
+        return (weight_vvfar * in[idx - 4 * stride] -
+                weight_vfar * in[idx - 3 * stride] +
+                weight_far * in[idx - 2 * stride] -
+                weight_near * in[idx - stride] + weight_local * in[idx] -
+                weight_near * in[idx + stride] +
+                weight_far * in[idx + 2 * stride] -
+                weight_vfar * in[idx + 3 * stride] +
+                weight_vvfar * in[idx + 4 * stride]) *
+               m_one_over_dx;
+    }
+    */
+
+    // Sixth order dissipation
+    template <class data_t>
+    ALWAYS_INLINE data_t dissipation_term(const double *in_ptr, const int idx,
+                                          const int stride) const
+    {
+        const auto in = SIMDIFY<data_t>(in_ptr);
+        data_t weight_vfar = 1.56250e-2;
+        data_t weight_far = 9.37500e-2;
+        data_t weight_near = 2.34375e-1;
+        data_t weight_local = 3.12500e-1;
+
+        return (weight_vfar * in[idx - 3 * stride] -
+                weight_far * in[idx - 2 * stride] +
+                weight_near * in[idx - stride] - weight_local * in[idx] +
+                weight_near * in[idx + stride] -
+                weight_far * in[idx + 2 * stride] +
+                weight_vfar * in[idx + 3 * stride]) *
+               m_one_over_dx;
+    }
+
+    template <class data_t, template <typename> class vars_t>
+    void add_dissipation(vars_t<data_t> &vars, const Cell<data_t> &current_cell,
+                         const double factor, const int direction) const
+    {
+        const int stride =
+            current_cell.get_box_pointers().m_in_stride[direction];
+        const int in_index = current_cell.get_in_index();
+        vars.enum_mapping([&](const int &ivar, data_t &var) {
+            // change sign for eigth order dissipation
+            var += /*-*/ factor *
+                   dissipation_term<data_t>(
+                       current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
+                       stride);
+        });
+    }
+
+    template <class data_t, template <typename> class vars_t>
+    void add_dissipation(vars_t<data_t> &vars, const Cell<data_t> &current_cell,
+                         const double factor) const
+    {
+        const auto in_index = current_cell.get_in_index();
+        vars.enum_mapping([&](const int &ivar, data_t &var) {
+            FOR1(dir)
+            {
+                const auto stride =
+                    current_cell.get_box_pointers().m_in_stride[dir];
+                // change sign for eighth order dissipation
+                var += /*-*/ factor *
+                       dissipation_term<data_t>(
+                           current_cell.get_box_pointers().m_in_ptr[ivar],
+                           in_index, stride);
+            }
+        });
+    }
+
+    template <class data_t>
+    void add_dissipation(data_t (&out)[NUM_VARS],
+                         const Cell<data_t> &current_cell, const double factor,
+                         const int direction) const
+    {
+        const int stride =
+            current_cell.get_box_pointers().m_in_stride[direction];
+        const int in_index = current_cell.get_in_index();
+        for (int ivar = 0; ivar < NUM_VARS; ++ivar)
+        {
+            // change sign for eighth order dissipation
+            out[ivar] +=
+                /*-*/ factor *
+                dissipation_term<data_t>(
+                    current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
+                    stride);
+        }
+    }
+};
+
+#endif /* SIXTHORDERDERIVATIVES_HPP_ */

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -294,7 +294,7 @@ class ChomboParameters
             (num_ghosts >= ((max_spatial_derivative_order == 6) ? 4 : 3)) &&
                 (num_ghosts <= block_factor),
             "must be >= 3 (4th order derivatives) or 4 (6th order derivatives) "
-            "and <= block_factor/min_box_size");
+            "and <= min_box_size (aka block_factor)");
         check_parameter("tag_buffer_size", tag_buffer_size,
                         tag_buffer_size >= 0, "must be >= 0");
         // assume ref_ratio is always 2
@@ -384,12 +384,12 @@ class ChomboParameters
     double coarsest_dx; // The coarsest resolution
     int max_level;      // the max number of regriddings to do
     int max_spatial_derivative_order; // The maximum order of the spatial
-                                      // derivatives This parameter does nothing
+                                      // derivatives - does nothing
                                       // in Chombo but can be used in examples
-    int num_ghosts;                   // must be at least 3 for KO dissipation
-    int tag_buffer_size;              // Amount the tagged region is grown by
-    int grid_buffer_size;             // Number of cells between level
-    Vector<int> ref_ratios;           // ref ratios between levels
+    int num_ghosts;         // min dependent on max_spatial_derivative_order
+    int tag_buffer_size;    // Amount the tagged region is grown by
+    int grid_buffer_size;   // Number of cells between level
+    Vector<int> ref_ratios; // ref ratios between levels
     // boundaries.
     Vector<int> regrid_interval; // steps between regrid at each level
     int max_steps;

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -36,7 +36,10 @@ class ChomboParameters
     {
         pp.load("verbosity", verbosity, 0);
         // Grid setup
-        pp.load("num_ghosts", num_ghosts, 3);
+        pp.load("max_spatial_derivative_order", max_spatial_derivative_order,
+                4);
+        pp.load("num_ghosts", num_ghosts,
+                (max_spatial_derivative_order == 6) ? 4 : 3);
         pp.load("tag_buffer_size", tag_buffer_size, 3);
         pp.load("grid_buffer_size", grid_buffer_size, 8);
         pp.load("dt_multiplier", dt_multiplier, 0.25);
@@ -279,11 +282,19 @@ class ChomboParameters
     {
         check_parameter("L", L, L > 0.0, "must be > 0.0");
         check_parameter("max_level", max_level, max_level >= 0, "must be >= 0");
-        // the following check assumes you will be taking some fourth (or
-        // higher) order one-sided derivatives
-        check_parameter("num_ghosts", num_ghosts,
-                        (num_ghosts >= 3) && (num_ghosts <= block_factor),
-                        "must be >= 3 and <= block_factor/min_box_size");
+        check_parameter("max_spatial_derivative_order",
+                        max_spatial_derivative_order,
+                        max_spatial_derivative_order == 4 ||
+                            max_spatial_derivative_order == 6,
+                        "only 4 and 6 are supported");
+        // the following check assumes you will be taking one-sided derivatives
+        // of the order given by max_spatial_derivative_order
+        check_parameter(
+            "num_ghosts", num_ghosts,
+            (num_ghosts >= ((max_spatial_derivative_order == 6) ? 4 : 3)) &&
+                (num_ghosts <= block_factor),
+            "must be >= 3 (4th order derivatives) or 4 (6th order derivatives) "
+            "and <= block_factor/min_box_size");
         check_parameter("tag_buffer_size", tag_buffer_size,
                         tag_buffer_size >= 0, "must be >= 0");
         // assume ref_ratio is always 2
@@ -369,13 +380,16 @@ class ChomboParameters
     int verbosity;
     double L;                               // Physical sidelength of the grid
     std::array<double, CH_SPACEDIM> center; // grid center
-    IntVect ivN;            // The number of grid cells in each dimension
-    double coarsest_dx;     // The coarsest resolution
-    int max_level;          // the max number of regriddings to do
-    int num_ghosts;         // must be at least 3 for KO dissipation
-    int tag_buffer_size;    // Amount the tagged region is grown by
-    int grid_buffer_size;   // Number of cells between level
-    Vector<int> ref_ratios; // ref ratios between levels
+    IntVect ivN;        // The number of grid cells in each dimension
+    double coarsest_dx; // The coarsest resolution
+    int max_level;      // the max number of regriddings to do
+    int max_spatial_derivative_order; // The maximum order of the spatial
+                                      // derivatives This parameter does nothing
+                                      // in Chombo but can be used in examples
+    int num_ghosts;                   // must be at least 3 for KO dissipation
+    int tag_buffer_size;              // Amount the tagged region is grown by
+    int grid_buffer_size;             // Number of cells between level
+    Vector<int> ref_ratios;           // ref ratios between levels
     // boundaries.
     Vector<int> regrid_interval; // steps between regrid at each level
     int max_steps;

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -248,34 +248,31 @@ class ChomboParameters
                                          (ivN[idir] + 1) * coarsest_dx;
         }
 
-        // Grid center
-        // now that L is surely set, get center
+        // First work out the default center ignoring reflective BCs
+        // but taking into account different grid lengths in each direction
+        std::array<double, CH_SPACEDIM> default_center;
 #if CH_SPACEDIM == 3
-        pp.load("center", center,
-                {0.5 * Ni[0] * coarsest_dx, 0.5 * Ni[1] * coarsest_dx,
-                 0.5 * Ni[2] * coarsest_dx}); // default to center
+        default_center = {0.5 * Ni[0] * coarsest_dx, 0.5 * Ni[1] * coarsest_dx,
+                          0.5 * Ni[2] * coarsest_dx};
 #elif CH_SPACEDIM == 2
-        pp.load("center", center,
-                {0.5 * Ni[0] * coarsest_dx,
-                 0.5 * Ni[1] * coarsest_dx}); // default to center
+        default_center = {0.5 * Ni[0] * coarsest_dx, 0.5 * Ni[1] * coarsest_dx};
 #endif
-
+        // Now take into account reflective BCs
         FOR1(idir)
         {
             if ((boundary_params.lo_boundary[idir] ==
                  BoundaryConditions::REFLECTIVE_BC) &&
                 (boundary_params.hi_boundary[idir] !=
                  BoundaryConditions::REFLECTIVE_BC))
-                center[idir] = 0.;
+                default_center[idir] = 0.;
             else if ((boundary_params.hi_boundary[idir] ==
                       BoundaryConditions::REFLECTIVE_BC) &&
                      (boundary_params.lo_boundary[idir] !=
                       BoundaryConditions::REFLECTIVE_BC))
-                center[idir] = coarsest_dx * Ni[idir];
+                default_center[idir] = coarsest_dx * Ni[idir];
         }
-        pout() << "Center has been set to: ";
-        FOR1(idir) { pout() << center[idir] << " "; }
-        pout() << endl;
+
+        pp.load("center", center, default_center); // default to center
     }
 
     void check_params()

--- a/Source/utils/ArrayTools.hpp
+++ b/Source/utils/ArrayTools.hpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <array>
 #include <string>
+#include <vector>
 
 /// A place for tools that operate on std::arrays
 namespace ArrayTools
@@ -50,6 +51,21 @@ std::string to_string(const std::array<T, N> a_array)
     out += std::to_string(a_array[N - 1]);
     return out;
 }
+
+// SFINAE for std::arrays and std::vectors
+template <typename T> struct is_std_array_or_vector : std::false_type
+{
+};
+
+template <typename elem_t>
+struct is_std_array_or_vector<std::vector<elem_t>> : std::true_type
+{
+};
+
+template <typename elem_t, std::size_t N>
+struct is_std_array_or_vector<std::array<elem_t, N>> : std::true_type
+{
+};
 } // namespace ArrayTools
 
 #endif /* ARRAYTOOLS_HPP */

--- a/Tests/DerivativeUnitTests/DerivativeTestsCompute.hpp
+++ b/Tests/DerivativeUnitTests/DerivativeTestsCompute.hpp
@@ -6,13 +6,12 @@
 #ifndef DERIVATIVETESTSCOMPUTE_HPP_
 #define DERIVATIVETESTSCOMPUTE_HPP_
 
-#include "FourthOrderDerivatives.hpp"
 #include "VarsTools.hpp"
 
-class DerivativeTestsCompute
+template <class deriv_t> class DerivativeTestsCompute
 {
   protected:
-    const FourthOrderDerivatives m_deriv;
+    const deriv_t m_deriv;
 
   public:
     DerivativeTestsCompute(double dx) : m_deriv(dx) {}

--- a/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
+++ b/Tests/DerivativeUnitTests/DerivativeUnitTests.cpp
@@ -13,6 +13,8 @@
 // Our includes
 #include "BoxLoops.hpp"
 #include "DerivativeTestsCompute.hpp"
+#include "FourthOrderDerivatives.hpp"
+#include "SixthOrderDerivatives.hpp"
 #include "UserVariables.hpp"
 
 // Chombo namespace
@@ -40,8 +42,8 @@ int main()
     // box is flat in y direction to make test cheaper
     IntVect domain_hi_vect(num_cells - 1, 0, num_cells - 1);
     Box box(IntVect(0, 0, 0), domain_hi_vect);
-    Box ghosted_box(IntVect(-3, -3, -3),
-                    IntVect(num_cells + 2, 3, num_cells + 2));
+    Box ghosted_box(IntVect(-4, -4, -4),
+                    IntVect(num_cells + 3, 4, num_cells + 3));
 
     FArrayBox in_fab(ghosted_box, NUM_VARS);
     FArrayBox out_fab(box, NUM_VARS);
@@ -62,8 +64,9 @@ int main()
                                       (z - 1) * z * pow(x, 6) / 720.;
     }
 
-    // Compute the derivatives for the timing comparison
-    BoxLoops::loop(DerivativeTestsCompute(dx), in_fab, out_fab);
+    // Fourth order derivatives
+    BoxLoops::loop(DerivativeTestsCompute<FourthOrderDerivatives>(dx), in_fab,
+                   out_fab);
 
     BoxIterator bit(box);
     for (bit.begin(); bit.ok(); ++bit)
@@ -72,22 +75,58 @@ int main()
         const double z = (0.5 + bit()[2]) * dx;
 
         bool error = false;
-        error |= is_wrong(out_fab(bit(), c_d1), 2 * x * (z - 0.5), "diff1");
-        error |= is_wrong(out_fab(bit(), c_d2), 2 * x, "diff2");
-        error |=
-            is_wrong(out_fab(bit(), c_d2_mixed), 2 * (z - 0.5), "mixed diff2");
+        error |= is_wrong(out_fab(bit(), c_d1), 2 * x * (z - 0.5),
+                          "diff1 (fourth order)");
+        error |= is_wrong(out_fab(bit(), c_d2), 2 * x, "diff2 (fourth order)");
+        error |= is_wrong(out_fab(bit(), c_d2_mixed), 2 * (z - 0.5),
+                          "mixed diff2 (fourth order)");
 
         double correct_dissipation = (1. + z * (z - 1)) * pow(dx, 5) / 64;
         error |= is_wrong(out_fab(bit(), c_diss), correct_dissipation,
-                          "dissipation");
+                          "dissipation (fourth order)");
 
         double correct_advec_down = -2 * z * (z - 1) - 3 * x * (2 * z - 1);
         error |= is_wrong(out_fab(bit(), c_advec_down), correct_advec_down,
-                          "advection down");
+                          "advection down (fourth order)");
 
         double correct_advec_up = 2 * z * (z - 1) + 3 * x * (2 * z - 1);
         error |= is_wrong(out_fab(bit(), c_advec_up), correct_advec_up,
-                          "advection up");
+                          "advection up (fourth order)");
+
+        if (error)
+        {
+            std::cout << "Derivative unit tests NOT passed.\n";
+            return error;
+        }
+    }
+
+    // Sixth order derivatives
+    BoxLoops::loop(DerivativeTestsCompute<SixthOrderDerivatives>(dx), in_fab,
+                   out_fab);
+
+    for (bit.begin(); bit.ok(); ++bit)
+    {
+        const double x = (0.5 + bit()[0]) * dx;
+        const double z = (0.5 + bit()[2]) * dx;
+
+        bool error = false;
+        error |= is_wrong(out_fab(bit(), c_d1), 2 * x * (z - 0.5),
+                          "diff1 (sixth order)");
+        error |= is_wrong(out_fab(bit(), c_d2), 2 * x, "diff2 (sixth order)");
+        error |= is_wrong(out_fab(bit(), c_d2_mixed), 2 * (z - 0.5),
+                          "mixed diff2 (sixth order)");
+
+        double correct_dissipation = (1. + z * (z - 1)) * pow(dx, 5) / 64;
+        error |= is_wrong(out_fab(bit(), c_diss), correct_dissipation,
+                          "dissipation (sixth order)");
+
+        double correct_advec_down = -2 * z * (z - 1) - 3 * x * (2 * z - 1);
+        error |= is_wrong(out_fab(bit(), c_advec_down), correct_advec_down,
+                          "advection down (sixth order)");
+
+        double correct_advec_up = 2 * z * (z - 1) + 3 * x * (2 * z - 1);
+        error |= is_wrong(out_fab(bit(), c_advec_up), correct_advec_up,
+                          "advection up (sixth order)");
 
         if (error)
         {


### PR DESCRIPTION
This adds the sixth order derivatives code I used in [arXiv:2101.11015](https://arxiv.org/abs/2101.11015). It has been added to all of the examples and is enabled by setting the new `max_spatial_derivative_order` to `6` (it is defaulted to 4 and gives an error when set to any other value). Note that in the case `max_spatial_derivative_order == 6`, the default value of `num_ghosts` is automatically changed to `4` (as one needs). The "max" is in the name as it only affects the CCZ4RHS compute class (and not e.g. the constraint compute classes, tagging criterion, etc.) but of course a user is free to use the max for all their compute classes.

The Derivatives unit test has been modified to test both 4th and 6th order derivatives.

The order of the Kreiss-Oliger dissipation is 6th order (same as 4th order derivatives). Whilst naively you might think that one should go to a higher order than the order of the ordinary spatial derivatives (cf. Alcubierre p345), actually the relevant order to compare is that of the time integration (which is of course 4th order). I did try 8th order dissipation at one point but didn't get very good results (though the evolution was stable) with the 1 or 2 values of `sigma` I tried so have left it in the file but commented out. Note that the sign of the whole dissipation term needs to be changed in this case.

I have also added the printing of default parameter values in the pout files so it prints out e.g.
```
Parameter: fill_ratio not found in parameter file. It has been set to its default value = 0.7.
```
instead of
```
Parameter: fill_ratio not found in parameter file. It has been set to its default value.
```