### PR TITLE
Fix absolute restart_file paths bug

### DIFF
--- a/Source/GRChomboCore/ChomboParameters.hpp
+++ b/Source/GRChomboCore/ChomboParameters.hpp
@@ -191,6 +191,10 @@ class ChomboParameters
 #endif
 #ifdef CH_USE_HDF5
             hdf5_path = output_path + hdf5_path;
+            // assume restart_file is an absolute path if it starts with '/'
+            // otherwise assume it is relative to hdf5_path
+            if (restart_from_checkpoint && restart_file.front() != '/')
+                restart_file = hdf5_path + restart_file;
 #endif
         }
 
@@ -385,7 +389,7 @@ class ChomboParameters
         if (restart_from_checkpoint)
         {
             bool restart_file_exists =
-                (access((hdf5_path + restart_file).c_str(), R_OK) == 0);
+                (access((restart_file).c_str(), R_OK) == 0);
             check_parameter("restart_file", restart_file, restart_file_exists,
                             "file cannot be opened for reading");
         }

--- a/Source/GRChomboCore/SetupFunctions.hpp
+++ b/Source/GRChomboCore/SetupFunctions.hpp
@@ -173,8 +173,7 @@ void setupAMRObject(GRAMR &gr_amr, AMRLevelFactory &a_factory)
     else
     {
 #ifdef CH_USE_HDF5
-        HDF5Handle handle(chombo_params.hdf5_path + chombo_params.restart_file,
-                          HDF5Handle::OPEN_RDONLY);
+        HDF5Handle handle(chombo_params.restart_file, HDF5Handle::OPEN_RDONLY);
         // read from checkpoint file
         gr_amr.setupForRestart(handle);
         handle.close();


### PR DESCRIPTION
The `restart_file` parameter is now assumed to be a path relative to the `hdf5_path` (`= output_path + hdf5_subpath`) unless it starts with a '/' in which case it is assumed to be an absolute path. This fixes #210.