### PR TITLE
Improve building of BinaryBH example with TwoPunctures

### DIFF
--- a/Examples/BinaryBH/GNUmakefile
+++ b/Examples/BinaryBH/GNUmakefile
@@ -42,3 +42,11 @@ ifeq ($(USE_TWOPUNCTURES),TRUE)
 endif
 
 include $(CHOMBO_HOME)/mk/Make.test
+
+ifdef TWOPUNCTURES_SOURCE
+all-tp: all-test
+	$(ECHO)mv $(_app_configs) $(ebase)_TP.$(config).ex
+else
+all-tp:
+	@echo "Set TWOPUNCTURES_SOURCE environment variable to build BinaryBH example with TwoPunctures.";
+endif

--- a/Examples/BinaryBH/README.md
+++ b/Examples/BinaryBH/README.md
@@ -7,10 +7,15 @@ e.g.
 ```bash
 export TWOPUNCTURES_SOURCE=/path/to/TwoPunctures/Source
 ```
-Then, simply build as normal e.g.
+Then, use `make` to build the `all-tp` target using a command such as
 ```bash
-make all -j 4
+make all-tp -j 4
 ```
+The created executable will have the filename
+```
+Main_BinaryBH_TP.<config>.ex
+```
+
 To stop using TwoPunctures, undefine the `TWOPUNCTURES_SOURCE` environment variable:
 ```bash
 unset TWOPUNCTURES_SOURCE
@@ -18,7 +23,7 @@ unset TWOPUNCTURES_SOURCE
 Alternatively, you can avoid defining an environment variable by defining it in
 the make command:
 ```bash
-make all -j 4 TWOPUNCTURES_SOURCE=/path/to/TwoPunctures/Source
+make all-tp -j 4 TWOPUNCTURES_SOURCE=/path/to/TwoPunctures/Source
 ```
 Note that the parameter names for TwoPunctures initial data differ to that of
 the vanilla example: see [params_two_punctures.txt](./params_two_punctures.txt)


### PR DESCRIPTION
This just adds an `all-tp` build target which renames the executable from
`Main_BinaryBH<config>.ex` to `Main_BinaryBH_TP.<config>.ex` after building to indicate that it has been built with TwoPunctures.

Note that if the `TWOPUNCTURES_SOURCE` environment variable is set, `make all` will still build the BinaryBH example with TwoPunctures but the executable will not be renamed.