### PR TITLE
Add ability to use diagnostic variables in tagging criterion

### DIFF
--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -98,8 +98,9 @@ void BinaryBHLevel::preTagCells()
 }
 
 // specify the cells to tag
-void BinaryBHLevel::computeTaggingCriterion(FArrayBox &tagging_criterion,
-                                            const FArrayBox &current_state)
+void BinaryBHLevel::computeTaggingCriterion(
+    FArrayBox &tagging_criterion, const FArrayBox &current_state,
+    const FArrayBox &current_state_diagnostics)
 {
     if (m_p.track_punctures)
     {

--- a/Examples/BinaryBH/BinaryBHLevel.hpp
+++ b/Examples/BinaryBH/BinaryBHLevel.hpp
@@ -42,9 +42,9 @@ class BinaryBHLevel : public GRAMRLevel
     virtual void preTagCells() override;
 
     /// Identify and tag the cells that need higher resolution
-    virtual void
-    computeTaggingCriterion(FArrayBox &tagging_criterion,
-                            const FArrayBox &current_state) override;
+    virtual void computeTaggingCriterion(
+        FArrayBox &tagging_criterion, const FArrayBox &current_state,
+        const FArrayBox &current_state_diagnostics) override;
 
     // to do post each time step on every level
     virtual void specificPostTimeStep() override;

--- a/Examples/KerrBH/KerrBHLevel.cpp
+++ b/Examples/KerrBH/KerrBHLevel.cpp
@@ -94,8 +94,9 @@ void KerrBHLevel::preTagCells()
     fillAllGhosts(VariableType::evolution, Interval(c_chi, c_chi));
 }
 
-void KerrBHLevel::computeTaggingCriterion(FArrayBox &tagging_criterion,
-                                          const FArrayBox &current_state)
+void KerrBHLevel::computeTaggingCriterion(
+    FArrayBox &tagging_criterion, const FArrayBox &current_state,
+    const FArrayBox &current_state_diagnostics)
 {
     BoxLoops::loop(ChiTaggingCriterion(m_dx), current_state, tagging_criterion);
 }

--- a/Examples/KerrBH/KerrBHLevel.hpp
+++ b/Examples/KerrBH/KerrBHLevel.hpp
@@ -39,9 +39,9 @@ class KerrBHLevel : public GRAMRLevel
     /// Things to do before tagging cells (i.e. filling ghosts)
     virtual void preTagCells() override;
 
-    virtual void
-    computeTaggingCriterion(FArrayBox &tagging_criterion,
-                            const FArrayBox &current_state) override;
+    virtual void computeTaggingCriterion(
+        FArrayBox &tagging_criterion, const FArrayBox &current_state,
+        const FArrayBox &current_state_diagnostics) override;
 };
 
 #endif /* KERRBHLEVEL_HPP_ */

--- a/Examples/ScalarField/ScalarFieldLevel.cpp
+++ b/Examples/ScalarField/ScalarFieldLevel.cpp
@@ -122,8 +122,9 @@ void ScalarFieldLevel::preTagCells()
     // used here so don't fill any
 }
 
-void ScalarFieldLevel::computeTaggingCriterion(FArrayBox &tagging_criterion,
-                                               const FArrayBox &current_state)
+void ScalarFieldLevel::computeTaggingCriterion(
+    FArrayBox &tagging_criterion, const FArrayBox &current_state,
+    const FArrayBox &current_state_diagnostics)
 {
     BoxLoops::loop(
         FixedGridsTaggingCriterion(m_dx, m_level, 2.0 * m_p.L, m_p.center),

--- a/Examples/ScalarField/ScalarFieldLevel.hpp
+++ b/Examples/ScalarField/ScalarFieldLevel.hpp
@@ -53,8 +53,9 @@ class ScalarFieldLevel : public GRAMRLevel
     virtual void preTagCells() override;
 
     //! Tell Chombo how to tag cells for regridding
-    virtual void computeTaggingCriterion(FArrayBox &tagging_criterion,
-                                         const FArrayBox &current_state);
+    virtual void computeTaggingCriterion(
+        FArrayBox &tagging_criterion, const FArrayBox &current_state,
+        const FArrayBox &current_state_diagnostics) override;
 };
 
 #endif /* SCALARFIELDLEVEL_HPP_ */

--- a/Source/GRChomboCore/GRAMRLevel.cpp
+++ b/Source/GRChomboCore/GRAMRLevel.cpp
@@ -186,6 +186,15 @@ void GRAMRLevel::postTimeStep()
         pout() << "GRAMRLevel::postTimeStep " << m_level << " finished" << endl;
 }
 
+// for examples that don't implement a computeTaggingCriterion with diagnostic
+// variables
+void GRAMRLevel::computeTaggingCriterion(
+    FArrayBox &tagging_criterion, const FArrayBox &current_state,
+    const FArrayBox &current_state_diagnostics)
+{
+    computeTaggingCriterion(tagging_criterion, current_state);
+}
+
 // things to do before tagging cells
 void GRAMRLevel::preTagCells()
 {
@@ -213,10 +222,16 @@ void GRAMRLevel::tagCells(IntVectSet &a_tags)
         DataIndex di = dit0[ibox];
         const Box &b = level_domain[di];
         const FArrayBox &state_fab = m_state_new[di];
+        FArrayBox invalid_box; // no array memory allocated
+        const FArrayBox *diagnostics_fab = &invalid_box;
+        if (NUM_DIAGNOSTIC_VARS > 0)
+        {
+            diagnostics_fab = &m_state_diagnostics[di];
+        }
 
-        // mod gradient
+        // FAB to store value of criterion
         FArrayBox tagging_criterion(b, 1);
-        computeTaggingCriterion(tagging_criterion, state_fab);
+        computeTaggingCriterion(tagging_criterion, state_fab, *diagnostics_fab);
 
         const IntVect &smallEnd = b.smallEnd();
         const IntVect &bigEnd = b.bigEnd();

--- a/Source/GRChomboCore/GRAMRLevel.hpp
+++ b/Source/GRChomboCore/GRAMRLevel.hpp
@@ -142,9 +142,19 @@ class GRAMRLevel : public AMRLevel, public InterpSource
     /// (Pure) virtual function for the initial data calculation
     virtual void initialData() = 0;
 
-    /// Computes which cells have insufficient resolution and should be tagged
+    /// Virtual function which tags cells for refinement based on just evolution
+    /// variables state
     virtual void computeTaggingCriterion(FArrayBox &tagging_criterion,
-                                         const FArrayBox &current_state) = 0;
+                                         const FArrayBox &current_state)
+    {
+    }
+
+    /// Virtual function which tags cells for refinement based on current
+    /// evolution and diagnostic variables state
+    virtual void
+    computeTaggingCriterion(FArrayBox &tagging_criterion,
+                            const FArrayBox &current_state,
+                            const FArrayBox &current_state_diagnostics);
 
 #ifdef CH_USE_HDF5
     /// Things to do immediately before checkpointing


### PR DESCRIPTION
This PR adds the ability to use diagnostic variables in the tagging criterion. Note that the old virtual function (without the diagnostics argument) still exists in `GRAMRLevel` so this shouldn't break compatibility with old examples. 

The only disadvantage is that the compiler will not throw an error if neither `computeTaggingCriterion` is overridden as they are both not pure virtual. It is up to the user to implement at least one of them.