### PR TITLE
Add support for AArch64

### DIFF
--- a/Source/simd/arm/arm.hpp
+++ b/Source/simd/arm/arm.hpp
@@ -14,11 +14,14 @@
 
 #include "sve.hpp"
 
+#elif defined(__ARM_NEON)
+
+#include "neon.hpp"
+
 #else
 
-#warning "Not using any intrinsics on ARM. If targetting SVE, you might need "\
-         "to enable SVE bits with a compiler flag\n"\
-         "e.g. -msve-vector-bits=... with GCC"
+#warning                                                                       \
+    "Not using any intrinsics on AArch64. If targetting SVE, you might need to enable SVE bits with a compiler flag e.g. -msve-vector-bits=... with GCC"
 
 #endif
 

--- a/Source/simd/arm/arm.hpp
+++ b/Source/simd/arm/arm.hpp
@@ -1,0 +1,25 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef SIMD_ARM_HPP_
+#define SIMD_ARM_HPP_
+
+#if !defined(SIMD_HPP_)
+#error "This file should only be included through simd.hpp"
+#endif
+
+#if defined(__ARM_FEATURE_SVE) && defined(__ARM_FEATURE_SVE_BITS)
+
+#include "sve.hpp"
+
+#else
+
+#warning "Not using any intrinsics on ARM. If targetting SVE, you might need "\
+         "to enable SVE bits with a compiler flag\n"\
+         "e.g. -msve-vector-bits=... with GCC"
+
+#endif
+
+#endif /* SIMD_ARM_HPP_ */

--- a/Source/simd/arm/neon.hpp
+++ b/Source/simd/arm/neon.hpp
@@ -1,0 +1,178 @@
+#ifndef SIMD_NEON_HPP_
+#define SIMD_NEON_HPP_
+
+#if !defined(SIMD_ARM_HPP_)
+#error "This file should only be included through arm.hpp"
+#endif
+
+#ifdef __ARM_NEON
+
+#include <arm_neon.h>
+
+template <> struct simd_traits<double>
+{
+    typedef float64x2_t data_t;
+    typedef uint64x2_t mask_t;
+    static const int simd_len = 2;
+};
+
+template <> struct simd_traits<float>
+{
+    typedef float32x4_t data_t;
+    typedef uint32x4_t mask_t;
+    static const int simd_len = 4;
+};
+
+template <> struct simd<double> : public simd_base<double>
+{
+    typedef typename simd_traits<double>::data_t data_t;
+    typedef typename simd_traits<double>::mask_t mask_t;
+
+    ALWAYS_INLINE
+    simd() : simd_base<double>(vdupq_n_f64(0.)) {}
+
+    ALWAYS_INLINE
+    simd(double x) : simd_base<double>(vdupq_n_f64(x)) {}
+
+    ALWAYS_INLINE
+    simd(const data_t &v) : simd_base<double>(v) {}
+
+    ALWAYS_INLINE
+    static simd load(const double *ptr) { return vld1q_f64(ptr); }
+
+    ALWAYS_INLINE
+    static void store(double *ptr, const simd &a) { vst1q_f64(ptr, a.m_value); }
+
+    ALWAYS_INLINE
+    simd &operator+=(const simd &a)
+    {
+        m_value = vaddq_f64(m_value, a.m_value);
+        return *this;
+    }
+    ALWAYS_INLINE
+    simd &operator-=(const simd &a)
+    {
+        m_value = vsubq_f64(m_value, a.m_value);
+        return *this;
+    }
+    ALWAYS_INLINE
+    simd &operator*=(const simd &a)
+    {
+        m_value = vmulq_f64(m_value, a.m_value);
+        return *this;
+    }
+    ALWAYS_INLINE
+    simd &operator/=(const simd &a)
+    {
+        m_value = vdivq_f64(m_value, a.m_value);
+        return *this;
+    }
+
+    friend ALWAYS_INLINE simd simd_conditional(const mask_t cond,
+                                               const simd &true_value,
+                                               const simd &false_value)
+    {
+        return vbslq_f64(cond, true_value, false_value);
+    }
+
+    friend ALWAYS_INLINE mask_t simd_compare_lt(const simd &a, const simd &b)
+    {
+        return vcltq_f64(a, b);
+    }
+
+    friend ALWAYS_INLINE mask_t simd_compare_gt(const simd &a, const simd &b)
+    {
+        return vcgtq_f64(a, b);
+    }
+
+    friend ALWAYS_INLINE simd simd_min(const simd &a, const simd &b)
+    {
+        return vminq_f64(a, b);
+    }
+
+    friend ALWAYS_INLINE simd simd_max(const simd &a, const simd &b)
+    {
+        return vmaxq_f64(a, b);
+    }
+
+    friend ALWAYS_INLINE simd simd_sqrt(const simd &a) { return vsqrtq_f64(a); }
+};
+
+template <> struct simd<float> : public simd_base<float>
+{
+    typedef typename simd_traits<float>::data_t data_t;
+    typedef typename simd_traits<float>::mask_t mask_t;
+
+    ALWAYS_INLINE
+    simd() : simd_base<float>(vdupq_n_f32(0.)) {}
+
+    ALWAYS_INLINE
+    simd(float x) : simd_base<float>(vdupq_n_f32(x)) {}
+
+    ALWAYS_INLINE
+    simd(const data_t &v) : simd_base<float>(v) {}
+
+    ALWAYS_INLINE
+    static simd load(const float *ptr) { return vld1q_f32(ptr); }
+
+    ALWAYS_INLINE
+    static void store(float *ptr, const simd &a) { vst1q_f32(ptr, a.m_value); }
+
+    ALWAYS_INLINE
+    simd &operator+=(const simd &a)
+    {
+        m_value = vaddq_f32(m_value, a.m_value);
+        return *this;
+    }
+    ALWAYS_INLINE
+    simd &operator-=(const simd &a)
+    {
+        m_value = vsubq_f32(m_value, a.m_value);
+        return *this;
+    }
+    ALWAYS_INLINE
+    simd &operator*=(const simd &a)
+    {
+        m_value = vmulq_f32(m_value, a.m_value);
+        return *this;
+    }
+    ALWAYS_INLINE
+    simd &operator/=(const simd &a)
+    {
+        m_value = vdivq_f32(m_value, a.m_value);
+        return *this;
+    }
+
+    friend ALWAYS_INLINE simd simd_conditional(const mask_t cond,
+                                               const simd &true_value,
+                                               const simd &false_value)
+    {
+        return vbslq_f32(cond, true_value, false_value);
+    }
+
+    friend ALWAYS_INLINE mask_t simd_compare_lt(const simd &a, const simd &b)
+    {
+        return vcltq_f32(a, b);
+    }
+
+    friend ALWAYS_INLINE mask_t simd_compare_gt(const simd &a, const simd &b)
+    {
+        return vcgtq_f32(a, b);
+    }
+
+    friend ALWAYS_INLINE simd simd_min(const simd &a, const simd &b)
+    {
+        return vminq_f32(a, b);
+    }
+
+    friend ALWAYS_INLINE simd simd_max(const simd &a, const simd &b)
+    {
+        return vmaxq_f32(a, b);
+    }
+
+    friend ALWAYS_INLINE simd simd_sqrt(const simd &a) { return vsqrtq_f32(a); }
+};
+
+#endif /* __ARM_NEON */
+
+#endif /* SIMD_NEON_HPP_*/

--- a/Source/simd/arm/sve.hpp
+++ b/Source/simd/arm/sve.hpp
@@ -1,0 +1,217 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef SIMD_SVE_HPP_
+#define SIMD_SVE_HPP_
+
+#if !defined(SIMD_ARM_HPP_)
+#error "This file should only be included through arm.hpp"
+#endif
+
+#if defined(__ARM_FEATURE_SVE) && defined(__ARM_FEATURE_SVE_BITS)
+
+#include <arm_sve.h>
+
+// Need to use this attribute in order to use the vector length specific
+// instructions. These are necessary because of our implementation of simd
+typedef svfloat64_t vecd
+    __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
+typedef svfloat32_t vecf
+    __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
+typedef svbool_t pred
+    __attribute__((arm_sve_vector_bits(__ARM_FEATURE_SVE_BITS)));
+
+// Note that even though SVE enables the removal of remainder loops through the
+// use of predicates (aka mask_t) in almost every intrinsic, we don't use these
+// in order to maintain compatbility with our existing interface.
+
+template <> struct simd_traits<double>
+{
+    typedef vecd data_t;
+    typedef pred mask_t;
+    static const int simd_len = sizeof(vecd) / sizeof(double);
+};
+
+template <> struct simd_traits<float>
+{
+    typedef vecf data_t;
+    typedef pred mask_t;
+    static const int simd_len = sizeof(vecf) / sizeof(float);
+};
+
+template <> struct simd<double> : public simd_base<double>
+{
+    typedef typename simd_traits<double>::data_t data_t;
+    typedef typename simd_traits<double>::mask_t mask_t;
+
+    ALWAYS_INLINE
+    simd() : simd_base<double>(svdup_n_f64(0.)) {}
+
+    ALWAYS_INLINE
+    simd(const double &s) : simd_base<double>(svdup_n_f64(s)) {}
+
+    ALWAYS_INLINE
+    simd(const data_t &v) : simd_base<double>(v) {}
+
+    ALWAYS_INLINE
+    static simd load(const double *ptr)
+    {
+        return svld1_f64(svptrue_b64(), ptr);
+    }
+
+    ALWAYS_INLINE
+    static void store(double *ptr, const simd &a)
+    {
+        svst1_f64(svptrue_b64(), ptr, a.m_value);
+    }
+
+    ALWAYS_INLINE
+    simd &operator+=(const simd &a)
+    {
+        m_value = svadd_f64_z(svptrue_b64(), m_value, a.m_value);
+        return *this;
+    }
+
+    ALWAYS_INLINE
+    simd &operator-=(const simd &a)
+    {
+        m_value = svsub_f64_z(svptrue_b64(), m_value, a.m_value);
+        return *this;
+    }
+
+    ALWAYS_INLINE
+    simd &operator*=(const simd &a)
+    {
+        m_value = svmul_f64_z(svptrue_b64(), m_value, a.m_value);
+        return *this;
+    }
+
+    ALWAYS_INLINE
+    simd &operator/=(const simd &a)
+    {
+        m_value = svdiv_f64_z(svptrue_b64(), m_value, a.m_value);
+        return *this;
+    }
+
+    friend ALWAYS_INLINE simd simd_conditional(const mask_t cond,
+                                               const simd &true_value,
+                                               const simd &false_value)
+    {
+        return svsel_f64(cond, true_value, false_value);
+    }
+
+    friend ALWAYS_INLINE mask_t simd_compare_lt(const simd &a, const simd &b)
+    {
+        return svcmplt_f64(svptrue_b64(), a, b);
+    }
+
+    friend ALWAYS_INLINE mask_t simd_compare_gt(const simd &a, const simd &b)
+    {
+        return svcmpgt_f64(svptrue_b64(), a, b);
+    }
+
+    friend ALWAYS_INLINE simd simd_min(const simd &a, const simd &b)
+    {
+        return svmin_f64_z(svptrue_b64(), a, b);
+    }
+
+    friend ALWAYS_INLINE simd simd_max(const simd &a, const simd &b)
+    {
+        return svmax_f64_z(svptrue_b64(), a, b);
+    }
+
+    friend ALWAYS_INLINE simd simd_sqrt(const simd &a)
+    {
+        return svsqrt_f64_z(svptrue_b64(), a);
+    }
+};
+
+template <> struct simd<float> : public simd_base<float>
+{
+    typedef typename simd_traits<float>::data_t data_t;
+    typedef typename simd_traits<float>::mask_t mask_t;
+
+    ALWAYS_INLINE
+    simd() : simd_base<float>(svdup_n_f32(0.)) {}
+
+    ALWAYS_INLINE
+    simd(const float &s) : simd_base<float>(svdup_n_f32(s)) {}
+
+    ALWAYS_INLINE
+    simd(const data_t &v) : simd_base<float>(v) {}
+
+    ALWAYS_INLINE
+    static simd load(const float *ptr) { return svld1_f32(svptrue_b32(), ptr); }
+
+    ALWAYS_INLINE
+    static void store(float *ptr, const simd &a)
+    {
+        svst1_f32(svptrue_b32(), ptr, a.m_value);
+    }
+
+    ALWAYS_INLINE
+    simd &operator+=(const simd &a)
+    {
+        m_value = svadd_f32_z(svptrue_b32(), m_value, a.m_value);
+        return *this;
+    }
+
+    ALWAYS_INLINE
+    simd &operator-=(const simd &a)
+    {
+        m_value = svsub_f32_z(svptrue_b32(), m_value, a.m_value);
+        return *this;
+    }
+
+    ALWAYS_INLINE
+    simd &operator*=(const simd &a)
+    {
+        m_value = svmul_f32_z(svptrue_b32(), m_value, a.m_value);
+        return *this;
+    }
+
+    ALWAYS_INLINE
+    simd &operator/=(const simd &a)
+    {
+        m_value = svdiv_f32_z(svptrue_b32(), m_value, a.m_value);
+        return *this;
+    }
+
+    friend ALWAYS_INLINE simd simd_conditional(const mask_t cond,
+                                               const simd &true_value,
+                                               const simd &false_value)
+    {
+        return svsel_f32(cond, true_value, false_value);
+    }
+
+    friend ALWAYS_INLINE mask_t simd_compare_lt(const simd &a, const simd &b)
+    {
+        return svcmplt_f32(svptrue_b32(), a, b);
+    }
+
+    friend ALWAYS_INLINE mask_t simd_compare_gt(const simd &a, const simd &b)
+    {
+        return svcmpgt_f32(svptrue_b32(), a, b);
+    }
+
+    friend ALWAYS_INLINE simd simd_min(const simd &a, const simd &b)
+    {
+        return svmin_f32_z(svptrue_b32(), a, b);
+    }
+
+    friend ALWAYS_INLINE simd simd_max(const simd &a, const simd &b)
+    {
+        return svmax_f32_z(svptrue_b32(), a, b);
+    }
+
+    friend ALWAYS_INLINE simd simd_sqrt(const simd &a)
+    {
+        return svsqrt_f32_z(svptrue_b32(), a);
+    }
+};
+
+#endif /* __ARM_FEATURE_SVE && __ARM_FEATURE_SVE_BITS */
+
+#endif /* SIMD_SVE_HPP_ */

--- a/Source/simd/simd.hpp
+++ b/Source/simd/simd.hpp
@@ -42,6 +42,7 @@ template <typename t> struct simd_traits
 // architecture-specific files and simd_base.hpp
 template <typename t> struct simd
 {
+    static const int simd_len = simd_traits<t>::simd_len;
     t m_value;
 
     ALWAYS_INLINE
@@ -62,30 +63,30 @@ template <typename t> struct simd
     ALWAYS_INLINE
     static void store(double *ptr, const simd &a) { *ptr = a.m_value; }
 
-    ALWAYS_INLINE
-    simd &operator+=(const simd &a)
-    {
-        m_value += a.m_value;
-        return *this;
-    }
-    ALWAYS_INLINE
-    simd &operator-=(const simd &a)
-    {
-        m_value -= a.m_value;
-        return *this;
-    }
-    ALWAYS_INLINE
-    simd &operator*=(const simd &a)
-    {
-        m_value *= a.m_value;
-        return *this;
-    }
-    ALWAYS_INLINE
-    simd &operator/=(const simd &a)
-    {
-        m_value /= a.m_value;
-        return *this;
-    }
+    //   ALWAYS_INLINE
+    //  simd &operator+=(const simd &a)
+    //  {
+    //      m_value += a.m_value;
+    //      return *this;
+    //  }
+    //  ALWAYS_INLINE
+    //  simd &operator-=(const simd &a)
+    //  {
+    //      m_value -= a.m_value;
+    //      return *this;
+    //  }
+    //  ALWAYS_INLINE
+    //  simd &operator*=(const simd &a)
+    //  {
+    //      m_value *= a.m_value;
+    //      return *this;
+    //  }
+    //  ALWAYS_INLINE
+    //  simd &operator/=(const simd &a)
+    //  {
+    //      m_value /= a.m_value;
+    //      return *this;
+    //  }
 
     ALWAYS_INLINE
     t operator[](int index) const { return m_value; }
@@ -98,6 +99,32 @@ template <typename t> struct simd
     template <typename op_t> ALWAYS_INLINE simd foreach (op_t op, t arg) const
     {
         return simd(op(m_value, arg));
+    }
+
+    friend simd simd_conditional(const bool cond, const simd &true_value,
+                                 const simd &false_value)
+    {
+        return cond ? true_value : false_value;
+    }
+
+    friend ALWAYS_INLINE bool simd_compare_lt(const simd &a, const simd &b)
+    {
+        return a < b;
+    }
+
+    friend ALWAYS_INLINE bool simd_compare_gt(const simd &a, const simd &b)
+    {
+        return a > b;
+    }
+
+    friend ALWAYS_INLINE simd simd_min(const simd &a, const simd &b)
+    {
+        return (a <= b) ? a : b;
+    }
+
+    friend ALWAYS_INLINE simd simd_max(const simd &a, const simd &b)
+    {
+        return (a > b) ? a : b;
     }
 };
 
@@ -137,6 +164,7 @@ template <typename t> ALWAYS_INLINE t simd_max(const t &a, const t &b)
 {
     return (a > b) ? a : b;
 }
+
 //<-- End: Defining the simd specific calls for non-simd datatypes.
 
 #include "simdify.hpp"

--- a/Source/simd/simd.hpp
+++ b/Source/simd/simd.hpp
@@ -128,10 +128,15 @@ template <typename t> struct simd
     }
 };
 
-#include "simd_base.hpp" //Define all the simd-functions whose implementation does not depend on the architecture
+// Define all the simd-functions whose implementation does not depend on the
+// architecture
+#include "simd_base.hpp"
 
+// Define simd-functions whose implementation depends on the architecture
 #if defined(__x86_64__)
-#include "x64/x64.hpp" //Define simd-functions whose implementation depends on the architecture
+#include "x64/x64.hpp"
+#elif defined(__aarch64__)
+#include "arm/arm.hpp"
 #endif
 
 // We have defined various simd-specific calls (simd_compare_lt,

--- a/Source/utils/Coordinates.hpp
+++ b/Source/utils/Coordinates.hpp
@@ -54,8 +54,8 @@ template <class data_t> class Coordinates
 
     static void // typename std::enable_if_t<(simd_traits<double>::simd_len >
                 // 1), void>
-                compute_coord(simd<double> &out, int position, double dx,
-                              double center_distance = 0)
+    compute_coord(simd<double> &out, int position, double dx,
+                  double center_distance = 0)
     {
         double out_arr[simd_traits<double>::simd_len];
         for (int i = 0; i < simd_traits<double>::simd_len; ++i)

--- a/Source/utils/Coordinates.hpp
+++ b/Source/utils/Coordinates.hpp
@@ -52,9 +52,10 @@ template <class data_t> class Coordinates
         out = (position + 0.5) * dx - center_distance;
     }
 
-    static typename std::enable_if_t<(simd_traits<double>::simd_len > 1), void>
-    compute_coord(simd<double> &out, int position, double dx,
-                  double center_distance = 0)
+    static void // typename std::enable_if_t<(simd_traits<double>::simd_len >
+                // 1), void>
+                compute_coord(simd<double> &out, int position, double dx,
+                              double center_distance = 0)
     {
         double out_arr[simd_traits<double>::simd_len];
         for (int i = 0; i < simd_traits<double>::simd_len; ++i)


### PR DESCRIPTION
This allows building GRChombo on AArch64 systems (e.g. Apple Silicon Macs).

The Neon instructions (relevant to current generation Apple Silicon) have been tested by running the tests on the [XCI part of the Isambard cluster](https://gw4-isambard.github.io/docs/user-guide/XCI.html).

The SVE instructions have been tested by running the tests on the [A64FX part of the Isambard cluster](https://gw4-isambard.github.io/docs/user-guide/A64FX.html). Note that the implementation of Scalable Vector Extension (SVE) instructions is a bit strange due to the limitations of our current interface. In particular, the Vector Length Specific (VLS) extension to SVE is required. On supported compilers, it may need to be manually enabled with a flag e.g. `-msve-vector-bits=<number of bits>` with GCC.