### PR TITLE
Add Clang Format pre-commit hook configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+-   repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v10.0.1  
+    hooks:
+    -   id: clang-format


### PR DESCRIPTION
This PR resolves #106 and #192 by adding a configuration file for a [pre-commit](https://pre-commit.com/) hook to check code conforms to the Clang Format style.

Instructions on how to set this up in your local clone of this repository are provided on [the Clang Format wiki page](https://github.com/GRChombo/GRChombo/wiki/Using-Clang-Format).

This should not affect any users that haven't set up pre-commit hooks following the instructions above.