### PR TITLE
Feature/admquantities

### DIFF
--- a/Examples/KerrBH/DiagnosticVariables.hpp
+++ b/Examples/KerrBH/DiagnosticVariables.hpp
@@ -15,6 +15,9 @@ enum
     c_Mom2,
     c_Mom3,
 
+    c_Madm,
+    c_Jadm,
+
     NUM_DIAGNOSTIC_VARS
 };
 
@@ -23,7 +26,9 @@ namespace DiagnosticVariables
 static const std::array<std::string, NUM_DIAGNOSTIC_VARS> variable_names = {
     "Ham",
 
-    "Mom1", "Mom2", "Mom3"};
+    "Mom1", "Mom2", "Mom3",
+
+    "Madm", "Jadm"};
 }
 
 #endif /* DIAGNOSTICVARIABLES_HPP */

--- a/Examples/KerrBH/params.txt
+++ b/Examples/KerrBH/params.txt
@@ -144,6 +144,21 @@ sigma = 0.3
 # min_lapse = 1.e-4
 
 #################################################
+# Extraction parameters for the ADM quantities
+
+# extraction_center = 256 256 256 # defaults to center
+activate_extraction = 1
+num_extraction_radii = 3
+extraction_radii = 60. 80. 100.
+extraction_levels = 2 1 0
+num_points_phi = 50
+num_points_theta = 51
+# num_modes = 3
+# modes = 2 0 # l m for spherical harmonics
+#        2 1
+#        2 2
+
+#################################################
 # Apparent Horizon Finder parameters
 
 AH_activate = 1 

--- a/Examples/KerrBH/params.txt
+++ b/Examples/KerrBH/params.txt
@@ -146,9 +146,10 @@ sigma = 0.3
 
 #################################################
 # Extraction parameters for the ADM quantities
+# Need larger box to extract ADM quantities (at least L=256M)
 
-# extraction_center = 256 256 256 # defaults to center
-activate_extraction = 1
+# extraction_center = 128 128 128 # defaults to center
+activate_extraction = 0
 num_extraction_radii = 3
 extraction_radii = 60. 80. 100.
 extraction_levels = 2 1 0
@@ -156,8 +157,8 @@ num_points_phi = 50
 num_points_theta = 51
 # num_modes = 3
 # modes = 2 0 # l m for spherical harmonics
-#        2 1
-#        2 2
+#         2 1
+#         2 2
 
 #################################################
 # Apparent Horizon Finder parameters

--- a/Examples/KerrBH/params.txt
+++ b/Examples/KerrBH/params.txt
@@ -95,6 +95,7 @@ vars_parity            = 0 0 4 6 0 5 0    #chi and hij
                          0 1 2 3          #Theta and Gamma
                          0 1 2 3 1 2 3    #lapse shift and B
 vars_parity_diagnostic = 0 1 2 3          #Ham and Mom
+			 0 0		  #Madm and Jadm
 
 # if sommerfeld boundaries selected, must select
 # non zero asymptotic values

--- a/Examples/KerrBH/params.txt
+++ b/Examples/KerrBH/params.txt
@@ -95,7 +95,7 @@ vars_parity            = 0 0 4 6 0 5 0    #chi and hij
                          0 1 2 3          #Theta and Gamma
                          0 1 2 3 1 2 3    #lapse shift and B
 vars_parity_diagnostic = 0 1 2 3          #Ham and Mom
-			 0 0		  #Madm and Jadm
+                         0 0              #Madm and Jadm
 
 # if sommerfeld boundaries selected, must select
 # non zero asymptotic values

--- a/Examples/KerrBH/params_cheap.txt
+++ b/Examples/KerrBH/params_cheap.txt
@@ -96,6 +96,7 @@ vars_parity            = 0 0 4 6 0 5 0    #chi and hij
                          0 1 2 3          #Theta and Gamma
                          0 1 2 3 1 2 3    #lapse shift and B
 vars_parity_diagnostic = 0 1 2 3          #Ham and Mom
+			 0 0		  #Madm and Jadm
 
 # if sommerfeld boundaries selected, must select
 # non zero asymptotic values

--- a/Examples/KerrBH/params_cheap.txt
+++ b/Examples/KerrBH/params_cheap.txt
@@ -96,7 +96,7 @@ vars_parity            = 0 0 4 6 0 5 0    #chi and hij
                          0 1 2 3          #Theta and Gamma
                          0 1 2 3 1 2 3    #lapse shift and B
 vars_parity_diagnostic = 0 1 2 3          #Ham and Mom
-			 0 0		  #Madm and Jadm
+                         0 0              #Madm and Jadm
 
 # if sommerfeld boundaries selected, must select
 # non zero asymptotic values

--- a/Source/CCZ4/ADMQuantities.hpp
+++ b/Source/CCZ4/ADMQuantities.hpp
@@ -1,0 +1,139 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef ADMQUANTITIES_HPP_
+#define ADMQUANTITIES_HPP_
+
+#include "ADMConformalVars.hpp"
+#include "CCZ4Geometry.hpp"
+#include "Cell.hpp"
+#include "Coordinates.hpp"
+#include "FourthOrderDerivatives.hpp"
+#include "GRInterval.hpp"
+#include "Tensor.hpp"
+#include "TensorAlgebra.hpp"
+#include "UserVariables.hpp" //This files needs NUM_VARS - total number of components
+#include "VarsTools.hpp"
+#include "simd.hpp"
+
+//! Calculates the ADM massa
+class ADMQuantities
+{
+    // Use the variable definition in ADMConformalVars - only require the key
+    // vars
+    template <class data_t> using Vars = ADMConformalVars::VarsNoGauge<data_t>;
+
+    template <class data_t>
+    using Diff1Vars = ADMConformalVars::Diff2VarsNoGauge<data_t>;
+
+  public:
+    enum DIR
+    {
+        X,
+        Y,
+        Z
+    };
+
+    ADMQuantities(const std::array<double, CH_SPACEDIM> &a_center, double a_dx,
+                  int a_c_Madm = -1, int a_c_Jadm = -1, double a_G_Newton = 1.0)
+        : m_deriv(a_dx), m_center(a_center), m_G_Newton(a_G_Newton),
+          m_c_Madm(a_c_Madm), m_c_Jadm(a_c_Jadm), m_dir(Z)
+    {
+    }
+
+    // in case user wants to change direction of spin calculation to something
+    // other than Z
+    void set_spin_dir(DIR spin_direction) { m_dir = spin_direction; }
+
+    template <class data_t> void compute(Cell<data_t> current_cell) const
+    {
+        // copy data from chombo gridpoint into local variables, and calc 1st
+        // derivs
+        const auto vars = current_cell.template load_vars<Vars>();
+        const auto d1 = m_deriv.template diff1<Diff1Vars>(current_cell);
+
+        using namespace TensorAlgebra;
+        const auto h_UU = compute_inverse_sym(vars.h);
+
+        // Surface element for integration
+        Coordinates<data_t> coords(current_cell, m_deriv.m_dx, m_center);
+        Tensor<1, data_t> x = {coords.x, coords.y, coords.z};
+        Tensor<1, data_t> dS_U = x;
+
+        data_t dS_norm = 0.;
+        FOR(i, j) { dS_norm += vars.h[i][j] / vars.chi * dS_U[i] * dS_U[j]; }
+        dS_norm = sqrt(dS_norm);
+        FOR(i) { dS_U[i] /= dS_norm; }
+
+        Tensor<1, data_t> dS_L;
+        FOR(i)
+        {
+            // dS_L[i] = dS_U[i];
+            dS_L[i] = 0.;
+            FOR(j) { dS_L[i] += vars.h[i][j] / vars.chi * dS_U[j]; }
+        }
+
+        // from eq. (7.15) from arXiv:gr-qc/0703035
+
+        if (m_c_Madm >= 0)
+        {
+            data_t Madm = 0.0;
+            FOR(i, j, k)
+            {
+                Madm += dS_L[i] / (16. * M_PI * m_G_Newton) /
+                        (vars.chi * sqrt(vars.chi)) * h_UU[i][k] *
+                        (vars.h[j][j] * d1.chi[k] - vars.chi * d1.h[j][j][k]);
+                FOR(l)
+                Madm += dS_L[i] / (16. * M_PI * m_G_Newton) /
+                        (vars.chi * sqrt(vars.chi)) * h_UU[j][l] * h_UU[i][k] *
+                        (vars.chi * d1.h[k][l][j] - vars.h[k][l] * d1.chi[j]);
+            }
+
+            // assign values of ADM Mass in output box
+            current_cell.store_vars(Madm, m_c_Madm);
+        }
+
+        // from eq. (7.56) from arXiv:gr-qc/0703035
+
+        if (m_c_Jadm >= 0)
+        {
+            // spin about m_dir axis (x, y or z)
+            data_t Jadm = 0.0;
+
+            // note this is the levi civita symbol,
+            // not tensor (eps_tensor = eps_symbol * chi^-1.5)
+            const Tensor<3, double> epsilon = TensorAlgebra::epsilon();
+
+            FOR(i, j, k)
+            {
+                Jadm += -dS_L[i] / (8. * M_PI * m_G_Newton) *
+                        epsilon[m_dir][j][k] * x[j] * vars.K *
+                        TensorAlgebra::delta(i, k);
+
+                FOR(l, m)
+                {
+                    Jadm += dS_L[i] / (8. * M_PI * m_G_Newton) *
+                            epsilon[m_dir][j][k] * x[j] * h_UU[i][l] *
+                            h_UU[k][m] * vars.chi *
+                            (vars.A[l][m] + vars.K * vars.h[l][m] / 3.);
+                }
+            }
+
+            // assign values of ADM Momentum in output box
+            current_cell.store_vars(Jadm, m_c_Jadm);
+        }
+    }
+
+  protected:
+    const FourthOrderDerivatives
+        m_deriv; //!< An object for calculating derivatives of the variables
+    const std::array<double, CH_SPACEDIM> &m_center;
+    const double m_G_Newton; //!< Newton's constant
+    const int m_c_Madm, m_c_Jadm;
+
+    DIR m_dir;
+};
+
+#endif /* ADMQUANTITIES_HPP_ */

--- a/Source/utils/ADMQuantitiesExtraction.hpp
+++ b/Source/utils/ADMQuantitiesExtraction.hpp
@@ -1,0 +1,84 @@
+/* GRChombo
+ * Copyright 2012 The GRChombo collaboration.
+ * Please refer to LICENSE in GRChombo's root directory.
+ */
+
+#ifndef ADMQUANTITIESEXTRACTION_HPP_
+#define ADMQUANTITIESEXTRACTION_HPP_
+
+#include "SphericalExtraction.hpp"
+//!  The class allows extraction of the values of the ADM mass and angular
+//!  momentum over spherical shells at specified radii, and integration over
+//!  those shells
+/*!
+   The class allows the user to extract data from the grid for the ADM mass and
+   angular momentum over spherical shells at specified radii. The values may
+   then be written to an output file, or integrated across the surfaces.
+*/
+class ADMQuantitiesExtraction : public SphericalExtraction
+{
+  public:
+    //! The constructor
+    ADMQuantitiesExtraction(const spherical_extraction_params_t &a_params,
+                            double a_dt, double a_time, bool a_first_step,
+                            double a_restart_time = 0.0, int a_c_Madm = -1,
+                            int a_c_Jadm = -1)
+        : SphericalExtraction(a_params, a_dt, a_time, a_first_step,
+                              a_restart_time),
+          m_c_Madm(a_c_Madm), m_c_Jadm(a_c_Jadm)
+    {
+        if (m_c_Madm >= 0)
+            add_var(m_c_Madm, VariableType::diagnostic);
+        if (m_c_Jadm >= 0)
+            add_var(m_c_Jadm, VariableType::diagnostic);
+    }
+
+    //! The old constructor which assumes it is called in specificPostTimeStep
+    //! so the first time step is when m_time == m_dt
+    ADMQuantitiesExtraction(const spherical_extraction_params_t a_params,
+                            double a_dt, double a_time,
+                            double a_restart_time = 0.0, int a_c_Madm = -1,
+                            int a_c_Jadm = -1)
+        : ADMQuantitiesExtraction(a_params, a_dt, a_time, (a_dt == a_time),
+                                  a_restart_time, a_c_Madm, a_c_Jadm)
+    {
+    }
+
+    //! Execute the query
+    void execute_query(AMRInterpolator<Lagrange<4>> *a_interpolator)
+    {
+        // extract the values of the ADM mass and spin on the spheres
+        extract(a_interpolator);
+
+        if (m_params.write_extraction)
+            write_extraction("ADMQuantitiesExtractionOut_");
+
+        int num_integrals = (m_c_Madm >= 0) + (m_c_Jadm >= 0);
+        if (!num_integrals)
+            return;
+
+        int J_index = m_c_Madm >= 0 ? 1 : 0;
+
+        std::vector<std::vector<double>> out_integrals(num_integrals);
+
+        if (m_c_Madm >= 0)
+            add_var_integrand(0, out_integrals[0], IntegrationMethod::simpson);
+        if (m_c_Jadm >= 0)
+            add_var_integrand(J_index, out_integrals[J_index],
+                              IntegrationMethod::simpson);
+
+        // do the integration over the surface
+        integrate();
+        std::vector<std::string> labels(num_integrals);
+        if (m_c_Madm >= 0)
+            labels[0] = "M_adm";
+        if (m_c_Jadm >= 0)
+            labels[J_index] = "J_adm";
+        write_integrals("IntegralADMQuantities", out_integrals, labels);
+    }
+
+  private:
+    const int m_c_Madm, m_c_Jadm;
+};
+
+#endif /* ADMQUANTITIESEXTRACTION_HPP_ */


### PR DESCRIPTION
This is a pull request to recover Tiago's one in #121. It adds the feature for computing the ADM mass and spin of a spacetime in the KerrBH example. It uses eq. (7.15) in [arxiv:gr-qc/0703035] for the ADM mass, which differs slightly from eq. (3.128) in Baumgarte & Shapiro's book used in #121, and eq. (3.191) in Baumgarte & Shapiro's book for the ADM momentum.
When extracted in the KerrBH using the CCZ4 formalism and over a box of L=256M for a BH of mass=2M and spin a=0.8M
<img width="639" height="469" alt="image" src="https://github.com/user-attachments/assets/b1678fe4-8b5f-4fe8-bae3-593e264e6774" />
<img width="637" height="467" alt="image" src="https://github.com/user-attachments/assets/ac83e285-f100-4e1f-8878-7cf539d5d70c" />

By doing the extrapolation to infinity using FitToInfinity.py in https://github.com/GRTLCollaboration/Postprocessing_tools/tree/feat/grchombo_and_gw_tools/PythonTools/DataAnalysis/GWTools, one gets the correct results, namely **J=1.603717148220815458M^2** and **mass=1.992012925023880276M**
