### PR TITLE
Disable non-blocking collectives with OpenMPI

### DIFF
--- a/Source/AMRInterpolator/MPIContext.impl.hpp
+++ b/Source/AMRInterpolator/MPIContext.impl.hpp
@@ -68,7 +68,7 @@ inline void MPIContext::asyncExchangeQuery(void *sendbuf, void *recvbuf,
     MPI_Request req;
     m_mpi_requests.push_back(req);
 
-#if MPI_VERSION >= 3
+#if MPI_VERSION >= 3 && !defined(OPEN_MPI)
     MPI_Ialltoallv(sendbuf, m_query.countsPtr(), m_query.displsPtr(), type,
                    recvbuf, m_answer.countsPtr(), m_answer.displsPtr(), type,
                    Chombo_MPI::comm, &m_mpi_requests.back());
@@ -86,7 +86,7 @@ inline void MPIContext::asyncExchangeAnswer(void *sendbuf, void *recvbuf,
     MPI_Request req;
     m_mpi_requests.push_back(req);
 
-#if MPI_VERSION >= 3
+#if MPI_VERSION >= 3 && !defined(OPEN_MPI)
     MPI_Ialltoallv(sendbuf, m_answer.countsPtr(), m_answer.displsPtr(), type,
                    recvbuf, m_query.countsPtr(), m_query.displsPtr(), type,
                    Chombo_MPI::comm, &m_mpi_requests.back());
@@ -102,7 +102,7 @@ inline void MPIContext::asyncEnd()
     CH_assert(m_async_active);
     m_async_active = false;
 
-#if MPI_VERSION >= 3
+#if MPI_VERSION >= 3 && !defined(OPEN_MPI)
     MPI_Waitall(m_mpi_requests.size(), &m_mpi_requests[0], MPI_STATUSES_IGNORE);
 #endif
 


### PR DESCRIPTION
This is a somewhat unsatisfactory workaround that resolves #208. In an ideal world, we'd figure out the cause of this problem properly but I think this is acceptable since OpenMPI is rarely the most performant MPI implemtation nor the only one available on most clusters.