### PR TITLE
Update nancheck to ensure exit using openmp

### DIFF
--- a/Examples/BinaryBH/BinaryBHLevel.cpp
+++ b/Examples/BinaryBH/BinaryBHLevel.cpp
@@ -32,8 +32,9 @@ void BinaryBHLevel::specificAdvance()
 
     // Check for nan's
     if (m_p.nan_check)
-        BoxLoops::loop(NanCheck("NaNCheck in specific Advance: "), m_state_new,
-                       m_state_new, EXCLUDE_GHOST_CELLS, disable_simd());
+        BoxLoops::loop(NanCheck(m_dx, "NaNCheck in specific Advance: "),
+                       m_state_new, m_state_new, EXCLUDE_GHOST_CELLS,
+                       disable_simd());
 }
 
 // This initial data uses an approximation for the metric which

--- a/Source/BoxUtils/NanCheck.hpp
+++ b/Source/BoxUtils/NanCheck.hpp
@@ -16,32 +16,46 @@ class NanCheck
   protected:
     const std::string m_error_info = "NanCheck";
     const double m_max_abs = 1e20;
+    const double m_dx;
 
   public:
-    NanCheck() {}
+    NanCheck(const double a_dx = 1.0) : m_dx(a_dx) {}
 
     /// This constructor takes a string which will be displayed when nans happen
-    NanCheck(const std::string a_error_info) : m_error_info(a_error_info) {}
+    NanCheck(const std::string a_error_info, const double a_dx = 1.0)
+        : m_error_info(a_error_info), m_dx(a_dx)
+    {
+    }
 
-    NanCheck(const std::string a_error_info, const double a_max_abs)
-        : m_error_info(a_error_info), m_max_abs(a_max_abs)
+    NanCheck(const std::string a_error_info, const double a_max_abs,
+             const double a_dx = 1.0)
+        : m_error_info(a_error_info), m_max_abs(a_max_abs), m_dx(a_dx)
     {
     }
 
     void compute(Cell<double> current_cell) const
     {
-        bool stop = false;
+        // stop is shared between all threads
+        bool stop;
+// guard update to prevent a race
+#pragma omp atomic write
+        stop = false;
+
         int num_vars = current_cell.get_num_in_vars();
         for (int ivar = 0; ivar < num_vars; ++ivar)
         {
             double val;
             current_cell.load_vars(val, ivar);
             if (std::isnan(val) || abs(val) > m_max_abs)
+// we want to exit if any of the threads find a nan
+#pragma omp atomic write
                 stop = true;
         }
         if (stop)
         {
-#pragma omp single
+// This needs to be the master thread, otherwise some schedulers have trouble
+// exiting
+#pragma omp master
             {
                 pout() << m_error_info
                        << "::Values have become nan. The current state is: \n";
@@ -52,6 +66,7 @@ class NanCheck
                 }
                 pout() << "Integer coordinates: " << current_cell.get_int_vect()
                        << std::endl;
+                pout() << "m_dx: " << m_dx << std::endl;
             }
             MayDay::Error("Values have become nan.");
         }


### PR DESCRIPTION
Fixes bug in #238.

Also (just because I had this in my code already) implements the output of physical coordinates instead of integer ones if m_dx is passed by the user. 

@mirenradia would you support moving the NanCheck to specificPostTimestep() instead of specifiAdvance()? I think this is a historic thing - I don't see that you gain much by exiting during a RK4 substep rather than at the end, and it means it runs a load more times. If so I would updated this in the Examples here.