### PR TITLE
Add fancier FOR macro replacing FOR1,FOR2,...

### DIFF
--- a/Examples/BinaryBH/SimulationParameters.hpp
+++ b/Examples/BinaryBH/SimulationParameters.hpp
@@ -82,7 +82,7 @@ class SimulationParameters : public SimulationParametersBase
         pp.load("TP_momentum_plus", bh2_params.momentum);
         pp.load("TP_spin_plus", spin_plus);
         pp.load("TP_spin_minus", spin_minus);
-        FOR1(i)
+        FOR(i)
         {
             tp_params.par_P_minus[i] = bh1_params.momentum[i];
             tp_params.par_P_plus[i] = bh2_params.momentum[i];
@@ -92,15 +92,15 @@ class SimulationParameters : public SimulationParametersBase
 
         pout() << "The corresponding momenta are:";
         pout() << "\nP_plus = ";
-        FOR1(i) { pout() << tp_params.par_P_plus[i] << " "; }
+        FOR(i) { pout() << tp_params.par_P_plus[i] << " "; }
         pout() << "\nP_minus = ";
-        FOR1(i) { pout() << tp_params.par_P_minus[i] << " "; }
+        FOR(i) { pout() << tp_params.par_P_minus[i] << " "; }
 
         pout() << "\nThe corresponding spins are:";
         pout() << "\nS_plus = ";
-        FOR1(i) { pout() << tp_params.par_S_plus[i] << " "; }
+        FOR(i) { pout() << tp_params.par_S_plus[i] << " "; }
         pout() << "\nS_minus = ";
-        FOR1(i) { pout() << tp_params.par_S_minus[i] << " "; }
+        FOR(i) { pout() << tp_params.par_S_minus[i] << " "; }
         pout() << "\n";
 
         // interpolation type
@@ -199,7 +199,7 @@ class SimulationParameters : public SimulationParametersBase
         pp.load("centerB", centerB, center);
         pp.load("offsetA", offsetA, {0.0, 0.0, 0.0});
         pp.load("offsetB", offsetB, {0.0, 0.0, 0.0});
-        FOR1(idir)
+        FOR(idir)
         {
             bh1_params.center[idir] = centerA[idir] + offsetA[idir];
             bh2_params.center[idir] = centerB[idir] + offsetB[idir];
@@ -273,7 +273,7 @@ class SimulationParameters : public SimulationParametersBase
             std::sqrt(ArrayTools::norm2(bh2_params.momentum)) <
                 0.3 * bh1_params.mass,
             "approximation used for boosted BH only valid for small boosts");
-        FOR1(idir)
+        FOR(idir)
         {
             std::string nameA = "centerA[" + std::to_string(idir) + "]";
             std::string nameB = "centerB[" + std::to_string(idir) + "]";

--- a/Examples/KerrBH/SimulationParameters.hpp
+++ b/Examples/KerrBH/SimulationParameters.hpp
@@ -39,7 +39,7 @@ class SimulationParameters : public SimulationParametersBase
                         std::abs(kerr_params.spin) <= kerr_params.mass,
                         "must satisfy |a| <= M = " +
                             std::to_string(kerr_params.mass));
-        FOR1(idir)
+        FOR(idir)
         {
             std::string name = "kerr_center[" + std::to_string(idir) + "]";
             warn_parameter(

--- a/Examples/ScalarField/SimulationParameters.hpp
+++ b/Examples/ScalarField/SimulationParameters.hpp
@@ -58,7 +58,7 @@ class SimulationParameters : public SimulationParametersBase
                         std::abs(kerr_params.spin) <= kerr_params.mass,
                         "must satisfy |a| <= M = " +
                             std::to_string(kerr_params.mass));
-        FOR1(idir)
+        FOR(idir)
         {
             std::string name = "kerr_center[" + std::to_string(idir) + "]";
             warn_parameter(

--- a/Source/AMRInterpolator/AMRInterpolator.impl.hpp
+++ b/Source/AMRInterpolator/AMRInterpolator.impl.hpp
@@ -806,7 +806,7 @@ void AMRInterpolator<InterpAlgo>::set_reflective_BC()
                                  .domainBox()
                                  .bigEnd();
 
-    FOR1(i)
+    FOR(i)
     {
         m_upper_corner[i] = (big_end[i] + 1) * m_coarsest_dx[i];
 
@@ -834,7 +834,7 @@ int AMRInterpolator<InterpAlgo>::get_var_parity(int comp,
                       "extracting diagnostic variables with reflective BC");
 
     int parity = 1;
-    FOR1(dir)
+    FOR(dir)
     {
         double coord = query.m_coords[dir][point_idx];
         if ((m_lo_boundary_reflective[dir] && coord < 0.) ||

--- a/Source/AMRInterpolator/SurfaceExtraction.impl.hpp
+++ b/Source/AMRInterpolator/SurfaceExtraction.impl.hpp
@@ -40,7 +40,7 @@ SurfaceExtraction<SurfaceGeometry>::SurfaceExtraction(
     // only interp points on rank 0
     if (procID() == 0)
     {
-        FOR1(idir) { m_interp_coords[idir].resize(m_num_interp_points); }
+        FOR(idir) { m_interp_coords[idir].resize(m_num_interp_points); }
 
         for (int isurface = 0; isurface < m_params.num_surfaces; ++isurface)
         {
@@ -52,7 +52,7 @@ SurfaceExtraction<SurfaceGeometry>::SurfaceExtraction(
                 for (int iv = 0; iv < m_params.num_points_v; ++iv)
                 {
                     double v = m_geom.v(iv, m_params.num_points_v);
-                    FOR1(idir)
+                    FOR(idir)
                     {
                         int idx = index(isurface, iu, iv);
                         m_interp_coords[idir][idx] = m_geom.get_grid_coord(
@@ -147,7 +147,7 @@ void SurfaceExtraction<SurfaceGeometry>::extract(
     }
     // m_num_interp_points is 0 on ranks > 0
     InterpolationQuery query(m_num_interp_points);
-    FOR1(idir) { query.setCoords(idir, m_interp_coords[idir].data()); }
+    FOR(idir) { query.setCoords(idir, m_interp_coords[idir].data()); }
     for (int ivar = 0; ivar < m_vars.size(); ++ivar)
     {
         // note the difference in order between the m_vars tuple in this class

--- a/Source/BlackHoles/PunctureTracker.cpp
+++ b/Source/BlackHoles/PunctureTracker.cpp
@@ -58,7 +58,7 @@ void PunctureTracker::set_initial_punctures()
     for (int ipuncture = 0; ipuncture < m_num_punctures; ipuncture++)
     {
         // assume initial shift is always zero
-        FOR1(i) { m_puncture_shift[ipuncture][i] = 0.0; }
+        FOR(i) { m_puncture_shift[ipuncture][i] = 0.0; }
     }
 
     // now the write out to a new file
@@ -153,7 +153,7 @@ void PunctureTracker::execute_tracking(double a_time, double a_restart_time,
     // update puncture locations using second order update
     for (int ipuncture = 0; ipuncture < m_num_punctures; ipuncture++)
     {
-        FOR1(i)
+        FOR(i)
         {
             m_puncture_coords[ipuncture][i] +=
                 -0.5 * a_dt *

--- a/Source/BoxUtils/ComputeModGrad.hpp
+++ b/Source/BoxUtils/ComputeModGrad.hpp
@@ -28,12 +28,12 @@ class ComputeModGrad
     template <class data_t> void compute(Cell<data_t> current_cell) const
     {
         Tensor<1, data_t> d1_arr[NUM_VARS];
-        FOR1(idir) m_deriv.diff1(d1_arr, current_cell, idir);
+        FOR(idir) m_deriv.diff1(d1_arr, current_cell, idir);
 
         std::array<data_t, NUM_VARS> mod_d1_arr = {0.};
         for (int ivar = 0; ivar < NUM_VARS; ++ivar)
         {
-            FOR1(idir)
+            FOR(idir)
             {
                 mod_d1_arr[ivar] += d1_arr[ivar][idir] * d1_arr[ivar][idir];
             }

--- a/Source/BoxUtils/FourthOrderDerivatives.hpp
+++ b/Source/BoxUtils/FourthOrderDerivatives.hpp
@@ -70,7 +70,7 @@ class FourthOrderDerivatives
         const auto strides = current_cell.get_box_pointers().m_in_stride;
         vars_t<Tensor<1, data_t>> d1;
         d1.enum_mapping([&](const int &ivar, Tensor<1, data_t> &var) {
-            FOR1(idir)
+            FOR(idir)
             {
                 var[idir] = diff1<data_t>(
                     current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
@@ -236,7 +236,7 @@ class FourthOrderDerivatives
         const auto in_index = current_cell.get_in_index();
         const auto strides = current_cell.get_box_pointers().m_in_stride;
         d2.enum_mapping([&](const int &ivar, Tensor<2, data_t> &var) {
-            FOR1(dir1) // First calculate the repeated derivatives
+            FOR(dir1) // First calculate the repeated derivatives
             {
                 var[dir1][dir1] = diff2<data_t>(
                     current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
@@ -332,7 +332,7 @@ class FourthOrderDerivatives
         vars_t<data_t> advec;
         advec.enum_mapping([&](const int &ivar, data_t &var) {
             var = 0.;
-            FOR1(dir)
+            FOR(dir)
             {
                 const auto shift_positive = simd_compare_gt(vector[dir], 0.0);
                 var += advection_term(
@@ -382,7 +382,7 @@ class FourthOrderDerivatives
     {
         const auto in_index = current_cell.get_in_index();
         vars.enum_mapping([&](const int &ivar, data_t &var) {
-            FOR1(dir)
+            FOR(dir)
             {
                 const auto stride =
                     current_cell.get_box_pointers().m_in_stride[dir];

--- a/Source/BoxUtils/SixthOrderDerivatives.hpp
+++ b/Source/BoxUtils/SixthOrderDerivatives.hpp
@@ -73,7 +73,7 @@ class SixthOrderDerivatives
         const auto strides = current_cell.get_box_pointers().m_in_stride;
         vars_t<Tensor<1, data_t>> d1;
         d1.enum_mapping([&](const int &ivar, Tensor<1, data_t> &var) {
-            FOR1(idir)
+            FOR(idir)
             {
                 var[idir] = diff1<data_t>(
                     current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
@@ -267,7 +267,7 @@ class SixthOrderDerivatives
         const auto in_index = current_cell.get_in_index();
         const auto strides = current_cell.get_box_pointers().m_in_stride;
         d2.enum_mapping([&](const int &ivar, Tensor<2, data_t> &var) {
-            FOR1(dir1) // First calculate the repeated derivatives
+            FOR(dir1) // First calculate the repeated derivatives
             {
                 var[dir1][dir1] = diff2<data_t>(
                     current_cell.get_box_pointers().m_in_ptr[ivar], in_index,
@@ -369,7 +369,7 @@ class SixthOrderDerivatives
         vars_t<data_t> advec;
         advec.enum_mapping([&](const int &ivar, data_t &var) {
             var = 0.;
-            FOR1(dir)
+            FOR(dir)
             {
                 const auto shift_positive = simd_compare_gt(vector[dir], 0.0);
                 var += advection_term(
@@ -448,7 +448,7 @@ class SixthOrderDerivatives
     {
         const auto in_index = current_cell.get_in_index();
         vars.enum_mapping([&](const int &ivar, data_t &var) {
-            FOR1(dir)
+            FOR(dir)
             {
                 const auto stride =
                     current_cell.get_box_pointers().m_in_stride[dir];

--- a/Source/CCZ4/CCZ4Geometry.hpp
+++ b/Source/CCZ4/CCZ4Geometry.hpp
@@ -36,7 +36,7 @@ class CCZ4Geometry
                     const Tensor<2, data_t> &h, const Tensor<1, data_t> &d1_chi)
     {
         data_t out = 0.;
-        FOR1(k)
+        FOR(k)
         {
             out += Z_over_chi[k] * (h[i][k] * d1_chi[j] + h[j][k] * d1_chi[i] -
                                     h[i][j] * d1_chi[k]);
@@ -57,29 +57,26 @@ class CCZ4Geometry
         ricci_t<data_t> out;
 
         Tensor<2, data_t> covdtilde2chi;
-        FOR2(k, l)
+        FOR(k, l)
         {
             covdtilde2chi[k][l] = d2.chi[k][l];
-            FOR1(m) { covdtilde2chi[k][l] -= chris.ULL[m][k][l] * d1.chi[m]; }
+            FOR(m) { covdtilde2chi[k][l] -= chris.ULL[m][k][l] * d1.chi[m]; }
         }
 
         Tensor<3, data_t> chris_LLU = {0.};
         data_t boxtildechi = 0.;
         data_t dchi_dot_dchi = 0.;
-        FOR2(i, j)
+        FOR(i, j)
         {
             boxtildechi += covdtilde2chi[i][j] * h_UU[i][j];
             dchi_dot_dchi += d1.chi[i] * d1.chi[j] * h_UU[i][j];
-            FOR2(k, l)
-            {
-                chris_LLU[i][j][k] += h_UU[k][l] * chris.LLL[i][j][l];
-            }
+            FOR(k, l) { chris_LLU[i][j][k] += h_UU[k][l] * chris.LLL[i][j][l]; }
         }
 
-        FOR2(i, j)
+        FOR(i, j)
         {
             data_t ricci_hat = 0;
-            FOR1(k)
+            FOR(k)
             {
                 // We call this ricci_hat rather than ricci_tilde as we have
                 // replaced what should be \tilde{Gamma} with \hat{Gamma} in
@@ -87,7 +84,7 @@ class CCZ4Geometry
                 ricci_hat += 0.5 * (vars.h[k][i] * d1.Gamma[k][j] +
                                     vars.h[k][j] * d1.Gamma[k][i]);
                 ricci_hat += 0.5 * vars.Gamma[k] * d1.h[i][j][k];
-                FOR1(l)
+                FOR(l)
                 {
                     ricci_hat += -0.5 * h_UU[k][l] * d2.h[i][j][k][l] +
                                  (chris.ULL[k][l][i] * chris_LLU[j][k][l] +
@@ -121,12 +118,12 @@ class CCZ4Geometry
                                 const Tensor<2, Tensor<2, data_t>> &d2_h)
     {
         Tensor<2, data_t> d1_chris_contracted = 0.0;
-        FOR2(i, j)
+        FOR(i, j)
         {
-            FOR3(m, n, p)
+            FOR(m, n, p)
             {
                 data_t d1_terms = 0.0;
-                FOR2(q, r)
+                FOR(q, r)
                 {
                     d1_terms += -h_UU[q][r] * (d1_h[n][q][j] * d1_h[m][p][r] +
                                                d1_h[m][n][j] * d1_h[p][q][r]);
@@ -158,10 +155,10 @@ class CCZ4Geometry
         auto d1_chris_contracted =
             compute_d1_chris_contracted(h_UU, d1.h, d2.h);
         Tensor<1, data_t> Z_over_chi;
-        FOR1(i) { Z_over_chi[i] = 0.5 * (vars.Gamma[i] - chris.contracted[i]); }
-        FOR2(i, j)
+        FOR(i) { Z_over_chi[i] = 0.5 * (vars.Gamma[i] - chris.contracted[i]); }
+        FOR(i, j)
         {
-            FOR1(m)
+            FOR(m)
             {
                 // This corrects for the \hat{Gamma}s in ricci_hat
                 ricci.LL[i][j] +=

--- a/Source/CCZ4/CCZ4RHS.impl.hpp
+++ b/Source/CCZ4/CCZ4RHS.impl.hpp
@@ -73,13 +73,13 @@ void CCZ4RHS<gauge_t, deriv_t>::rhs_equation(
 
     if (m_formulation == USE_BSSN)
     {
-        FOR1(i) Z_over_chi[i] = 0.0;
+        FOR(i) Z_over_chi[i] = 0.0;
     }
     else
     {
-        FOR1(i) Z_over_chi[i] = 0.5 * (vars.Gamma[i] - chris.contracted[i]);
+        FOR(i) Z_over_chi[i] = 0.5 * (vars.Gamma[i] - chris.contracted[i]);
     }
-    FOR1(i) Z[i] = vars.chi * Z_over_chi[i];
+    FOR(i) Z[i] = vars.chi * Z_over_chi[i];
 
     auto ricci =
         CCZ4Geometry::compute_ricci_Z(vars, d1, d2, h_UU, chris, Z_over_chi);
@@ -90,10 +90,10 @@ void CCZ4RHS<gauge_t, deriv_t>::rhs_equation(
 
     Tensor<2, data_t> covdtilde2lapse;
     Tensor<2, data_t> covd2lapse;
-    FOR2(k, l)
+    FOR(k, l)
     {
         covdtilde2lapse[k][l] = d2.lapse[k][l];
-        FOR1(m) { covdtilde2lapse[k][l] -= chris.ULL[m][k][l] * d1.lapse[m]; }
+        FOR(m) { covdtilde2lapse[k][l] -= chris.ULL[m][k][l] * d1.lapse[m]; }
         covd2lapse[k][l] =
             vars.chi * covdtilde2lapse[k][l] +
             0.5 * (d1.lapse[k] * d1.chi[l] + d1.chi[k] * d1.lapse[l] -
@@ -101,10 +101,10 @@ void CCZ4RHS<gauge_t, deriv_t>::rhs_equation(
     }
 
     data_t tr_covd2lapse = -(GR_SPACEDIM / 2.0) * dlapse_dot_dchi;
-    FOR1(i)
+    FOR(i)
     {
         tr_covd2lapse -= vars.chi * chris.contracted[i] * d1.lapse[i];
-        FOR1(j)
+        FOR(j)
         {
             tr_covd2lapse += h_UU[i][j] * (vars.chi * d2.lapse[i][j] +
                                            d1.lapse[i] * d1.chi[j]);
@@ -117,11 +117,11 @@ void CCZ4RHS<gauge_t, deriv_t>::rhs_equation(
     data_t tr_A2 = compute_trace(vars.A, A_UU);
     rhs.chi = advec.chi +
               (2.0 / GR_SPACEDIM) * vars.chi * (vars.lapse * vars.K - divshift);
-    FOR2(i, j)
+    FOR(i, j)
     {
         rhs.h[i][j] = advec.h[i][j] - 2.0 * vars.lapse * vars.A[i][j] -
                       (2.0 / GR_SPACEDIM) * vars.h[i][j] * divshift;
-        FOR1(k)
+        FOR(k)
         {
             rhs.h[i][j] +=
                 vars.h[k][i] * d1.shift[k][j] + vars.h[k][j] * d1.shift[k][i];
@@ -129,23 +129,23 @@ void CCZ4RHS<gauge_t, deriv_t>::rhs_equation(
     }
 
     Tensor<2, data_t> Adot_TF;
-    FOR2(i, j)
+    FOR(i, j)
     {
         Adot_TF[i][j] =
             -covd2lapse[i][j] + vars.chi * vars.lapse * ricci.LL[i][j];
     }
     make_trace_free(Adot_TF, vars.h, h_UU);
 
-    FOR2(i, j)
+    FOR(i, j)
     {
         rhs.A[i][j] = advec.A[i][j] + Adot_TF[i][j] +
                       vars.A[i][j] * (vars.lapse * (vars.K - 2 * vars.Theta) -
                                       (2.0 / GR_SPACEDIM) * divshift);
-        FOR1(k)
+        FOR(k)
         {
             rhs.A[i][j] +=
                 vars.A[k][i] * d1.shift[k][j] + vars.A[k][j] * d1.shift[k][i];
-            FOR1(l)
+            FOR(l)
             {
                 rhs.A[i][j] -=
                     2 * vars.lapse * h_UU[k][l] * vars.A[i][k] * vars.A[l][j];
@@ -191,14 +191,14 @@ void CCZ4RHS<gauge_t, deriv_t>::rhs_equation(
     }
 
     Tensor<1, data_t> Gammadot;
-    FOR1(i)
+    FOR(i)
     {
         Gammadot[i] = (2.0 / GR_SPACEDIM) *
                           (divshift * (chris.contracted[i] +
                                        2 * m_params.kappa3 * Z_over_chi[i]) -
                            2 * vars.lapse * vars.K * Z_over_chi[i]) -
                       2 * kappa1_times_lapse * Z_over_chi[i];
-        FOR1(j)
+        FOR(j)
         {
             Gammadot[i] +=
                 2 * h_UU[i][j] *
@@ -210,7 +210,7 @@ void CCZ4RHS<gauge_t, deriv_t>::rhs_equation(
                 (chris.contracted[j] + 2 * m_params.kappa3 * Z_over_chi[j]) *
                     d1.shift[i][j];
 
-            FOR1(k)
+            FOR(k)
             {
                 Gammadot[i] +=
                     2 * vars.lapse * chris.ULL[i][j][k] * A_UU[j][k] +
@@ -221,7 +221,7 @@ void CCZ4RHS<gauge_t, deriv_t>::rhs_equation(
         }
     }
 
-    FOR1(i) { rhs.Gamma[i] = advec.Gamma[i] + Gammadot[i]; }
+    FOR(i) { rhs.Gamma[i] = advec.Gamma[i] + Gammadot[i]; }
 
     m_gauge.rhs_gauge(rhs, vars, d1, d2, advec);
 }

--- a/Source/CCZ4/Constraints.impl.hpp
+++ b/Source/CCZ4/Constraints.impl.hpp
@@ -56,18 +56,18 @@ Constraints::Vars<data_t> Constraints::constraint_equations(
     out.Ham -= 2 * m_cosmological_constant;
 
     Tensor<2, data_t> covd_A[CH_SPACEDIM];
-    FOR3(i, j, k)
+    FOR(i, j, k)
     {
         covd_A[i][j][k] = d1.A[j][k][i];
-        FOR1(l)
+        FOR(l)
         {
             covd_A[i][j][k] += -chris.ULL[l][i][j] * vars.A[l][k] -
                                chris.ULL[l][i][k] * vars.A[l][j];
         }
     }
 
-    FOR1(i) { out.Mom[i] = -(GR_SPACEDIM - 1.) * d1.K[i] / GR_SPACEDIM; }
-    FOR3(i, j, k)
+    FOR(i) { out.Mom[i] = -(GR_SPACEDIM - 1.) * d1.K[i] / GR_SPACEDIM; }
+    FOR(i, j, k)
     {
         out.Mom[i] += h_UU[j][k] *
                       (covd_A[k][j][i] - GR_SPACEDIM * vars.A[i][j] *

--- a/Source/CCZ4/IntegratedMovingPunctureGauge.hpp
+++ b/Source/CCZ4/IntegratedMovingPunctureGauge.hpp
@@ -63,7 +63,7 @@ class IntegratedMovingPunctureGauge
         const auto vars = current_cell.template load_vars<Vars>();
 
         Tensor<1, data_t> B;
-        FOR1(i)
+        FOR(i)
         {
             B[i] = m_params.shift_Gamma_coeff * vars.Gamma[i] -
                    m_params.eta * vars.shift[i];
@@ -83,7 +83,7 @@ class IntegratedMovingPunctureGauge
                     m_params.lapse_coeff *
                         pow(vars.lapse, m_params.lapse_power) *
                         (vars.K - 2 * vars.Theta);
-        FOR1(i)
+        FOR(i)
         {
             rhs.shift[i] = m_params.shift_advec_coeff * advec.shift[i] +
                            m_params.shift_Gamma_coeff * vars.Gamma[i] -

--- a/Source/CCZ4/MovingPunctureGauge.hpp
+++ b/Source/CCZ4/MovingPunctureGauge.hpp
@@ -55,7 +55,7 @@ class MovingPunctureGauge
                     m_params.lapse_coeff *
                         pow(vars.lapse, m_params.lapse_power) *
                         (vars.K - 2 * vars.Theta);
-        FOR1(i)
+        FOR(i)
         {
             rhs.shift[i] = m_params.shift_advec_coeff * advec.shift[i] +
                            m_params.shift_Gamma_coeff * vars.B[i];

--- a/Source/CCZ4/NewConstraints.impl.hpp
+++ b/Source/CCZ4/NewConstraints.impl.hpp
@@ -70,16 +70,16 @@ Constraints::Vars<data_t> Constraints::constraint_equations(
     if (m_c_Moms.size() > 0 || m_c_Moms_abs_terms.size() > 0)
     {
         Tensor<2, data_t> covd_A[CH_SPACEDIM];
-        FOR3(i, j, k)
+        FOR(i, j, k)
         {
             covd_A[i][j][k] = d1.A[j][k][i];
-            FOR1(l)
+            FOR(l)
             {
                 covd_A[i][j][k] += -chris.ULL[l][i][j] * vars.A[l][k] -
                                    chris.ULL[l][i][k] * vars.A[l][j];
             }
         }
-        FOR1(i)
+        FOR(i)
         {
             out.Mom[i] = -(GR_SPACEDIM - 1.) * d1.K[i] / GR_SPACEDIM;
             out.Mom_abs_terms[i] = abs(out.Mom[i]);
@@ -87,13 +87,13 @@ Constraints::Vars<data_t> Constraints::constraint_equations(
         Tensor<1, data_t> covd_A_term = 0.0;
         Tensor<1, data_t> d1_chi_term = 0.0;
         const data_t chi_regularised = simd_max(1e-6, vars.chi);
-        FOR3(i, j, k)
+        FOR(i, j, k)
         {
             covd_A_term[i] += h_UU[j][k] * covd_A[k][j][i];
             d1_chi_term[i] += -GR_SPACEDIM * h_UU[j][k] * vars.A[i][j] *
                               d1.chi[k] / (2 * chi_regularised);
         }
-        FOR1(i)
+        FOR(i)
         {
             out.Mom[i] += covd_A_term[i] + d1_chi_term[i];
             out.Mom_abs_terms[i] += abs(covd_A_term[i]) + abs(d1_chi_term[i]);
@@ -112,7 +112,7 @@ void Constraints::store_vars(Vars<data_t> &out,
         current_cell.store_vars(out.Ham_abs_terms, m_c_Ham_abs_terms);
     if (m_c_Moms.size() == GR_SPACEDIM)
     {
-        FOR1(i)
+        FOR(i)
         {
             int ivar = m_c_Moms.begin() + i;
             current_cell.store_vars(out.Mom[i], ivar);
@@ -121,13 +121,13 @@ void Constraints::store_vars(Vars<data_t> &out,
     else if (m_c_Moms.size() == 1)
     {
         data_t Mom_sq = 0.0;
-        FOR1(i) { Mom_sq += out.Mom[i] * out.Mom[i]; }
+        FOR(i) { Mom_sq += out.Mom[i] * out.Mom[i]; }
         data_t Mom = sqrt(Mom_sq);
         current_cell.store_vars(Mom, m_c_Moms.begin());
     }
     if (m_c_Moms_abs_terms.size() == GR_SPACEDIM)
     {
-        FOR1(i)
+        FOR(i)
         {
             int ivar = m_c_Moms_abs_terms.begin() + i;
             current_cell.store_vars(out.Mom_abs_terms[i], ivar);
@@ -136,7 +136,7 @@ void Constraints::store_vars(Vars<data_t> &out,
     else if (m_c_Moms_abs_terms.size() == 1)
     {
         data_t Mom_abs_terms_sq = 0.0;
-        FOR1(i)
+        FOR(i)
         {
             Mom_abs_terms_sq += out.Mom_abs_terms[i] * out.Mom_abs_terms[i];
         }

--- a/Source/CCZ4/Weyl4.impl.hpp
+++ b/Source/CCZ4/Weyl4.impl.hpp
@@ -50,7 +50,7 @@ Weyl4::compute_epsilon3_LUU(const Vars<data_t> &vars,
     // raised normal vector, NB index 3 is time
     data_t n_U[4];
     n_U[3] = 1. / vars.lapse;
-    FOR1(i) { n_U[i] = -vars.shift[i] / vars.lapse; }
+    FOR(i) { n_U[i] = -vars.shift[i] / vars.lapse; }
 
     // 4D levi civita symbol and 3D levi civita tensor in LLL and LUU form
     const auto epsilon4 = TensorAlgebra::epsilon4D();
@@ -59,14 +59,14 @@ Weyl4::compute_epsilon3_LUU(const Vars<data_t> &vars,
 
     // Projection of antisymmentric Tensor onto hypersurface - see 8.3.17,
     // Alcubierre
-    FOR3(i, j, k)
+    FOR(i, j, k)
     {
         epsilon3_LLL[i][j][k] = 0.0;
         epsilon3_LUU[i][j][k] = 0.0;
     }
     // projection of 4-antisymetric tensor to 3-tensor on hypersurface
     // note last index contracted as per footnote 86 pg 290 Alcubierre
-    FOR3(i, j, k)
+    FOR(i, j, k)
     {
         for (int l = 0; l < 4; ++l)
         {
@@ -75,9 +75,9 @@ Weyl4::compute_epsilon3_LUU(const Vars<data_t> &vars,
         }
     }
     // rasing indices
-    FOR3(i, j, k)
+    FOR(i, j, k)
     {
-        FOR2(m, n)
+        FOR(m, n)
         {
             epsilon3_LUU[i][j][k] += epsilon3_LLL[i][m][n] * h_UU[m][j] *
                                      vars.chi * h_UU[n][k] * vars.chi;
@@ -118,12 +118,12 @@ EBFields_t<data_t> Weyl4::compute_EB_fields(
         compute_phys_chris(d1.chi, vars.chi, vars.h, h_UU, chris.ULL);
 
     // Extrinsic curvature and corresponding covariant and partial derivatives
-    FOR2(i, j)
+    FOR(i, j)
     {
         K_tensor[i][j] = vars.A[i][j] / vars.chi +
                          1. / 3. * (vars.h[i][j] * vars.K) / vars.chi;
 
-        FOR1(k)
+        FOR(k)
         {
             d1_K_tensor[i][j][k] = d1.A[i][j][k] / vars.chi -
                                    d1.chi[k] / vars.chi * K_tensor[i][j] +
@@ -132,11 +132,11 @@ EBFields_t<data_t> Weyl4::compute_EB_fields(
         }
     }
     // covariant derivative of K
-    FOR3(i, j, k)
+    FOR(i, j, k)
     {
         covariant_deriv_K_tensor[i][j][k] = d1_K_tensor[i][j][k];
 
-        FOR1(l)
+        FOR(l)
         {
             covariant_deriv_K_tensor[i][j][k] +=
                 -chris_phys[l][k][i] * K_tensor[l][j] -
@@ -151,18 +151,18 @@ EBFields_t<data_t> Weyl4::compute_EB_fields(
         K_minus_theta -= vars.Theta;
 
     // Calculate electric and magnetic fields
-    FOR2(i, j)
+    FOR(i, j)
     {
         out.E[i][j] = 0.0;
         out.B[i][j] = 0.0;
     }
 
-    FOR2(i, j)
+    FOR(i, j)
     {
         out.E[i][j] +=
             ricci_and_Z_terms.LL[i][j] + K_minus_theta * K_tensor[i][j];
 
-        FOR2(k, l)
+        FOR(k, l)
         {
             out.E[i][j] +=
                 -K_tensor[i][k] * K_tensor[l][j] * h_UU[k][l] * vars.chi;
@@ -206,7 +206,7 @@ NPScalar_t<data_t> Weyl4::compute_Weyl4(const EBFields_t<data_t> &ebfields,
     // Projection of Electric and magnetic field components using tetrads
     out.Real = 0.0;
     out.Im = 0.0;
-    FOR2(i, j)
+    FOR(i, j)
     {
         out.Real += 0.5 * (ebfields.E[i][j] * (tetrad.w[i] * tetrad.w[j] -
                                                tetrad.v[i] * tetrad.v[j]) -
@@ -255,7 +255,7 @@ Weyl4::compute_null_tetrad(const Vars<data_t> &vars,
     // floor on chi
     const data_t chi = simd_max(vars.chi, 1e-4);
 
-    FOR4(i, j, k, m)
+    FOR(i, j, k, m)
     {
         out.w[i] += 1. / sqrt(chi) * h_UU[i][j] * epsilon[j][k][m] * out.v[k] *
                     out.u[m];
@@ -264,29 +264,29 @@ Weyl4::compute_null_tetrad(const Vars<data_t> &vars,
     // Gram Schmitt orthonormalisation
     // Choice of orthonormalisaion to avoid frame-dragging
     data_t omega_11 = 0.0;
-    FOR2(i, j) { omega_11 += out.v[i] * out.v[j] * vars.h[i][j] / chi; }
-    FOR1(i) { out.v[i] = out.v[i] / sqrt(omega_11); }
+    FOR(i, j) { omega_11 += out.v[i] * out.v[j] * vars.h[i][j] / chi; }
+    FOR(i) { out.v[i] = out.v[i] / sqrt(omega_11); }
 
     data_t omega_12 = 0.0;
-    FOR2(i, j) { omega_12 += out.v[i] * out.u[j] * vars.h[i][j] / chi; }
-    FOR1(i) { out.u[i] += -omega_12 * out.v[i]; }
+    FOR(i, j) { omega_12 += out.v[i] * out.u[j] * vars.h[i][j] / chi; }
+    FOR(i) { out.u[i] += -omega_12 * out.v[i]; }
 
     data_t omega_22 = 0.0;
-    FOR2(i, j) { omega_22 += out.u[i] * out.u[j] * vars.h[i][j] / chi; }
-    FOR1(i) { out.u[i] = out.u[i] / sqrt(omega_22); }
+    FOR(i, j) { omega_22 += out.u[i] * out.u[j] * vars.h[i][j] / chi; }
+    FOR(i) { out.u[i] = out.u[i] / sqrt(omega_22); }
 
     data_t omega_13 = 0.0;
     data_t omega_23 = 0.0;
-    FOR2(i, j)
+    FOR(i, j)
     {
         omega_13 += out.v[i] * out.w[j] * vars.h[i][j] / chi;
         omega_23 += out.u[i] * out.w[j] * vars.h[i][j] / chi;
     }
-    FOR1(i) { out.w[i] += -(omega_13 * out.v[i] + omega_23 * out.u[i]); }
+    FOR(i) { out.w[i] += -(omega_13 * out.v[i] + omega_23 * out.u[i]); }
 
     data_t omega_33 = 0.0;
-    FOR2(i, j) { omega_33 += out.w[i] * out.w[j] * vars.h[i][j] / chi; }
-    FOR1(i) { out.w[i] = out.w[i] / sqrt(omega_33); }
+    FOR(i, j) { omega_33 += out.w[i] * out.w[j] * vars.h[i][j] / chi; }
+    FOR(i) { out.w[i] = out.w[i] / sqrt(omega_33); }
 
     return out;
 }

--- a/Source/GRChomboCore/BoundaryConditions.cpp
+++ b/Source/GRChomboCore/BoundaryConditions.cpp
@@ -40,7 +40,7 @@ void BoundaryConditions::params_t::set_is_periodic(
     const std::array<bool, CH_SPACEDIM> &a_is_periodic)
 {
     is_periodic = a_is_periodic;
-    FOR1(idir)
+    FOR(idir)
     {
         if (!is_periodic[idir])
             nonperiodic_boundaries_exist = true;
@@ -49,7 +49,7 @@ void BoundaryConditions::params_t::set_is_periodic(
 void BoundaryConditions::params_t::set_hi_boundary(
     const std::array<int, CH_SPACEDIM> &a_hi_boundary)
 {
-    FOR1(idir)
+    FOR(idir)
     {
         if (!is_periodic[idir])
         {
@@ -85,7 +85,7 @@ void BoundaryConditions::params_t::set_hi_boundary(
 void BoundaryConditions::params_t::set_lo_boundary(
     const std::array<int, CH_SPACEDIM> &a_lo_boundary)
 {
-    FOR1(idir)
+    FOR(idir)
     {
         if (!is_periodic[idir])
         {
@@ -218,7 +218,7 @@ void BoundaryConditions::define(double a_dx,
     m_domain = a_domain;
     m_domain_box = a_domain.domainBox();
     m_num_ghosts = a_num_ghosts;
-    FOR1(i) { m_center[i] = a_center[i]; }
+    FOR(i) { m_center[i] = a_center[i]; }
     is_defined = true;
 }
 
@@ -307,7 +307,7 @@ void BoundaryConditions::write_boundary_conditions(const params_t &a_params)
                                            {REFLECTIVE_BC, "Reflective"},
                                            {EXTRAPOLATING_BC, "Extrapolating"},
                                            {MIXED_BC, "Mixed"}};
-    FOR1(idir)
+    FOR(idir)
     {
         if (!a_params.is_periodic[idir])
         {
@@ -398,7 +398,7 @@ void BoundaryConditions::fill_rhs_boundaries(const Side::LoHiSide a_side,
     CH_TIME("BoundaryConditions::fill_rhs_boundaries");
 
     // cycle through the directions, filling the rhs
-    FOR1(idir)
+    FOR(idir)
     {
         // only do something if this direction is not periodic
         if (!m_params.is_periodic[idir])
@@ -422,7 +422,7 @@ void BoundaryConditions::fill_solution_boundaries(const Side::LoHiSide a_side,
     CH_TIME("BoundaryConditions::fill_solution_boundaries");
 
     // cycle through the directions
-    FOR1(idir)
+    FOR(idir)
     {
         // only do something if this direction is not periodic and solution
         // boundary enforced in this direction
@@ -454,7 +454,7 @@ void BoundaryConditions::fill_diagnostic_boundaries(const Side::LoHiSide a_side,
     CH_TIME("BoundaryConditions::fill_diagnostic_boundaries");
 
     // cycle through the directions
-    FOR1(idir)
+    FOR(idir)
     {
         // only do something if this direction is not periodic
         if (!m_params.is_periodic[idir])
@@ -587,7 +587,7 @@ void BoundaryConditions::fill_sommerfeld_cell(
     loc *= m_dx;
     loc -= m_center;
     double radius_squared = 0.0;
-    FOR1(i) { radius_squared += loc[i] * loc[i]; }
+    FOR(i) { radius_squared += loc[i] * loc[i]; }
     double radius = sqrt(radius_squared);
     IntVect lo_local_offset = iv - soln_box.smallEnd();
     IntVect hi_local_offset = soln_box.bigEnd() - iv;
@@ -596,7 +596,7 @@ void BoundaryConditions::fill_sommerfeld_cell(
     for (int icomp : sommerfeld_comps)
     {
         rhs_box(iv, icomp) = 0.0;
-        FOR1(idir2)
+        FOR(idir2)
         {
             IntVect iv_offset1 = iv;
             IntVect iv_offset2 = iv;
@@ -699,7 +699,7 @@ void BoundaryConditions::fill_extrapolating_cell(
             {
                 IntVect iv_tmp = iv;
                 iv_tmp[dir] += -units_from_edge - i;
-                FOR1(idir)
+                FOR(idir)
                 {
                     if (iv_tmp[idir] > m_domain_box.bigEnd(idir))
                     {
@@ -724,7 +724,7 @@ void BoundaryConditions::fill_extrapolating_cell(
             {
                 IntVect iv_tmp = iv;
                 iv_tmp[dir] += units_from_edge + i;
-                FOR1(idir)
+                FOR(idir)
                 {
                     if (iv_tmp[idir] > m_domain_box.bigEnd(idir))
                     {
@@ -781,7 +781,7 @@ void BoundaryConditions::copy_boundary_cells(const Side::LoHiSide a_side,
     if (a_src.boxLayout() == a_dest.boxLayout())
     {
         // cycle through the directions
-        FOR1(idir)
+        FOR(idir)
         {
             // only do something if this direction is not periodic
             if (!m_params.is_periodic[idir])
@@ -835,7 +835,7 @@ void BoundaryConditions::interp_boundaries(GRLevelData &a_fine_state,
     CH_TIME("BoundaryConditions::interp_boundaries");
 
     // cycle through the directions
-    FOR1(idir)
+    FOR(idir)
     {
         // only do something if this direction is not periodic
         if (!m_params.is_periodic[idir])
@@ -910,7 +910,7 @@ void BoundaryConditions::interp_boundaries(GRLevelData &a_fine_state,
                     // edges of the box
                     bool near_boundary = false;
                     IntVect local_boundary_offset = IntVect::Zero;
-                    FOR1(idir2)
+                    FOR(idir2)
                     {
                         if (idir2 == idir)
                         {
@@ -1008,7 +1008,7 @@ Box BoundaryConditions::get_boundary_box(
         // but only want to fill them once, so y fills x, z fills y and x
         // etc. Required in periodic direction corners in cases where there
         // are mixed boundaries, (otherwise these corners are full of nans)
-        FOR1(idir)
+        FOR(idir)
         {
             if (offset_lo[idir] > 0) // this direction is a low end boundary
             {
@@ -1055,7 +1055,7 @@ Box ExpandGridsToBoundaries::operator()(const Box &a_in_box)
         -out_box.smallEnd() + m_boundaries.m_domain_box.smallEnd();
     IntVect offset_hi = +out_box.bigEnd() - m_boundaries.m_domain_box.bigEnd();
 
-    FOR1(idir)
+    FOR(idir)
     {
         if (!m_boundaries.m_params.is_periodic[idir])
         {
@@ -1095,7 +1095,7 @@ void BoundaryConditions::expand_grids_to_boundaries(
 
     // Grow the problem domain to include the boundary ghosts
     ProblemDomain domain_with_boundaries = a_in_grids.physDomain();
-    FOR1(idir)
+    FOR(idir)
     {
         if (!m_params.is_periodic[idir])
         {

--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -224,7 +224,7 @@ class ChomboParameters
 
         // read all options (N, N_full, Ni_full and Ni) and then choose
         // accordingly
-        FOR1(dir)
+        FOR(dir)
         {
             std::string name = ("N" + std::to_string(dir + 1));
             std::string name_full = ("N" + std::to_string(dir + 1) + "_full");
@@ -313,7 +313,7 @@ class ChomboParameters
         origin.fill(coarsest_dx / 2.0);
 
         // These aren't parameters but used in parameter checks
-        FOR1(idir)
+        FOR(idir)
         {
             reflective_domain_lo[idir] = ((boundary_params.lo_boundary[idir] ==
                                            BoundaryConditions::REFLECTIVE_BC)
@@ -337,7 +337,7 @@ class ChomboParameters
         default_center = {0.5 * Ni[0] * coarsest_dx, 0.5 * Ni[1] * coarsest_dx};
 #endif
         // Now take into account reflective BCs
-        FOR1(idir)
+        FOR(idir)
         {
             if ((boundary_params.lo_boundary[idir] ==
                  BoundaryConditions::REFLECTIVE_BC) &&
@@ -405,7 +405,7 @@ class ChomboParameters
                         max_grid_size % block_factor == 0,
                         "must divide max_grid_size/max_box_size = " +
                             std::to_string(max_grid_size));
-        FOR1(idir)
+        FOR(idir)
         {
             std::string Ni_string = "N" + std::to_string(idir + 1);
             std::string invalid_message = "must divide " + Ni_string;

--- a/Source/GRChomboCore/SimulationParametersBase.hpp
+++ b/Source/GRChomboCore/SimulationParametersBase.hpp
@@ -247,7 +247,7 @@ class SimulationParametersBase : public ChomboParameters
                 extraction_params.num_extraction_radii > 0,
                 "must be bigger than 0 when activate_extraction = 1");
 
-            FOR1(idir)
+            FOR(idir)
             {
                 std::string center_name =
                     "extraction_center[" + std::to_string(idir) + "]";

--- a/Source/InitialConditions/BlackHoles/BinaryBH.impl.hpp
+++ b/Source/InitialConditions/BlackHoles/BinaryBH.impl.hpp
@@ -25,7 +25,7 @@ template <class data_t> void BinaryBH::compute(Cell<data_t> current_cell) const
     vars.chi = compute_chi(coords);
 
     // Conformal metric is flat
-    FOR1(i) vars.h[i][i] = 1.;
+    FOR(i) vars.h[i][i] = 1.;
 
     vars.A = compute_A(vars.chi, coords);
 
@@ -65,7 +65,7 @@ Tensor<2, data_t> BinaryBH::compute_A(data_t chi,
     Tensor<2, data_t> out;
 
     // Aij(CCZ4) = psi^(-6) * Aij(Baumgarte&Shapiro book)
-    FOR2(i, j) out[i][j] = pow(chi, 3 / 2.) * (Aij1[i][j] + Aij2[i][j]);
+    FOR(i, j) out[i][j] = pow(chi, 3 / 2.) * (Aij1[i][j] + Aij2[i][j]);
 
     return out;
 }

--- a/Source/InitialConditions/BlackHoles/BoostedBH.impl.hpp
+++ b/Source/InitialConditions/BlackHoles/BoostedBH.impl.hpp
@@ -41,7 +41,7 @@ Tensor<2, data_t> BoostedBH::Aij(Coordinates<data_t> coords) const
 
     Tensor<2, data_t> out;
 
-    FOR2(i, j)
+    FOR(i, j)
     {
         const double delta = (i == j) ? 1 : 0;
         out[i][j] = 1.5 *

--- a/Source/InitialConditions/BlackHoles/KerrBH.impl.hpp
+++ b/Source/InitialConditions/BlackHoles/KerrBH.impl.hpp
@@ -54,7 +54,7 @@ template <class data_t> void KerrBH::compute(Cell<data_t> current_cell) const
     make_trace_free(vars.A, vars.h, h_UU);
 
     // Make conformal
-    FOR2(i, j)
+    FOR(i, j)
     {
         vars.h[i][j] *= vars.chi;
         vars.A[i][j] *= vars.chi;
@@ -119,13 +119,13 @@ void KerrBH::compute_kerr(Tensor<2, data_t> &spherical_g,
 
     // Metric in semi isotropic Kerr-Schild coordinates, r, theta (t or th), phi
     // (p)
-    FOR2(i, j) { spherical_g[i][j] = 0.0; }
+    FOR(i, j) { spherical_g[i][j] = 0.0; }
     spherical_g[0][0] = gamma_rr;                // gamma_rr
     spherical_g[1][1] = Sigma;                   // gamma_tt
     spherical_g[2][2] = AA / Sigma * sin_theta2; // gamma_pp
 
     // Extrinsic curvature
-    FOR2(i, j) { spherical_K[i][j] = 0.0; }
+    FOR(i, j) { spherical_K[i][j] = 0.0; }
 
     // set non zero elements of Krtp - K_rp, K_tp
     spherical_K[0][2] =

--- a/Source/InitialConditions/BlackHoles/TwoPuncturesInitialData.impl.hpp
+++ b/Source/InitialConditions/BlackHoles/TwoPuncturesInitialData.impl.hpp
@@ -29,14 +29,14 @@ void TwoPuncturesInitialData::compute(Cell<double> current_cell) const
 
     // metric variables
     vars.chi = pow(compute_determinant_sym(h_phys), -1. / 3.);
-    FOR1(i)
+    FOR(i)
     {
         // Bowen-York data is conformally flat
         vars.h[i][i] = 1.0;
     }
 
     // extrinsic curvature
-    FOR2(i, j) { vars.A[i][j] = vars.chi * K_tensor[i][j]; }
+    FOR(i, j) { vars.A[i][j] = vars.chi * K_tensor[i][j]; }
     // conformal flatness means h_UU = h
     make_trace_free(vars.A, vars.h, vars.h);
 

--- a/Source/InitialConditions/ScalarFields/ScalarBubble.impl.hpp
+++ b/Source/InitialConditions/ScalarFields/ScalarBubble.impl.hpp
@@ -32,7 +32,7 @@ void ScalarBubble::compute(Cell<data_t> current_cell) const
     vars.chi = 1;
 
     // conformal metric is flat
-    FOR1(i) vars.h[i][i] = 1.;
+    FOR(i) vars.h[i][i] = 1.;
 
     // Store the initial values of the variables
     current_cell.store_vars(vars);

--- a/Source/Matter/EMTensor.impl.hpp
+++ b/Source/Matter/EMTensor.impl.hpp
@@ -60,7 +60,7 @@ void EMTensor<matter_t>::compute(Cell<data_t> current_cell) const
     if (m_c_Si.size() > 0)
     {
 #if DEFAULT_TENSOR_DIM == 3
-        FOR1(i) { current_cell.store_vars(emtensor.Si[i], m_c_Si.begin() + i); }
+        FOR(i) { current_cell.store_vars(emtensor.Si[i], m_c_Si.begin() + i); }
 #endif
     }
 

--- a/Source/Matter/MatterCCZ4RHS.impl.hpp
+++ b/Source/Matter/MatterCCZ4RHS.impl.hpp
@@ -85,16 +85,16 @@ void MatterCCZ4RHS<matter_t, gauge_t, deriv_t>::add_emtensor_rhs(
     Tensor<2, data_t> Sij_TF = emtensor.Sij;
     make_trace_free(Sij_TF, matter_vars.h, h_UU);
 
-    FOR2(i, j)
+    FOR(i, j)
     {
         matter_rhs.A[i][j] += -8.0 * M_PI * m_G_Newton * matter_vars.chi *
                               matter_vars.lapse * Sij_TF[i][j];
     }
 
-    FOR1(i)
+    FOR(i)
     {
         data_t matter_term_Gamma = 0.0;
-        FOR1(j)
+        FOR(j)
         {
             matter_term_Gamma += -16.0 * M_PI * m_G_Newton * matter_vars.lapse *
                                  h_UU[i][j] * emtensor.Si[j];

--- a/Source/Matter/MatterConstraints.impl.hpp
+++ b/Source/Matter/MatterConstraints.impl.hpp
@@ -42,7 +42,7 @@ void MatterConstraints<matter_t>::compute(Cell<data_t> current_cell) const
     out.Ham += -16.0 * M_PI * m_G_Newton * emtensor.rho;
 
     // Momentum constraints
-    FOR1(i) { out.Mom[i] += -8.0 * M_PI * m_G_Newton * emtensor.Si[i]; }
+    FOR(i) { out.Mom[i] += -8.0 * M_PI * m_G_Newton * emtensor.Si[i]; }
 
     // Write the constraints into the output FArrayBox
     current_cell.store_vars(out);

--- a/Source/Matter/MatterWeyl4.impl.hpp
+++ b/Source/Matter/MatterWeyl4.impl.hpp
@@ -64,7 +64,7 @@ void MatterWeyl4<matter_t>::add_matter_EB(EBFields_t<data_t> &ebfields,
 
     // as we made the vacuum expression of Bij explictly symmetric and Eij
     // explictly trace-free, only Eij has matter terms
-    FOR2(i, j) { ebfields.E[i][j] += -4.0 * M_PI * m_G_Newton * Sij_TF[i][j]; }
+    FOR(i, j) { ebfields.E[i][j] += -4.0 * M_PI * m_G_Newton * Sij_TF[i][j]; }
 }
 
 #endif /* MATTERWEYL4_IMPL_HPP_ */

--- a/Source/Matter/NewMatterConstraints.impl.hpp
+++ b/Source/Matter/NewMatterConstraints.impl.hpp
@@ -51,7 +51,7 @@ void MatterConstraints<matter_t>::compute(Cell<data_t> current_cell) const
     // Momentum constraints
     if (m_c_Moms.size() > 0 || m_c_Moms_abs_terms.size() > 0)
     {
-        FOR1(i)
+        FOR(i)
         {
             out.Mom[i] += -8.0 * M_PI * m_G_Newton * emtensor.Si[i];
             out.Mom_abs_terms[i] +=

--- a/Source/Matter/ScalarField.impl.hpp
+++ b/Source/Matter/ScalarField.impl.hpp
@@ -31,7 +31,7 @@ emtensor_t<data_t> ScalarField<potential_t>::compute_emtensor(
 
     out.rho += V_of_phi;
     out.S += -3.0 * V_of_phi;
-    FOR2(i, j) { out.Sij[i][j] += -vars.h[i][j] * V_of_phi / vars.chi; }
+    FOR(i, j) { out.Sij[i][j] += -vars.h[i][j] * V_of_phi / vars.chi; }
 
     return out;
 }
@@ -46,11 +46,11 @@ void ScalarField<potential_t>::emtensor_excl_potential(
 {
     // Useful quantity Vt
     data_t Vt = -vars.Pi * vars.Pi;
-    FOR2(i, j) { Vt += vars.chi * h_UU[i][j] * d1.phi[i] * d1.phi[j]; }
+    FOR(i, j) { Vt += vars.chi * h_UU[i][j] * d1.phi[i] * d1.phi[j]; }
 
     // Calculate components of EM Tensor
     // S_ij = T_ij
-    FOR2(i, j)
+    FOR(i, j)
     {
         out.Sij[i][j] =
             -0.5 * vars.h[i][j] * Vt / vars.chi + d1.phi[i] * d1.phi[j];
@@ -60,7 +60,7 @@ void ScalarField<potential_t>::emtensor_excl_potential(
     out.S = vars.chi * TensorAlgebra::compute_trace(out.Sij, h_UU);
 
     // S_i (note lower index) = - n^a T_ai
-    FOR1(i) { out.Si[i] = -d1.phi[i] * vars.Pi; }
+    FOR(i) { out.Si[i] = -d1.phi[i] * vars.Pi; }
 
     // rho = n^a n^b T_ab
     out.rho = vars.Pi * vars.Pi + 0.5 * Vt;
@@ -112,13 +112,13 @@ void ScalarField<potential_t>::matter_rhs_excl_potential(
     rhs.phi = vars.lapse * vars.Pi + advec.phi;
     rhs.Pi = vars.lapse * vars.K * vars.Pi + advec.Pi;
 
-    FOR2(i, j)
+    FOR(i, j)
     {
         // includes non conformal parts of chris not included in chris_ULL
         rhs.Pi += h_UU[i][j] * (-0.5 * d1.chi[j] * vars.lapse * d1.phi[i] +
                                 vars.chi * vars.lapse * d2.phi[i][j] +
                                 vars.chi * d1.lapse[i] * d1.phi[j]);
-        FOR1(k)
+        FOR(k)
         {
             rhs.Pi += -vars.chi * vars.lapse * h_UU[i][j] * chris.ULL[k][i][j] *
                       d1.phi[k];

--- a/Source/TaggingCriteria/ChiAndPhiTaggingCriterion.hpp
+++ b/Source/TaggingCriteria/ChiAndPhiTaggingCriterion.hpp
@@ -52,7 +52,7 @@ class ChiAndPhiTaggingCriterion
         data_t mod_d2_chi = 0;
         data_t mod_d2_phi = 0;
 
-        FOR2(idir, jdir)
+        FOR(idir, jdir)
         {
             mod_d2_chi += d2chi.chi[idir][jdir] * d2chi.chi[idir][jdir];
 

--- a/Source/TaggingCriteria/ChiExtractionTaggingCriterion.hpp
+++ b/Source/TaggingCriteria/ChiExtractionTaggingCriterion.hpp
@@ -57,7 +57,7 @@ class ChiExtractionTaggingCriterion
         // first test the gradients for regions of high curvature
         const auto d2 = m_deriv.template diff2<Vars>(current_cell);
         data_t mod_d2_chi = 0;
-        FOR2(idir, jdir)
+        FOR(idir, jdir)
         {
             mod_d2_chi += d2.chi[idir][jdir] * d2.chi[idir][jdir];
         }

--- a/Source/TaggingCriteria/ChiPunctureExtractionTaggingCriterion.hpp
+++ b/Source/TaggingCriteria/ChiPunctureExtractionTaggingCriterion.hpp
@@ -67,7 +67,7 @@ class ChiPunctureExtractionTaggingCriterion
         // first test the gradients for regions of high curvature
         const auto d2 = m_deriv.template diff2<Vars>(current_cell);
         data_t mod_d2_chi = 0;
-        FOR2(idir, jdir)
+        FOR(idir, jdir)
         {
             mod_d2_chi += d2.chi[idir][jdir] * d2.chi[idir][jdir];
         }

--- a/Source/TaggingCriteria/ChiTaggingCriterion.hpp
+++ b/Source/TaggingCriteria/ChiTaggingCriterion.hpp
@@ -24,10 +24,10 @@ class ChiTaggingCriterion
     {
         auto chi = current_cell.load_vars(c_chi);
         Tensor<1, data_t> d1_chi;
-        FOR1(idir) m_deriv.diff1(d1_chi, current_cell, idir, c_chi);
+        FOR(idir) m_deriv.diff1(d1_chi, current_cell, idir, c_chi);
 
         data_t mod_d1_chi = 0;
-        FOR1(idir) mod_d1_chi += d1_chi[idir] * d1_chi[idir];
+        FOR(idir) mod_d1_chi += d1_chi[idir] * d1_chi[idir];
         data_t criterion = m_dx * sqrt(mod_d1_chi) / pow(chi, 2);
 
         // Write back into the flattened Chombo box

--- a/Source/TaggingCriteria/PhiAndKTaggingCriterion.hpp
+++ b/Source/TaggingCriteria/PhiAndKTaggingCriterion.hpp
@@ -27,14 +27,14 @@ class PhiAndKTaggingCriterion
     template <class data_t> void compute(Cell<data_t> current_cell) const
     {
         Tensor<1, data_t> d1_phi;
-        FOR1(idir) m_deriv.diff1(d1_phi, current_cell, idir, c_phi);
+        FOR(idir) m_deriv.diff1(d1_phi, current_cell, idir, c_phi);
 
         Tensor<1, data_t> d1_K;
-        FOR1(idir) m_deriv.diff1(d1_K, current_cell, idir, c_K);
+        FOR(idir) m_deriv.diff1(d1_K, current_cell, idir, c_K);
 
         data_t mod_d1_phi = 0;
         data_t mod_d1_K = 0;
-        FOR1(idir)
+        FOR(idir)
         {
             mod_d1_phi += d1_phi[idir] * d1_phi[idir];
             mod_d1_K += d1_K[idir] * d1_K[idir];

--- a/Source/utils/CoordinateTransformations.hpp
+++ b/Source/utils/CoordinateTransformations.hpp
@@ -86,10 +86,10 @@ spherical_to_cartesian_LL(const Tensor<2, data_t> &spherical_g, const data_t x,
     Tensor<2, data_t> jac = spherical_jacobian(x, y, z);
 
     // Convert the Tensor to cartesian coords
-    FOR2(i, j)
+    FOR(i, j)
     {
         cartesian_g[i][j] = 0.;
-        FOR2(k, l)
+        FOR(k, l)
         {
             cartesian_g[i][j] += spherical_g[k][l] * jac[k][i] * jac[l][j];
         }
@@ -110,10 +110,10 @@ spherical_to_cartesian_UU(const Tensor<2, data_t> &spherical_g_UU,
     Tensor<2, data_t> inv_jac = inverse_spherical_jacobian(x, y, z);
 
     // Convert the Tensor to cartesian coords
-    FOR2(i, j)
+    FOR(i, j)
     {
         cartesian_g_UU[i][j] = 0.;
-        FOR2(k, l)
+        FOR(k, l)
         {
             cartesian_g_UU[i][j] +=
                 spherical_g_UU[k][l] * inv_jac[i][k] * inv_jac[j][l];
@@ -135,10 +135,10 @@ cartesian_to_spherical_LL(const Tensor<2, data_t> &cartesian_g, const data_t x,
     Tensor<2, data_t> inv_jac = inverse_spherical_jacobian(x, y, z);
 
     // Convert the Tensor to spherical coords
-    FOR2(i, j)
+    FOR(i, j)
     {
         spherical_g[i][j] = 0.;
-        FOR2(k, l)
+        FOR(k, l)
         {
             spherical_g[i][j] +=
                 cartesian_g[k][l] * inv_jac[k][i] * inv_jac[l][j];
@@ -160,10 +160,10 @@ cartesian_to_spherical_UU(const Tensor<2, data_t> &cartesian_g_UU, data_t x,
     Tensor<2, data_t> jac = spherical_jacobian(x, y, z);
 
     // Convert the Tensor to spherical coords
-    FOR2(i, j)
+    FOR(i, j)
     {
         spherical_g_UU[i][j] = 0.;
-        FOR2(k, l)
+        FOR(k, l)
         {
             spherical_g_UU[i][j] +=
                 cartesian_g_UU[k][l] * jac[i][k] * jac[j][l];
@@ -185,10 +185,10 @@ spherical_to_cartesian_U(const Tensor<1, data_t> &spherical_v_U, data_t x,
     Tensor<2, data_t> inv_jac = inverse_spherical_jacobian(x, y, z);
 
     // transform the vector to cartesian coords
-    FOR1(i)
+    FOR(i)
     {
         cartesian_v_U[i] = 0.0;
-        FOR1(j) { cartesian_v_U[i] += inv_jac[i][j] * spherical_v_U[j]; }
+        FOR(j) { cartesian_v_U[i] += inv_jac[i][j] * spherical_v_U[j]; }
     }
     return cartesian_v_U;
 }
@@ -206,10 +206,10 @@ spherical_to_cartesian_L(const Tensor<1, data_t> &spherical_v_L, data_t x,
     Tensor<2, data_t> jac = spherical_jacobian(x, y, z);
 
     // transform the vector to cartesian coords
-    FOR1(i)
+    FOR(i)
     {
         cartesian_v_L[i] = 0.0;
-        FOR1(j) { cartesian_v_L[i] += spherical_v_L[j] * jac[j][i]; }
+        FOR(j) { cartesian_v_L[i] += spherical_v_L[j] * jac[j][i]; }
     }
     return cartesian_v_L;
 }
@@ -227,10 +227,10 @@ cartesian_to_spherical_U(const Tensor<1, data_t> &cartesian_v_U, data_t x,
     Tensor<2, data_t> jac = spherical_jacobian(x, y, z);
 
     // transform the vector to cartesian coords
-    FOR1(i)
+    FOR(i)
     {
         spherical_v_U[i] = 0.0;
-        FOR1(j) { spherical_v_U[i] += jac[i][j] * cartesian_v_U[j]; }
+        FOR(j) { spherical_v_U[i] += jac[i][j] * cartesian_v_U[j]; }
     }
     return spherical_v_U;
 }
@@ -248,10 +248,10 @@ cartesian_to_spherical_L(const Tensor<1, data_t> &cartesian_v_L, data_t x,
     Tensor<2, data_t> inv_jac = inverse_spherical_jacobian(x, y, z);
 
     // transform the vector to cartesian coords
-    FOR1(i)
+    FOR(i)
     {
         spherical_v_L[i] = 0.0;
-        FOR1(j) { spherical_v_L[i] += cartesian_v_L[j] * inv_jac[j][i]; }
+        FOR(j) { spherical_v_L[i] += cartesian_v_L[j] * inv_jac[j][i]; }
     }
     return spherical_v_L;
 }

--- a/Source/utils/DimensionDefinitions.hpp
+++ b/Source/utils/DimensionDefinitions.hpp
@@ -11,12 +11,23 @@
 #endif
 
 #ifndef DEFAULT_TENSOR_DIM
-#define DEFAULT_TENSOR_DIM 3
+#define DEFAULT_TENSOR_DIM CH_SPACEDIM
 #endif
 
+// Fancy 'for' loop macros to iterate through spatial tensors
+// use as "FOR(i, j) { ... }"
 #define FOR1(IDX) for (int IDX = 0; IDX < DEFAULT_TENSOR_DIM; ++IDX)
 #define FOR2(IDX1, IDX2) FOR1(IDX1) FOR1(IDX2)
 #define FOR3(IDX1, IDX2, IDX3) FOR2(IDX1, IDX2) FOR1(IDX3)
 #define FOR4(IDX1, IDX2, IDX3, IDX4) FOR2(IDX1, IDX2) FOR2(IDX3, IDX4)
+#define FOR5(IDX1, IDX2, IDX3, IDX4, IDX5)                                     \
+    FOR4(IDX1, IDX2, IDX3, IDX4) FOR1(IDX5)
+#define DUMMYFOR() // prevents warning that appeared in debug mode:
+                   // 'ISO C++11 requires at least one argument for the "..." in
+                   // a variadic macro'
+
+#define GET_MACRO6(_1, _2, _3, _4, _5, NAME, ...) NAME
+#define FOR(...)                                                               \
+    GET_MACRO6(__VA_ARGS__, FOR5, FOR4, FOR3, FOR2, FOR1, DUMMYFOR)(__VA_ARGS__)
 
 #endif /* GRUTILS_HPP_*/

--- a/Source/utils/TensorAlgebra.hpp
+++ b/Source/utils/TensorAlgebra.hpp
@@ -110,7 +110,7 @@ ALWAYS_INLINE data_t compute_trace(const Tensor<2, data_t> &tensor_LL,
                                    const Tensor<2, data_t> &inverse_metric)
 {
     data_t trace = 0.;
-    FOR2(i, j) { trace += inverse_metric[i][j] * tensor_LL[i][j]; }
+    FOR(i, j) { trace += inverse_metric[i][j] * tensor_LL[i][j]; }
     return trace;
 }
 
@@ -119,7 +119,7 @@ template <class data_t>
 ALWAYS_INLINE data_t compute_trace(const Tensor<2, data_t> &tensor_UL)
 {
     data_t trace = 0.;
-    FOR1(i) trace += tensor_UL[i][i];
+    FOR(i) trace += tensor_UL[i][i];
     return trace;
 }
 
@@ -128,7 +128,7 @@ ALWAYS_INLINE data_t
 compute_trace(const Tensor<1, Tensor<1, data_t>> &tensor_UL)
 {
     data_t trace = 0.;
-    FOR1(i) trace += tensor_UL[i][i];
+    FOR(i) trace += tensor_UL[i][i];
     return trace;
 }
 
@@ -138,7 +138,7 @@ ALWAYS_INLINE data_t compute_dot_product(const Tensor<1, data_t> &vector_U,
                                          const Tensor<1, data_t> &covector_L)
 {
     data_t dot_product = 0.;
-    FOR1(i) dot_product += vector_U[i] * covector_L[i];
+    FOR(i) dot_product += vector_U[i] * covector_L[i];
     return dot_product;
 }
 
@@ -150,7 +150,7 @@ ALWAYS_INLINE data_t compute_dot_product(
     const Tensor<2, data_t> &inverse_metric)
 {
     data_t dot_product = 0.;
-    FOR2(m, n)
+    FOR(m, n)
     {
         dot_product += inverse_metric[m][n] * covector1_L[m] * covector2_L[n];
     }
@@ -167,7 +167,7 @@ ALWAYS_INLINE void make_trace_free(Tensor<2, data_t> &tensor_LL,
 {
     auto trace = compute_trace(tensor_LL, inverse_metric);
     double one_over_gr_spacedim = 1. / ((double)GR_SPACEDIM);
-    FOR2(i, j)
+    FOR(i, j)
     {
         tensor_LL[i][j] -= one_over_gr_spacedim * metric[i][j] * trace;
     }
@@ -194,7 +194,7 @@ raise_all(const Tensor<1, data_t> &tensor_L,
           const Tensor<2, data_t> &inverse_metric)
 {
     Tensor<1, data_t> tensor_U = 0.;
-    FOR2(i, j) { tensor_U[i] += inverse_metric[i][j] * tensor_L[j]; }
+    FOR(i, j) { tensor_U[i] += inverse_metric[i][j] * tensor_L[j]; }
     return tensor_U;
 }
 
@@ -205,7 +205,7 @@ raise_all(const Tensor<2, data_t> &tensor_LL,
           const Tensor<2, data_t> &inverse_metric)
 {
     Tensor<2, data_t> tensor_UU = 0.;
-    FOR4(i, j, k, l)
+    FOR(i, j, k, l)
     {
         tensor_UU[i][j] +=
             inverse_metric[i][k] * inverse_metric[j][l] * tensor_LL[k][l];
@@ -291,20 +291,20 @@ compute_christoffel(const Tensor<2, Tensor<1, data_t>> &d1_metric,
 {
     chris_t<data_t> out;
 
-    FOR3(i, j, k)
+    FOR(i, j, k)
     {
         out.LLL[i][j][k] = 0.5 * (d1_metric[j][i][k] + d1_metric[k][i][j] -
                                   d1_metric[j][k][i]);
     }
-    FOR3(i, j, k)
+    FOR(i, j, k)
     {
         out.ULL[i][j][k] = 0;
-        FOR1(l) { out.ULL[i][j][k] += h_UU[i][l] * out.LLL[l][j][k]; }
+        FOR(l) { out.ULL[i][j][k] += h_UU[i][l] * out.LLL[l][j][k]; }
     }
-    FOR1(i)
+    FOR(i)
     {
         out.contracted[i] = 0;
-        FOR2(j, k) { out.contracted[i] += h_UU[j][k] * out.ULL[i][j][k]; }
+        FOR(j, k) { out.contracted[i] += h_UU[j][k] * out.ULL[i][j][k]; }
     }
 
     return out;
@@ -318,13 +318,13 @@ Tensor<3, data_t> compute_phys_chris(const Tensor<1, data_t> &d1_chi,
                                      const Tensor<3, data_t> &chris_ULL)
 {
     Tensor<3, data_t> chris_phys;
-    FOR3(i, j, k)
+    FOR(i, j, k)
     {
         chris_phys[i][j][k] =
             chris_ULL[i][j][k] -
             0.5 / vars_chi *
                 (delta(i, k) * d1_chi[j] + delta(i, j) * d1_chi[k]);
-        FOR1(m)
+        FOR(m)
         {
             chris_phys[i][j][k] +=
                 0.5 / vars_chi * vars_h[j][k] * h_UU[i][m] * d1_chi[m];

--- a/Tests/BSSNMatterTest/BSSNMatterTest.cpp
+++ b/Tests/BSSNMatterTest/BSSNMatterTest.cpp
@@ -147,7 +147,7 @@ int main()
                     K[2][1] = K[1][2];
 
                     double trK = 0;
-                    FOR2(a, b) { trK += g_UU[a][b] * K[a][b]; }
+                    FOR(a, b) { trK += g_UU[a][b] * K[a][b]; }
 
                     in_fab(iv, c_K) = trK;
                     in_fab(iv, c_A11) =

--- a/Tests/CCZ4GeometryUnitTests/CCZ4GeometryUnitTest.cpp
+++ b/Tests/CCZ4GeometryUnitTests/CCZ4GeometryUnitTest.cpp
@@ -37,7 +37,7 @@ int main()
     std::cout << std::setprecision(16);
 
     // Compare
-    FOR2(i, j)
+    FOR(i, j)
     {
         double diff = h_UU[i][j] - h_UU_known[i][j];
         if (diff > 1e-14)
@@ -48,7 +48,7 @@ int main()
         }
     }
 
-    FOR3(i, j, k)
+    FOR(i, j, k)
     {
         double diff = chris.ULL[i][j][k] - chris_known[i][j][k];
         if (diff > 1e-14)
@@ -61,7 +61,7 @@ int main()
         }
     }
 
-    FOR1(i)
+    FOR(i)
     {
         double diff = chris.contracted[i] - chris_contracted_known[i];
         if (diff > 1e-14)
@@ -75,7 +75,7 @@ int main()
         }
     }
 
-    FOR2(i, j)
+    FOR(i, j)
     {
         double diff = ricciZ.LL[i][j] - ricciZ_known[i][j];
         if (diff > 1e-14)

--- a/Tests/CCZ4Test/CCZ4Test.cpp
+++ b/Tests/CCZ4Test/CCZ4Test.cpp
@@ -136,7 +136,7 @@ int main()
                     K[2][1] = K[1][2];
 
                     double trK = 0;
-                    FOR2(a, b) { trK += g_UU[a][b] * K[a][b]; }
+                    FOR(a, b) { trK += g_UU[a][b] * K[a][b]; }
 
                     in_fab(iv, c_K) = trK;
                     in_fab(iv, c_A11) =

--- a/Tests/ConstraintTest/ConstraintTest.cpp
+++ b/Tests/ConstraintTest/ConstraintTest.cpp
@@ -135,7 +135,7 @@ int main()
                     K[2][1] = K[1][2];
 
                     double trK = 0;
-                    FOR2(a, b) { trK += g_UU[a][b] * K[a][b]; }
+                    FOR(a, b) { trK += g_UU[a][b] * K[a][b]; }
 
                     in_fab(iv, c_K) = trK;
                     in_fab(iv, c_A11) =

--- a/Tests/CoordinateTransformationsTest/CoordinateTransformationsTest.cpp
+++ b/Tests/CoordinateTransformationsTest/CoordinateTransformationsTest.cpp
@@ -33,7 +33,7 @@ bool check_tensor(const Tensor<2, double> &tensor,
                   const std::string &test_name)
 {
     bool failed = false;
-    FOR2(i, j)
+    FOR(i, j)
     {
         if (!almost_equal(tensor[i][j], correct_tensor[i][j], ulp))
         {
@@ -52,7 +52,7 @@ bool check_vector(const Tensor<1, double> &vector,
                   const std::string &test_name)
 {
     bool failed = false;
-    FOR1(i)
+    FOR(i)
     {
         if (!almost_equal(vector[i], correct_vector[i], ulp))
         {
@@ -101,13 +101,13 @@ int main()
 
     // Test tensor transformations
     Tensor<2, double> Mij_cart;
-    FOR2(i, j) { Mij_cart[i][j] = 0.; }
+    FOR(i, j) { Mij_cart[i][j] = 0.; }
     Mij_cart[0][0] = 1.;
     Mij_cart[1][1] = 1.;
     Mij_cart[2][2] = 1.;
 
     Tensor<2, double> Mij_spher;
-    FOR2(i, j) { Mij_spher[i][j] = 0.; }
+    FOR(i, j) { Mij_spher[i][j] = 0.; }
     Mij_spher[0][0] = 1.;
     Mij_spher[1][1] = r * r;
     Mij_spher[2][2] = r2sin2theta;

--- a/Tests/MatterWeyl4Test/MatterWeyl4Test.cpp
+++ b/Tests/MatterWeyl4Test/MatterWeyl4Test.cpp
@@ -137,7 +137,7 @@ int main()
                     K[2][1] = K[1][2];
 
                     double trK = 0;
-                    FOR2(a, b) { trK += g_UU[a][b] * K[a][b]; }
+                    FOR(a, b) { trK += g_UU[a][b] * K[a][b]; }
 
                     in_fab(iv, c_K) = trK;
                     in_fab(iv, c_A11) =


### PR DESCRIPTION
This allows doing simply `FOR(i)` or `FOR(i,j)`, instead of specifying which one (`FOR1`, `FOR2`) you want.
It's a simple PR. Something I have been using that I think is really neat.