### PR TITLE
Update clang-format to v16

### DIFF
--- a/.github/workflows/test-clang-format.yml
+++ b/.github/workflows/test-clang-format.yml
@@ -8,8 +8,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: DoozyX/clang-format-lint-action@v0.16
+    - uses: DoozyX/clang-format-lint-action@v0.16.2
       with:
         source: '.'
         extensions: 'hpp,cpp'
-        clangFormatVersion: 15
+        clangFormatVersion: 16

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
 -   repo: https://github.com/pre-commit/mirrors-clang-format
-    rev: v15.0.7  
+    rev: v16.0.4  
     hooks:
     -   id: clang-format

--- a/Source/CCZ4/Constraints.hpp
+++ b/Source/CCZ4/Constraints.hpp
@@ -55,10 +55,10 @@ class [[deprecated(
 
     template <class data_t, template <typename> class vars_t,
               template <typename> class diff2_vars_t>
-    Vars<data_t> constraint_equations(const vars_t<data_t> &vars,
-                                      const vars_t<Tensor<1, data_t>> &d1,
-                                      const diff2_vars_t<Tensor<2, data_t>> &d2)
-        const;
+    Vars<data_t>
+    constraint_equations(const vars_t<data_t> &vars,
+                         const vars_t<Tensor<1, data_t>> &d1,
+                         const diff2_vars_t<Tensor<2, data_t>> &d2) const;
 };
 
 #include "Constraints.impl.hpp"


### PR DESCRIPTION
Pretty much in the title. The [pre-commit hook](https://github.com/GRChombo/GRChombo/wiki/Using-Clang-Format#setting-up-the-pre-commit-hook) version has also been updated.