### PR TITLE
Minor Optimisations

### DIFF
--- a/Source/CCZ4/Weyl4.impl.hpp
+++ b/Source/CCZ4/Weyl4.impl.hpp
@@ -68,7 +68,7 @@ Weyl4::compute_EB_fields(const Vars<data_t> &vars,
         for (int l = 0; l < 4; ++l)
         {
             epsilon3_LLL[i][j][k] += n_U[l] * epsilon4[i][j][k][l] *
-                                     vars.lapse * pow(vars.chi, -1.5);
+                                     vars.lapse / vars.chi / sqrt(vars.chi);
         }
     }
     // rasing indices
@@ -210,8 +210,9 @@ Weyl4::compute_null_tetrad(const Vars<data_t> &vars,
 
     FOR4(i, j, k, m)
     {
-        out.w[i] += pow(chi, -0.5) * h_UU[i][j] * epsilon[j][k][m] * out.v[k] *
-                    out.u[m];
+        out.w[i] += 1. / sqrt(chi) * h_UU[i][j] * epsilon[j][k][m] * out.v[k] *
+                     out.u[m];
+
     }
 
     // Gram Schmitt orthonormalisation

--- a/Source/CCZ4/Weyl4.impl.hpp
+++ b/Source/CCZ4/Weyl4.impl.hpp
@@ -68,7 +68,7 @@ Weyl4::compute_EB_fields(const Vars<data_t> &vars,
         for (int l = 0; l < 4; ++l)
         {
             epsilon3_LLL[i][j][k] += n_U[l] * epsilon4[i][j][k][l] *
-                                     vars.lapse / vars.chi / sqrt(vars.chi);
+                                     vars.lapse / (vars.chi * sqrt(vars.chi));
         }
     }
     // rasing indices
@@ -211,8 +211,7 @@ Weyl4::compute_null_tetrad(const Vars<data_t> &vars,
     FOR4(i, j, k, m)
     {
         out.w[i] += 1. / sqrt(chi) * h_UU[i][j] * epsilon[j][k][m] * out.v[k] *
-                     out.u[m];
-
+                    out.u[m];
     }
 
     // Gram Schmitt orthonormalisation

--- a/Source/utils/Coordinates.hpp
+++ b/Source/utils/Coordinates.hpp
@@ -69,7 +69,7 @@ template <class data_t> class Coordinates
     data_t get_radius() const
     {
         // Note that this is not currently dimension independent
-        data_t r = sqrt(pow(x, 2) + pow(y, 2) + pow(z, 2));
+        data_t r = sqrt(x * x + y * y + z * z);
 
         const double minimum_r = 1e-6;
         return simd_max(r, minimum_r);
@@ -89,7 +89,7 @@ template <class data_t> class Coordinates
         compute_coord(yy, integer_coords[1], dx, center[1]);
         compute_coord(zz, integer_coords[2], dx, center[2]);
 
-        data_t r = sqrt(pow(xx, 2) + pow(yy, 2) + pow(zz, 2));
+        data_t r = sqrt(xx * xx + yy * yy + zz * zz);
 
         const double minimum_r = 1e-6;
         return simd_max(r, minimum_r);


### PR DESCRIPTION
This PR replaces `pow` where appropriate with `sqrt` or multiplication. This should be preferred as we have not implemented intrinsics for `pow`. Thanks to @draenog for spotting this.

I have not bothered to make this change in initial data compute classes since these do not matter during the evolution.