### PR TITLE
Fix compilation with LLVM

### DIFF
--- a/.github/workflows/run-grchombo-tests-clang.yml
+++ b/.github/workflows/run-grchombo-tests-clang.yml
@@ -1,4 +1,4 @@
-name: Run GRChombo Tests (GCC)
+name: Run GRChombo Tests (Clang)
 
 on: [push]
 
@@ -8,6 +8,7 @@ jobs:
     env:
       CHOMBO_HOME: ${{ github.workspace }}/Chombo/lib
       OMP_NUM_THREADS: 1
+      OMPI_CXX: clang++
 
     steps:
     - name: Checkout Chombo
@@ -24,17 +25,11 @@ jobs:
     - name: Install Chombo dependencies
       run: |
         sudo apt-get update
-        sudo apt-get -y --no-install-recommends install csh gfortran-10 g++-10 cpp-10 libhdf5-dev libhdf5-openmpi-dev openmpi-bin libblas-dev liblapack-dev libgetopt-complete-perl
-
-    - name: Set Compilers
-      run: |
-        sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-10 100
-        sudo update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-10 100
-        sudo update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-10 100
+        sudo apt-get -y --no-install-recommends install csh libhdf5-dev libhdf5-openmpi-dev openmpi-bin libblas-dev liblapack-dev libgetopt-complete-perl
 
     - name: Build Chombo
       run: |
-        cp $GITHUB_WORKSPACE/GRChombo/InstallNotes/MakeDefsLocalExamples/ubuntu-gcc.Make.defs.local $CHOMBO_HOME/mk/Make.defs.local
+        cp $GITHUB_WORKSPACE/GRChombo/InstallNotes/MakeDefsLocalExamples/ubuntu-clang.Make.defs.local $CHOMBO_HOME/mk/Make.defs.local
         make -j 4 AMRTimeDependent AMRTools BaseTools BoxTools
       working-directory: ${{ env.CHOMBO_HOME }}
 

--- a/InstallNotes/MakeDefsLocalExamples/ubuntu-clang.Make.defs.local
+++ b/InstallNotes/MakeDefsLocalExamples/ubuntu-clang.Make.defs.local
@@ -1,0 +1,29 @@
+#begin  -- dont change this line
+# This is used for the github action that runs the tests
+# To use clang++ with the ubuntu openmpi package, set the environment variable
+# export OMPI_CXX=clang++
+
+DIM            = 3
+DEBUG          = TRUE
+PRECISION      = DOUBLE
+OPT            = TRUE
+PROFILE        = FALSE
+CXX            = clang++
+FC             = gfortran
+MPI            = TRUE
+OPENMPCC       = TRUE
+MPICXX         = mpicxx
+USE_64         = TRUE
+USE_HDF        = TRUE
+HDFINCFLAGS    = -I/usr/lib/x86_64-linux-gnu/hdf5/serial/include
+HDFLIBFLAGS    = -L/usr/lib/x86_64-linux-gnu/hdf5/serial/lib -lhdf5 -lz
+HDFMPIINCFLAGS = -I/usr/lib/x86_64-linux-gnu/hdf5/openmpi/include
+HDFMPILIBFLAGS = -L/usr/lib/x86_64-linux-gnu/hdf5/openmpi/lib -lhdf5 -lz
+# The following line puts all of the Chombo code in a Chombo namespace
+NAMESPACE      = TRUE
+USE_MT         = FALSE
+cxxoptflags    = -march=native -O3
+foptflags      = -march=native -O3
+syslibflags    = -lblas -llapack
+
+#end  -- dont change this line

--- a/InstallNotes/MakeDefsLocalExamples/ubuntu-gcc.Make.defs.local
+++ b/InstallNotes/MakeDefsLocalExamples/ubuntu-gcc.Make.defs.local
@@ -1,7 +1,7 @@
 #begin  -- dont change this line
 # This is used for the github action that runs the tests
 # Dependencies can be installed with the command:
-# sudo apt-get install csh make gfortran-8 g++-8 cpp-8 libhdf5-dev \
+# sudo apt-get install csh make gfortran-10 g++-10 cpp-10 libhdf5-dev \
 # libhdf5-openmpi-dev openmpi-bin libblas-dev liblapack-dev \
 # libgetopt-complete-perl ssh
 

--- a/Source/AMRInterpolator/AMRInterpolator.impl.hpp
+++ b/Source/AMRInterpolator/AMRInterpolator.impl.hpp
@@ -89,7 +89,7 @@ void AMRInterpolator<InterpAlgo>::limit_num_levels(unsigned int num_levels)
 {
     CH_TIME("AMRInterpolator::limit_num_levels");
 
-    int max_num_levels = const_cast<AMR &>(m_gr_amr).getAMRLevels().size();
+    int max_num_levels = const_cast<GRAMR &>(m_gr_amr).getAMRLevels().size();
     if (num_levels > max_num_levels || num_levels == 0)
     {
         m_num_levels = max_num_levels;

--- a/Source/BoxUtils/BoxLoops.impl.hpp
+++ b/Source/BoxUtils/BoxLoops.impl.hpp
@@ -28,7 +28,7 @@ void BoxLoops::innermost_loop(const ComputePack<compute_ts...> &compute_pack,
 // SIMD LOOP
 #ifdef __INTEL_COMPILER
 #pragma novector
-#else
+#elif !defined(__clang__)
 #pragma omp simd safelen(1)
 #endif /* __INTEL_COMPILER */
     for (int ix = loop_lo_x; ix <= x_simd_max; ix += simd_width)

--- a/Source/simd/x64/avx.hpp
+++ b/Source/simd/x64/avx.hpp
@@ -33,6 +33,7 @@ template <> struct simd<double> : public simd_base<double>
     typedef typename simd_traits<double>::data_t data_t;
     typedef typename simd_traits<double>::mask_t mask_t;
 
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wuninitialized"
     ALWAYS_INLINE
     simd() : simd_base<double>(_mm256_setzero_pd()) {}

--- a/Tests/SphericalExtractionTest/SphericalExtractionTest.cpp
+++ b/Tests/SphericalExtractionTest/SphericalExtractionTest.cpp
@@ -92,10 +92,10 @@ int runSphericalExtractionTest(int argc, char *argv[])
     spherical_extraction_hi.write_extraction("ExtractionOutHi_");
 
     // real part is the zeroth componenent and imaginary part is first component
-    auto extracted_harmonic = [](std::vector<double> &data, double, double,
-                                 double) {
-        return std::make_pair(data[0], data[1]);
-    };
+    SphericalExtraction::complex_function_t extracted_harmonic =
+        [](std::vector<double> &data, double, double, double) {
+            return std::make_pair(data[0], data[1]);
+        };
 
     // add the spherical harmonic mode integrands for each resolution and for
     // the trapezium rule, Simpson's rule and Boole's rule


### PR DESCRIPTION
This fixes #186. Furthermore, a github action has been added to run the tests with vanilla Clang to ensure compilation doesn't break later on.